### PR TITLE
Fix remaining Windows CI SoftHSM fixture regression

### DIFF
--- a/eng/setup-softhsm-fixture.ps1
+++ b/eng/setup-softhsm-fixture.ps1
@@ -126,7 +126,7 @@ function Download-SoftHsmPortable {
 
 function Resolve-SoftHsmRoot {
     param(
-        [Parameter(Mandatory = $true)][string]$RequestedRoot,
+        [AllowEmptyString()][string]$RequestedRoot,
         [Parameter(Mandatory = $true)][string]$RequestedVersion,
         [Parameter(Mandatory = $true)][bool]$ShouldDownload,
         [Parameter(Mandatory = $true)][string]$WorkspaceRoot
@@ -161,7 +161,7 @@ function Resolve-SoftHsmRoot {
 }
 
 function Resolve-Pkcs11ToolPath {
-    param([Parameter(Mandatory = $true)][string]$RequestedPath)
+    param([AllowEmptyString()][string]$RequestedPath)
 
     $candidates = @()
     foreach ($candidate in @(


### PR DESCRIPTION
## Summary
Fix the remaining Windows CI failure in `eng/setup-softhsm-fixture.ps1`.

## Root cause
The helper passed empty strings into internal functions that declared those values as mandatory non-empty string parameters. On GitHub Actions Windows, that failed early with:

> Cannot bind argument to parameter 'RequestedRoot' because it is an empty string.

## Fix
- allow empty-string inputs for the optional requested SoftHSM/OpenSC paths
- keep existing discovery/download fallback behavior intact

## Validation
- static script diff review against the failing path
- GitHub CI rerun after merge
