### PR TITLE
Fix Windows CI OpenSC fallback asset names

### DIFF
--- a/eng/setup-softhsm-fixture.ps1
+++ b/eng/setup-softhsm-fixture.ps1
@@ -133,8 +133,8 @@ function Download-OpenScPortable {
 
     $downloadDir = Join-Path $DestinationRoot 'downloads'
     $assetCandidates = @(
-        "OpenSC-${Version}_x64.zip",
-        "OpenSC-${Version}-Light_x64.zip"
+        "OpenSC-${Version}_x64-dbg.zip",
+        "OpenSC-${Version}-Light_x64-dbg.zip"
     )
 
     New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null


### PR DESCRIPTION
## Summary
Fix the OpenSC portable fallback asset names used by Windows CI.

## Root cause
The previous fallback used OpenSC asset names that do not exist in the GitHub release payload. The Windows CI log showed 404s for both attempted archive URLs.

## Fix
- switch fallback asset candidates to the published `*-dbg.zip` artifacts

## Validation
- direct review against the latest failing CI log
- GitHub CI rerun after merge
