### PR TITLE
Fix Windows CI OpenSC fallback archive naming

### DIFF
--- a/eng/setup-softhsm-fixture.ps1
+++ b/eng/setup-softhsm-fixture.ps1
@@ -133,8 +133,8 @@ function Download-OpenScPortable {
 
     $downloadDir = Join-Path $DestinationRoot 'downloads'
     $assetCandidates = @(
-        "OpenSC-$Version_x64.zip",
-        "OpenSC-$Version-Light_x64.zip"
+        "OpenSC-${Version}_x64.zip",
+        "OpenSC-${Version}-Light_x64.zip"
     )
 
     New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null


### PR DESCRIPTION
## Summary
Fix the Windows CI OpenSC portable fallback filename interpolation bug.

## Root cause
The OpenSC portable fallback used strings like `OpenSC-$Version_x64.zip`, which PowerShell interpreted as the unset variable `$Version_x64` instead of `${Version}` plus the suffix.

## Fix
- use `${Version}` interpolation explicitly for portable OpenSC asset names

## Validation
- direct review against the latest failing CI log
- GitHub CI rerun after merge
