### PR TITLE
Add structured PKCS#11 operation telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ int slotCount = module.GetSlotCount();
 Console.WriteLine($"Discovered {slotCount} slot(s).");
 ```
 
+### Structured operation telemetry
+
+Telemetry is opt-in and disabled by default. When you attach a listener, the wrapper emits a compact structured event after each major PKCS#11 wrapper operation with:
+
+- operation name + native PKCS#11 function name
+- elapsed duration
+- success / returned-false / failure status
+- native return value when available
+- optional slot, session, and mechanism context
+- captured exception for faulted operations
+
+Listener failures are swallowed so observational code does not break the underlying PKCS#11 call flow.
+
+```csharp
+using Pkcs11Wrapper;
+using Pkcs11Wrapper.Native;
+
+sealed class ConsoleTelemetryListener : IPkcs11OperationTelemetryListener
+{
+    public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+    {
+        Console.WriteLine(
+            $"{operationEvent.OperationName} ({operationEvent.NativeOperationName}) " +
+            $"status={operationEvent.Status} duration={operationEvent.Duration.TotalMilliseconds:F3}ms " +
+            $"slot={operationEvent.SlotId} session={operationEvent.SessionHandle} mechanism={operationEvent.MechanismType}");
+    }
+}
+
+using Pkcs11Module module = Pkcs11Module.Load("/path/to/pkcs11/module", new ConsoleTelemetryListener());
+module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+```
+
+You can also swap the listener at runtime through `Pkcs11Module.TelemetryListener`.
+
 ### 2) Run the admin panel
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,7 @@ The wrapper surface implemented through the current phase set includes:
 - multipart operations and operation-state APIs
 - optional PKCS#11 v3 interface discovery and message-based API surface
 - optional `C_LoginUser` / `C_SessionCancel` through the discovered v3 interface
+- opt-in structured operation telemetry with duration, result/exception, and slot/session/mechanism context
 - administrative operations for session invalidation and token/PIN provisioning
 - NativeAOT smoke validation through the sample app on Linux and Windows
 
@@ -92,6 +93,12 @@ Notable current assumptions:
 - Wrapper errors expose taxonomy metadata that classifies CKR outcomes into stable high-level categories (`Success`, `Lifecycle`, `StateConflict`, `InputValidation`, `Authentication`, `ObjectHandle`, `Capability`, `Resource`, `Device`, `Session`, `Integrity`, `Unknown`).
 - Taxonomy metadata includes a retryability hint via `IsRetryable` (`true`/`false`) for control-flow policy.
 - The raw `CK_RV` value is always preserved and remains the authoritative signal for exact module/token semantics.
+
+### Telemetry contract
+
+- Telemetry is disabled unless a consumer provides `IPkcs11OperationTelemetryListener`.
+- Emitted events carry operation/native-operation names, duration, status, raw return value when available, plus optional slot/session/mechanism metadata.
+- Listener exceptions are swallowed so telemetry remains observational and cannot break the primary PKCS#11 operation flow.
 
 ## Related docs
 

--- a/src/Pkcs11Wrapper.Native/Pkcs11NativeModule.cs
+++ b/src/Pkcs11Wrapper.Native/Pkcs11NativeModule.cs
@@ -25,18 +25,21 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     private readonly object _lifecycleSync = new();
     private volatile bool _disposed;
     private volatile bool _isInitialized;
+    private volatile IPkcs11OperationTelemetryListener? _telemetryListener;
     private bool _ownsInitialization;
 
     private Pkcs11NativeModule(
         nint handle,
         CK_FUNCTION_LIST* functionList,
         nint getInterfaceListExport,
-        nint getInterfaceExport)
+        nint getInterfaceExport,
+        IPkcs11OperationTelemetryListener? telemetryListener)
     {
         _handle = handle;
         _functionList = functionList;
         _getInterfaceListExport = getInterfaceListExport;
         _getInterfaceExport = getInterfaceExport;
+        _telemetryListener = telemetryListener;
     }
 
     public CK_FUNCTION_LIST* FunctionList
@@ -56,7 +59,15 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public bool IsInitialized => _isInitialized;
 
-    public static Pkcs11NativeModule Load(string libraryPath)
+    public IPkcs11OperationTelemetryListener? TelemetryListener
+    {
+        get => _telemetryListener;
+        set => _telemetryListener = value;
+    }
+
+    public static Pkcs11NativeModule Load(string libraryPath) => Load(libraryPath, null);
+
+    public static Pkcs11NativeModule Load(string libraryPath, IPkcs11OperationTelemetryListener? telemetryListener)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(libraryPath);
 
@@ -64,32 +75,42 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
         try
         {
-            nint exportAddress = NativeLibrary.GetExport(handle, "C_GetFunctionList");
-            delegate* unmanaged[Cdecl]<CK_FUNCTION_LIST**, CK_RV> getFunctionList = (delegate* unmanaged[Cdecl]<CK_FUNCTION_LIST**, CK_RV>)exportAddress;
-
-            CK_FUNCTION_LIST* functionList = null;
-            CK_RV result = getFunctionList(&functionList);
-            ThrowIfFailed(result, "C_GetFunctionList");
-
-            if (functionList is null)
+            Pkcs11OperationTelemetryScope telemetry = new(telemetryListener, nameof(Load), "C_GetFunctionList");
+            try
             {
-                throw new InvalidOperationException("C_GetFunctionList returned a null function list pointer.");
+                nint exportAddress = NativeLibrary.GetExport(handle, "C_GetFunctionList");
+                delegate* unmanaged[Cdecl]<CK_FUNCTION_LIST**, CK_RV> getFunctionList = (delegate* unmanaged[Cdecl]<CK_FUNCTION_LIST**, CK_RV>)exportAddress;
+
+                CK_FUNCTION_LIST* functionList = null;
+                CK_RV result = getFunctionList(&functionList);
+                ThrowIfFailed(result, "C_GetFunctionList");
+
+                if (functionList is null)
+                {
+                    throw new InvalidOperationException("C_GetFunctionList returned a null function list pointer.");
+                }
+
+                nint getInterfaceList = 0;
+                nint getInterface = 0;
+
+                if (NativeLibrary.TryGetExport(handle, "C_GetInterfaceList", out nint getInterfaceListAddress))
+                {
+                    getInterfaceList = getInterfaceListAddress;
+                }
+
+                if (NativeLibrary.TryGetExport(handle, "C_GetInterface", out nint getInterfaceAddress))
+                {
+                    getInterface = getInterfaceAddress;
+                }
+
+                telemetry.Succeeded(result);
+                return new Pkcs11NativeModule(handle, functionList, getInterfaceList, getInterface, telemetryListener);
             }
-
-            nint getInterfaceList = 0;
-            nint getInterface = 0;
-
-            if (NativeLibrary.TryGetExport(handle, "C_GetInterfaceList", out nint getInterfaceListAddress))
+            catch (Exception ex)
             {
-                getInterfaceList = getInterfaceListAddress;
+                telemetry.Failed(ex);
+                throw;
             }
-
-            if (NativeLibrary.TryGetExport(handle, "C_GetInterface", out nint getInterfaceAddress))
-            {
-                getInterface = getInterfaceAddress;
-            }
-
-            return new Pkcs11NativeModule(handle, functionList, getInterfaceList, getInterface);
         }
         catch
         {
@@ -104,26 +125,38 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     {
         lock (_lifecycleSync)
         {
-            EnsureNotDisposed();
-
-            if (_isInitialized)
+            Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(Initialize), "C_Initialize");
+            try
             {
-                return;
-            }
+                EnsureNotDisposed();
 
-            EnsureFunctionAvailable((void*)FunctionList->C_Initialize, "C_Initialize");
+                if (_isInitialized)
+                {
+                    telemetry.Succeeded(CK_RV.Ok);
+                    return;
+                }
 
-            CK_RV result = FunctionList->C_Initialize(initializeArgs);
-            if (result == Pkcs11ReturnValues.CryptokiAlreadyInitialized)
-            {
+                EnsureFunctionAvailable((void*)FunctionList->C_Initialize, "C_Initialize");
+
+                CK_RV result = FunctionList->C_Initialize(initializeArgs);
+                if (result == Pkcs11ReturnValues.CryptokiAlreadyInitialized)
+                {
+                    _isInitialized = true;
+                    _ownsInitialization = false;
+                    telemetry.Succeeded(result);
+                    return;
+                }
+
+                ThrowIfFailed(result, "C_Initialize");
                 _isInitialized = true;
-                _ownsInitialization = false;
-                return;
+                _ownsInitialization = true;
+                telemetry.Succeeded(result);
             }
-
-            ThrowIfFailed(result, "C_Initialize");
-            _isInitialized = true;
-            _ownsInitialization = true;
+            catch (Exception ex)
+            {
+                telemetry.Failed(ex);
+                throw;
+            }
         }
     }
 
@@ -131,487 +164,732 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     {
         lock (_lifecycleSync)
         {
-            EnsureNotDisposed();
-
-            if (!_isInitialized)
+            Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(FinalizeModule), "C_Finalize");
+            try
             {
-                return;
-            }
+                EnsureNotDisposed();
 
-            if (_ownsInitialization)
+                if (!_isInitialized)
+                {
+                    telemetry.Succeeded(CK_RV.Ok);
+                    return;
+                }
+
+                if (_ownsInitialization)
+                {
+                    InvokeFinalize();
+                }
+
+                _isInitialized = false;
+                _ownsInitialization = false;
+                telemetry.Succeeded(CK_RV.Ok);
+            }
+            catch (Exception ex)
             {
-                InvokeFinalize();
+                telemetry.Failed(ex);
+                throw;
             }
-
-            _isInitialized = false;
-            _ownsInitialization = false;
         }
     }
 
     public CK_INFO GetInfo()
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetInfo), "C_GetInfo");
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_GetInfo, "C_GetInfo");
+            EnsureFunctionAvailable((void*)FunctionList->C_GetInfo, "C_GetInfo");
 
-        var info = default(CK_INFO);
-        CK_RV result = FunctionList->C_GetInfo(&info);
-        ThrowIfFailed(result, "C_GetInfo");
-        return info;
+            var info = default(CK_INFO);
+            CK_RV result = FunctionList->C_GetInfo(&info);
+            ThrowIfFailed(result, "C_GetInfo");
+            telemetry.Succeeded(result);
+            return info;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public CK_VERSION GetFunctionListVersion()
     {
-        EnsureNotDisposed();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GetFunctionList, "C_GetFunctionList");
-
-        CK_FUNCTION_LIST* functionList = null;
-        CK_RV result = FunctionList->C_GetFunctionList(&functionList);
-        ThrowIfFailed(result, "C_GetFunctionList");
-
-        if (functionList is null)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetFunctionListVersion), "C_GetFunctionList");
+        try
         {
-            throw new InvalidOperationException("C_GetFunctionList returned a null function list pointer.");
-        }
+            EnsureNotDisposed();
 
-        return functionList->Version;
+            EnsureFunctionAvailable((void*)FunctionList->C_GetFunctionList, "C_GetFunctionList");
+
+            CK_FUNCTION_LIST* functionList = null;
+            CK_RV result = FunctionList->C_GetFunctionList(&functionList);
+            ThrowIfFailed(result, "C_GetFunctionList");
+
+            if (functionList is null)
+            {
+                throw new InvalidOperationException("C_GetFunctionList returned a null function list pointer.");
+            }
+
+            telemetry.Succeeded(result);
+            return functionList->Version;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool SupportsInterfaceDiscovery => _getInterfaceListExport != 0 && _getInterfaceExport != 0;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Pkcs11OperationTelemetryScope BeginTelemetry(
+        string operationName,
+        string? nativeOperationName,
+        CK_SLOT_ID? slotId = null,
+        CK_SESSION_HANDLE? sessionHandle = null,
+        CK_MECHANISM_TYPE? mechanismType = null)
+        => new(_telemetryListener, operationName, nativeOperationName, slotId, sessionHandle, mechanismType);
+
     public int GetInterfaceCount()
     {
-        EnsureNotDisposed();
-
-        if (_getInterfaceListExport == 0)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetInterfaceCount), "C_GetInterfaceList");
+        try
         {
-            return 0;
+            EnsureNotDisposed();
+
+            if (_getInterfaceListExport == 0)
+            {
+                telemetry.Succeeded(CK_RV.Ok);
+                return 0;
+            }
+
+            delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV> getInterfaceList = (delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV>)_getInterfaceListExport;
+
+            CK_ULONG count = default;
+            CK_RV result = getInterfaceList(null, &count);
+            ThrowIfFailed(result, "C_GetInterfaceList");
+            telemetry.Succeeded(result);
+            return ToInt32Checked(count, "interface count");
         }
-
-        delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV> getInterfaceList = (delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV>)_getInterfaceListExport;
-
-        CK_ULONG count = default;
-        CK_RV result = getInterfaceList(null, &count);
-        ThrowIfFailed(result, "C_GetInterfaceList");
-        return ToInt32Checked(count, "interface count");
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetInterfaces(Span<CK_INTERFACE> destination, out int written)
     {
-        EnsureNotDisposed();
-
-        if (_getInterfaceListExport == 0)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetInterfaces), "C_GetInterfaceList");
+        try
         {
-            written = 0;
-            return true;
-        }
+            EnsureNotDisposed();
 
-        delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV> getInterfaceList = (delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV>)_getInterfaceListExport;
+            if (_getInterfaceListExport == 0)
+            {
+                written = 0;
+                telemetry.Succeeded(CK_RV.Ok);
+                return true;
+            }
 
-        CK_ULONG count = default;
-        CK_RV result = getInterfaceList(null, &count);
-        ThrowIfFailed(result, "C_GetInterfaceList");
+            delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV> getInterfaceList = (delegate* unmanaged[Cdecl]<CK_INTERFACE*, CK_ULONG*, CK_RV>)_getInterfaceListExport;
 
-        int required = ToInt32Checked(count, "interface count");
-        if (destination.Length < required)
-        {
-            written = required;
-            return false;
-        }
+            CK_ULONG count = default;
+            CK_RV result = getInterfaceList(null, &count);
+            ThrowIfFailed(result, "C_GetInterfaceList");
 
-        if (required == 0)
-        {
-            written = 0;
-            return true;
-        }
+            int required = ToInt32Checked(count, "interface count");
+            if (destination.Length < required)
+            {
+                written = required;
+                telemetry.ReturnedFalse(Pkcs11ReturnValues.BufferTooSmall);
+                return false;
+            }
 
-        count = (CK_ULONG)(nuint)required;
-        fixed (CK_INTERFACE* destinationPointer = destination)
-        {
-            result = getInterfaceList(destinationPointer, &count);
-        }
+            if (required == 0)
+            {
+                written = 0;
+                telemetry.Succeeded(result);
+                return true;
+            }
 
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
+            count = (CK_ULONG)(nuint)required;
+            fixed (CK_INTERFACE* destinationPointer = destination)
+            {
+                result = getInterfaceList(destinationPointer, &count);
+            }
+
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(count, "interface count");
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetInterfaceList");
             written = ToInt32Checked(count, "interface count");
-            return false;
+            telemetry.Succeeded(result);
+            return true;
         }
-
-        ThrowIfFailed(result, "C_GetInterfaceList");
-        written = ToInt32Checked(count, "interface count");
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetInterface(ReadOnlySpan<byte> nameUtf8, CK_VERSION? version, CK_FLAGS flags, out CK_INTERFACE nativeInterface)
     {
-        EnsureNotDisposed();
-
-        if (_getInterfaceExport == 0)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetInterface), "C_GetInterface");
+        try
         {
-            nativeInterface = default;
-            return false;
-        }
+            EnsureNotDisposed();
 
-        delegate* unmanaged[Cdecl]<byte*, CK_VERSION*, CK_INTERFACE**, CK_FLAGS, CK_RV> getInterface = (delegate* unmanaged[Cdecl]<byte*, CK_VERSION*, CK_INTERFACE**, CK_FLAGS, CK_RV>)_getInterfaceExport;
-
-        CK_INTERFACE* interfacePointer = null;
-        CK_VERSION requestedVersion = version ?? default;
-        CK_VERSION* requestedVersionPointer = version is null ? null : &requestedVersion;
-
-        CK_RV result;
-        if (nameUtf8.IsEmpty)
-        {
-            result = getInterface(null, requestedVersionPointer, &interfacePointer, flags);
-        }
-        else
-        {
-            fixed (byte* namePointer = nameUtf8)
+            if (_getInterfaceExport == 0)
             {
-                result = getInterface(namePointer, requestedVersionPointer, &interfacePointer, flags);
+                nativeInterface = default;
+                telemetry.ReturnedFalse(Pkcs11ReturnValues.FunctionNotSupported);
+                return false;
             }
-        }
 
-        if (result == Pkcs11ReturnValues.FunctionNotSupported)
+            delegate* unmanaged[Cdecl]<byte*, CK_VERSION*, CK_INTERFACE**, CK_FLAGS, CK_RV> getInterface = (delegate* unmanaged[Cdecl]<byte*, CK_VERSION*, CK_INTERFACE**, CK_FLAGS, CK_RV>)_getInterfaceExport;
+
+            CK_INTERFACE* interfacePointer = null;
+            CK_VERSION requestedVersion = version ?? default;
+            CK_VERSION* requestedVersionPointer = version is null ? null : &requestedVersion;
+
+            CK_RV result;
+            if (nameUtf8.IsEmpty)
+            {
+                result = getInterface(null, requestedVersionPointer, &interfacePointer, flags);
+            }
+            else
+            {
+                fixed (byte* namePointer = nameUtf8)
+                {
+                    result = getInterface(namePointer, requestedVersionPointer, &interfacePointer, flags);
+                }
+            }
+
+            if (result == Pkcs11ReturnValues.FunctionNotSupported)
+            {
+                nativeInterface = default;
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetInterface");
+
+            if (interfacePointer is null)
+            {
+                throw new InvalidOperationException("C_GetInterface returned a null interface pointer.");
+            }
+
+            nativeInterface = *interfacePointer;
+            telemetry.Succeeded(result);
+            return true;
+        }
+        catch (Exception ex)
         {
-            nativeInterface = default;
-            return false;
+            telemetry.Failed(ex);
+            throw;
         }
-
-        ThrowIfFailed(result, "C_GetInterface");
-
-        if (interfacePointer is null)
-        {
-            throw new InvalidOperationException("C_GetInterface returned a null interface pointer.");
-        }
-
-        nativeInterface = *interfacePointer;
-        return true;
     }
 
     public int GetSlotCount(bool tokenPresentOnly)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetSlotCount), "C_GetSlotList");
+        try
+        {
+            EnsureInitialized();
 
-        CK_ULONG count = default;
-        CK_RV result = GetSlotList(tokenPresentOnly, null, &count);
-        ThrowIfFailed(result, "C_GetSlotList");
-        return ToInt32Checked(count, "slot count");
+            CK_ULONG count = default;
+            CK_RV result = GetSlotList(tokenPresentOnly, null, &count);
+            ThrowIfFailed(result, "C_GetSlotList");
+            telemetry.Succeeded(result);
+            return ToInt32Checked(count, "slot count");
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetSlots(Span<CK_SLOT_ID> destination, out int written, bool tokenPresentOnly)
     {
-        EnsureInitialized();
-
-        CK_ULONG count = default;
-        CK_RV result = GetSlotList(tokenPresentOnly, null, &count);
-        ThrowIfFailed(result, "C_GetSlotList");
-
-        int required = ToInt32Checked(count, "slot count");
-        if (destination.Length < required)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetSlots), "C_GetSlotList");
+        try
         {
-            written = required;
-            return false;
-        }
+            EnsureInitialized();
 
-        if (required == 0)
-        {
-            written = 0;
+            CK_ULONG count = default;
+            CK_RV result = GetSlotList(tokenPresentOnly, null, &count);
+            ThrowIfFailed(result, "C_GetSlotList");
+
+            int required = ToInt32Checked(count, "slot count");
+            if (destination.Length < required)
+            {
+                written = required;
+                telemetry.ReturnedFalse(Pkcs11ReturnValues.BufferTooSmall);
+                return false;
+            }
+
+            if (required == 0)
+            {
+                written = 0;
+                telemetry.Succeeded(result);
+                return true;
+            }
+
+            count = (CK_ULONG)(nuint)required;
+            fixed (CK_SLOT_ID* destinationPointer = destination)
+            {
+                result = GetSlotList(tokenPresentOnly, destinationPointer, &count);
+            }
+
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(count, "slot count");
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetSlotList");
+            written = ToInt32Checked(count, "slot count");
+            telemetry.Succeeded(result);
             return true;
         }
-
-        count = (CK_ULONG)(nuint)required;
-        fixed (CK_SLOT_ID* destinationPointer = destination)
+        catch (Exception ex)
         {
-            result = GetSlotList(tokenPresentOnly, destinationPointer, &count);
+            telemetry.Failed(ex);
+            throw;
         }
-
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
-            written = ToInt32Checked(count, "slot count");
-            return false;
-        }
-
-        ThrowIfFailed(result, "C_GetSlotList");
-        written = ToInt32Checked(count, "slot count");
-        return true;
     }
 
     public CK_SLOT_INFO GetSlotInfo(CK_SLOT_ID slotId)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetSlotInfo), "C_GetSlotInfo", slotId: slotId);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_GetSlotInfo, "C_GetSlotInfo");
+            EnsureFunctionAvailable((void*)FunctionList->C_GetSlotInfo, "C_GetSlotInfo");
 
-        var slotInfo = default(CK_SLOT_INFO);
-        CK_RV result = FunctionList->C_GetSlotInfo(slotId, &slotInfo);
-        ThrowIfFailed(result, "C_GetSlotInfo");
-        return slotInfo;
+            var slotInfo = default(CK_SLOT_INFO);
+            CK_RV result = FunctionList->C_GetSlotInfo(slotId, &slotInfo);
+            ThrowIfFailed(result, "C_GetSlotInfo");
+            telemetry.Succeeded(result);
+            return slotInfo;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetTokenInfo(CK_SLOT_ID slotId, out CK_TOKEN_INFO tokenInfo)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GetTokenInfo, "C_GetTokenInfo");
-
-        CK_TOKEN_INFO nativeTokenInfo = default;
-        CK_RV result = FunctionList->C_GetTokenInfo(slotId, &nativeTokenInfo);
-        if (result == Pkcs11ReturnValues.TokenNotPresent)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetTokenInfo), "C_GetTokenInfo", slotId: slotId);
+        try
         {
-            tokenInfo = default;
-            return false;
-        }
+            EnsureInitialized();
 
-        ThrowIfFailed(result, "C_GetTokenInfo");
-        tokenInfo = nativeTokenInfo;
-        return true;
+            EnsureFunctionAvailable((void*)FunctionList->C_GetTokenInfo, "C_GetTokenInfo");
+
+            CK_TOKEN_INFO nativeTokenInfo = default;
+            CK_RV result = FunctionList->C_GetTokenInfo(slotId, &nativeTokenInfo);
+            if (result == Pkcs11ReturnValues.TokenNotPresent)
+            {
+                tokenInfo = default;
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetTokenInfo");
+            tokenInfo = nativeTokenInfo;
+            telemetry.Succeeded(result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void InitToken(CK_SLOT_ID slotId, ReadOnlySpan<byte> soPinUtf8, ReadOnlySpan<byte> label)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_InitToken, "C_InitToken");
-
-        if (label.Length != 32)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(InitToken), "C_InitToken", slotId: slotId);
+        try
         {
-            throw new ArgumentException("The PKCS#11 token label must already be blank-padded to exactly 32 bytes.", nameof(label));
-        }
+            EnsureInitialized();
 
-        CK_ULONG soPinLength = (CK_ULONG)(nuint)soPinUtf8.Length;
-        CK_RV result;
+            EnsureFunctionAvailable((void*)FunctionList->C_InitToken, "C_InitToken");
 
-        if (soPinUtf8.IsEmpty)
-        {
-            fixed (byte* labelPointer = label)
+            if (label.Length != 32)
             {
-                result = FunctionList->C_InitToken(slotId, null, soPinLength, labelPointer);
+                throw new ArgumentException("The PKCS#11 token label must already be blank-padded to exactly 32 bytes.", nameof(label));
             }
-        }
-        else
-        {
-            fixed (byte* soPinPointer = soPinUtf8)
-            fixed (byte* labelPointer = label)
-            {
-                result = FunctionList->C_InitToken(slotId, soPinPointer, soPinLength, labelPointer);
-            }
-        }
 
-        ThrowIfFailed(result, "C_InitToken");
+            CK_ULONG soPinLength = (CK_ULONG)(nuint)soPinUtf8.Length;
+            CK_RV result;
+
+            if (soPinUtf8.IsEmpty)
+            {
+                fixed (byte* labelPointer = label)
+                {
+                    result = FunctionList->C_InitToken(slotId, null, soPinLength, labelPointer);
+                }
+            }
+            else
+            {
+                fixed (byte* soPinPointer = soPinUtf8)
+                fixed (byte* labelPointer = label)
+                {
+                    result = FunctionList->C_InitToken(slotId, soPinPointer, soPinLength, labelPointer);
+                }
+            }
+
+            ThrowIfFailed(result, "C_InitToken");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public int GetMechanismCount(CK_SLOT_ID slotId)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetMechanismCount), "C_GetMechanismList", slotId: slotId);
+        try
+        {
+            EnsureInitialized();
 
-        CK_ULONG count = default;
-        CK_RV result = GetMechanismList(slotId, null, &count);
-        ThrowIfFailed(result, "C_GetMechanismList");
-        return ToInt32Checked(count, "mechanism count");
+            CK_ULONG count = default;
+            CK_RV result = GetMechanismList(slotId, null, &count);
+            ThrowIfFailed(result, "C_GetMechanismList");
+            telemetry.Succeeded(result);
+            return ToInt32Checked(count, "mechanism count");
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetMechanisms(CK_SLOT_ID slotId, Span<CK_MECHANISM_TYPE> destination, out int written)
     {
-        EnsureInitialized();
-
-        CK_ULONG count = default;
-        CK_RV result = GetMechanismList(slotId, null, &count);
-        ThrowIfFailed(result, "C_GetMechanismList");
-
-        int required = ToInt32Checked(count, "mechanism count");
-        if (destination.Length < required)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetMechanisms), "C_GetMechanismList", slotId: slotId);
+        try
         {
-            written = required;
-            return false;
-        }
+            EnsureInitialized();
 
-        if (required == 0)
-        {
-            written = 0;
+            CK_ULONG count = default;
+            CK_RV result = GetMechanismList(slotId, null, &count);
+            ThrowIfFailed(result, "C_GetMechanismList");
+
+            int required = ToInt32Checked(count, "mechanism count");
+            if (destination.Length < required)
+            {
+                written = required;
+                telemetry.ReturnedFalse(Pkcs11ReturnValues.BufferTooSmall);
+                return false;
+            }
+
+            if (required == 0)
+            {
+                written = 0;
+                telemetry.Succeeded(result);
+                return true;
+            }
+
+            count = (CK_ULONG)(nuint)required;
+            fixed (CK_MECHANISM_TYPE* destinationPointer = destination)
+            {
+                result = GetMechanismList(slotId, destinationPointer, &count);
+            }
+
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(count, "mechanism count");
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetMechanismList");
+            written = ToInt32Checked(count, "mechanism count");
+            telemetry.Succeeded(result);
             return true;
         }
-
-        count = (CK_ULONG)(nuint)required;
-        fixed (CK_MECHANISM_TYPE* destinationPointer = destination)
+        catch (Exception ex)
         {
-            result = GetMechanismList(slotId, destinationPointer, &count);
+            telemetry.Failed(ex);
+            throw;
         }
-
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
-            written = ToInt32Checked(count, "mechanism count");
-            return false;
-        }
-
-        ThrowIfFailed(result, "C_GetMechanismList");
-        written = ToInt32Checked(count, "mechanism count");
-        return true;
     }
 
     public CK_MECHANISM_INFO GetMechanismInfo(CK_SLOT_ID slotId, CK_MECHANISM_TYPE mechanismType)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetMechanismInfo), "C_GetMechanismInfo", slotId: slotId, mechanismType: mechanismType);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_GetMechanismInfo, "C_GetMechanismInfo");
+            EnsureFunctionAvailable((void*)FunctionList->C_GetMechanismInfo, "C_GetMechanismInfo");
 
-        CK_MECHANISM_INFO info = default;
-        CK_RV result = FunctionList->C_GetMechanismInfo(slotId, mechanismType, &info);
-        ThrowIfFailed(result, "C_GetMechanismInfo");
-        return info;
+            CK_MECHANISM_INFO info = default;
+            CK_RV result = FunctionList->C_GetMechanismInfo(slotId, mechanismType, &info);
+            ThrowIfFailed(result, "C_GetMechanismInfo");
+            telemetry.Succeeded(result);
+            return info;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public CK_SESSION_HANDLE OpenSession(CK_SLOT_ID slotId, bool readWrite)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_OpenSession, "C_OpenSession");
-
-        CK_SESSION_HANDLE sessionHandle = default;
-        nuint flagsValue = Pkcs11SessionFlags.SerialSession;
-        if (readWrite)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(OpenSession), "C_OpenSession", slotId: slotId);
+        try
         {
-            flagsValue |= Pkcs11SessionFlags.ReadWriteSession;
-        }
+            EnsureInitialized();
 
-        CK_FLAGS flags = new(flagsValue);
-        CK_RV result = FunctionList->C_OpenSession(slotId, flags, null, null, &sessionHandle);
-        ThrowIfFailed(result, "C_OpenSession");
-        return sessionHandle;
+            EnsureFunctionAvailable((void*)FunctionList->C_OpenSession, "C_OpenSession");
+
+            CK_SESSION_HANDLE sessionHandle = default;
+            nuint flagsValue = Pkcs11SessionFlags.SerialSession;
+            if (readWrite)
+            {
+                flagsValue |= Pkcs11SessionFlags.ReadWriteSession;
+            }
+
+            CK_FLAGS flags = new(flagsValue);
+            CK_RV result = FunctionList->C_OpenSession(slotId, flags, null, null, &sessionHandle);
+            ThrowIfFailed(result, "C_OpenSession");
+            telemetry.Succeeded(result);
+            return sessionHandle;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void CloseSession(CK_SESSION_HANDLE sessionHandle)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(CloseSession), "C_CloseSession", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_CloseSession, "C_CloseSession");
+            EnsureFunctionAvailable((void*)FunctionList->C_CloseSession, "C_CloseSession");
 
-        CK_RV result = FunctionList->C_CloseSession(sessionHandle);
-        ThrowIfFailed(result, "C_CloseSession");
+            CK_RV result = FunctionList->C_CloseSession(sessionHandle);
+            ThrowIfFailed(result, "C_CloseSession");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void CloseAllSessions(CK_SLOT_ID slotId)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(CloseAllSessions), "C_CloseAllSessions", slotId: slotId);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_CloseAllSessions, "C_CloseAllSessions");
+            EnsureFunctionAvailable((void*)FunctionList->C_CloseAllSessions, "C_CloseAllSessions");
 
-        CK_RV result = FunctionList->C_CloseAllSessions(slotId);
-        ThrowIfFailed(result, "C_CloseAllSessions");
+            CK_RV result = FunctionList->C_CloseAllSessions(slotId);
+            ThrowIfFailed(result, "C_CloseAllSessions");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public CK_SESSION_INFO GetSessionInfo(CK_SESSION_HANDLE sessionHandle)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetSessionInfo), "C_GetSessionInfo", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_GetSessionInfo, "C_GetSessionInfo");
+            EnsureFunctionAvailable((void*)FunctionList->C_GetSessionInfo, "C_GetSessionInfo");
 
-        CK_SESSION_INFO sessionInfo = default;
-        CK_RV result = FunctionList->C_GetSessionInfo(sessionHandle, &sessionInfo);
-        ThrowIfFailed(result, "C_GetSessionInfo");
-        return sessionInfo;
+            CK_SESSION_INFO sessionInfo = default;
+            CK_RV result = FunctionList->C_GetSessionInfo(sessionHandle, &sessionInfo);
+            ThrowIfFailed(result, "C_GetSessionInfo");
+            telemetry.Succeeded(result);
+            return sessionInfo;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void Login(CK_SESSION_HANDLE sessionHandle, CK_USER_TYPE userType, ReadOnlySpan<byte> pinUtf8)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_Login, "C_Login");
-
-        CK_ULONG pinLength = (CK_ULONG)(nuint)pinUtf8.Length;
-        CK_RV result;
-
-        if (pinUtf8.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(Login), "C_Login", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_Login(sessionHandle, userType, null, pinLength);
-        }
-        else
-        {
-            fixed (byte* pinPointer = pinUtf8)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_Login, "C_Login");
+
+            CK_ULONG pinLength = (CK_ULONG)(nuint)pinUtf8.Length;
+            CK_RV result;
+
+            if (pinUtf8.IsEmpty)
             {
-                result = FunctionList->C_Login(sessionHandle, userType, pinPointer, pinLength);
+                result = FunctionList->C_Login(sessionHandle, userType, null, pinLength);
             }
-        }
+            else
+            {
+                fixed (byte* pinPointer = pinUtf8)
+                {
+                    result = FunctionList->C_Login(sessionHandle, userType, pinPointer, pinLength);
+                }
+            }
 
-        ThrowIfFailed(result, "C_Login");
+            ThrowIfFailed(result, "C_Login");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void Logout(CK_SESSION_HANDLE sessionHandle)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(Logout), "C_Logout", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_Logout, "C_Logout");
+            EnsureFunctionAvailable((void*)FunctionList->C_Logout, "C_Logout");
 
-        CK_RV result = FunctionList->C_Logout(sessionHandle);
-        ThrowIfFailed(result, "C_Logout");
+            CK_RV result = FunctionList->C_Logout(sessionHandle);
+            ThrowIfFailed(result, "C_Logout");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void InitPin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> pinUtf8)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_InitPIN, "C_InitPIN");
-
-        CK_ULONG pinLength = (CK_ULONG)(nuint)pinUtf8.Length;
-        CK_RV result;
-
-        if (pinUtf8.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(InitPin), "C_InitPIN", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_InitPIN(sessionHandle, null, pinLength);
-        }
-        else
-        {
-            fixed (byte* pinPointer = pinUtf8)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_InitPIN, "C_InitPIN");
+
+            CK_ULONG pinLength = (CK_ULONG)(nuint)pinUtf8.Length;
+            CK_RV result;
+
+            if (pinUtf8.IsEmpty)
             {
-                result = FunctionList->C_InitPIN(sessionHandle, pinPointer, pinLength);
+                result = FunctionList->C_InitPIN(sessionHandle, null, pinLength);
             }
-        }
+            else
+            {
+                fixed (byte* pinPointer = pinUtf8)
+                {
+                    result = FunctionList->C_InitPIN(sessionHandle, pinPointer, pinLength);
+                }
+            }
 
-        ThrowIfFailed(result, "C_InitPIN");
+            ThrowIfFailed(result, "C_InitPIN");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void SetPin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> oldPinUtf8, ReadOnlySpan<byte> newPinUtf8)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_SetPIN, "C_SetPIN");
-
-        CK_ULONG oldPinLength = (CK_ULONG)(nuint)oldPinUtf8.Length;
-        CK_ULONG newPinLength = (CK_ULONG)(nuint)newPinUtf8.Length;
-        CK_RV result;
-
-        if (oldPinUtf8.IsEmpty && newPinUtf8.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SetPin), "C_SetPIN", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_SetPIN(sessionHandle, null, oldPinLength, null, newPinLength);
-        }
-        else if (oldPinUtf8.IsEmpty)
-        {
-            fixed (byte* newPinPointer = newPinUtf8)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_SetPIN, "C_SetPIN");
+
+            CK_ULONG oldPinLength = (CK_ULONG)(nuint)oldPinUtf8.Length;
+            CK_ULONG newPinLength = (CK_ULONG)(nuint)newPinUtf8.Length;
+            CK_RV result;
+
+            if (oldPinUtf8.IsEmpty && newPinUtf8.IsEmpty)
             {
-                result = FunctionList->C_SetPIN(sessionHandle, null, oldPinLength, newPinPointer, newPinLength);
+                result = FunctionList->C_SetPIN(sessionHandle, null, oldPinLength, null, newPinLength);
             }
-        }
-        else if (newPinUtf8.IsEmpty)
-        {
-            fixed (byte* oldPinPointer = oldPinUtf8)
+            else if (oldPinUtf8.IsEmpty)
             {
-                result = FunctionList->C_SetPIN(sessionHandle, oldPinPointer, oldPinLength, null, newPinLength);
+                fixed (byte* newPinPointer = newPinUtf8)
+                {
+                    result = FunctionList->C_SetPIN(sessionHandle, null, oldPinLength, newPinPointer, newPinLength);
+                }
             }
-        }
-        else
-        {
-            fixed (byte* oldPinPointer = oldPinUtf8)
-            fixed (byte* newPinPointer = newPinUtf8)
+            else if (newPinUtf8.IsEmpty)
             {
-                result = FunctionList->C_SetPIN(sessionHandle, oldPinPointer, oldPinLength, newPinPointer, newPinLength);
+                fixed (byte* oldPinPointer = oldPinUtf8)
+                {
+                    result = FunctionList->C_SetPIN(sessionHandle, oldPinPointer, oldPinLength, null, newPinLength);
+                }
             }
-        }
+            else
+            {
+                fixed (byte* oldPinPointer = oldPinUtf8)
+                fixed (byte* newPinPointer = newPinUtf8)
+                {
+                    result = FunctionList->C_SetPIN(sessionHandle, oldPinPointer, oldPinLength, newPinPointer, newPinLength);
+                }
+            }
 
-        ThrowIfFailed(result, "C_SetPIN");
+            ThrowIfFailed(result, "C_SetPIN");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryFindObjects(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<CK_ATTRIBUTE> template, Span<CK_OBJECT_HANDLE> destination, out int written, out bool hasMore)
     {
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryFindObjects), "C_FindObjects", sessionHandle: sessionHandle);
         EnsureInitialized();
 
         EnsureFunctionAvailable((void*)FunctionList->C_FindObjectsInit, "C_FindObjectsInit");
@@ -640,6 +918,15 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 ThrowIfFailed(extraResult, "C_FindObjects");
                 written = 0;
                 hasMore = extraCount.Value != 0;
+                if (hasMore)
+                {
+                    telemetry.ReturnedFalse(extraResult);
+                }
+                else
+                {
+                    telemetry.Succeeded(extraResult);
+                }
+
                 return !hasMore;
             }
 
@@ -655,6 +942,7 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
             if (written < destination.Length)
             {
                 hasMore = false;
+                telemetry.Succeeded(result);
                 return true;
             }
 
@@ -664,7 +952,21 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
             ThrowIfFailed(extraFindResult, "C_FindObjects");
 
             hasMore = extraFound.Value != 0;
+            if (hasMore)
+            {
+                telemetry.ReturnedFalse(extraFindResult);
+            }
+            else
+            {
+                telemetry.Succeeded(extraFindResult);
+            }
+
             return !hasMore;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
         finally
         {
@@ -678,76 +980,100 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public Pkcs11NativeAttributeQuery QueryAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, CK_ATTRIBUTE_TYPE attributeType)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GetAttributeValue, "C_GetAttributeValue");
-
-        CK_ATTRIBUTE attribute = new()
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(QueryAttributeValue), "C_GetAttributeValue", sessionHandle: sessionHandle);
+        try
         {
-            Type = attributeType,
-            Value = null,
-            ValueLength = 0,
-        };
+            EnsureInitialized();
 
-        CK_RV result = FunctionList->C_GetAttributeValue(sessionHandle, objectHandle, &attribute, 1);
-        ThrowIfAttributeQueryFailed(result, "C_GetAttributeValue");
-        return new Pkcs11NativeAttributeQuery(result, (nuint)attribute.ValueLength);
+            EnsureFunctionAvailable((void*)FunctionList->C_GetAttributeValue, "C_GetAttributeValue");
+
+            CK_ATTRIBUTE attribute = new()
+            {
+                Type = attributeType,
+                Value = null,
+                ValueLength = 0,
+            };
+
+            CK_RV result = FunctionList->C_GetAttributeValue(sessionHandle, objectHandle, &attribute, 1);
+            ThrowIfAttributeQueryFailed(result, "C_GetAttributeValue");
+            telemetry.Succeeded(result);
+            return new Pkcs11NativeAttributeQuery(result, (nuint)attribute.ValueLength);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, CK_ATTRIBUTE_TYPE attributeType, Span<byte> destination, out int written, out Pkcs11NativeAttributeQuery query)
     {
-        query = QueryAttributeValue(sessionHandle, objectHandle, attributeType);
-        if (!query.IsReadable)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetAttributeValue), "C_GetAttributeValue", sessionHandle: sessionHandle);
+        try
         {
-            written = 0;
-            return false;
-        }
-
-        if (query.IsUnavailableInformation)
-        {
-            written = 0;
-            return false;
-        }
-
-        int requiredLength = ToInt32Checked(new CK_ULONG(query.Length), "attribute length");
-        if (destination.Length < requiredLength)
-        {
-            written = requiredLength;
-            return false;
-        }
-
-        CK_ATTRIBUTE attribute = new()
-        {
-            Type = attributeType,
-            ValueLength = (CK_ULONG)(nuint)destination.Length,
-        };
-
-        CK_RV result;
-        if (destination.IsEmpty)
-        {
-            attribute.Value = null;
-            result = FunctionList->C_GetAttributeValue(sessionHandle, objectHandle, &attribute, 1);
-        }
-        else
-        {
-            fixed (byte* destinationPointer = destination)
+            query = QueryAttributeValue(sessionHandle, objectHandle, attributeType);
+            if (!query.IsReadable)
             {
-                attribute.Value = destinationPointer;
+                written = 0;
+                telemetry.ReturnedFalse(query.Result);
+                return false;
+            }
+
+            if (query.IsUnavailableInformation)
+            {
+                written = 0;
+                telemetry.ReturnedFalse(query.Result);
+                return false;
+            }
+
+            int requiredLength = ToInt32Checked(new CK_ULONG(query.Length), "attribute length");
+            if (destination.Length < requiredLength)
+            {
+                written = requiredLength;
+                telemetry.ReturnedFalse(Pkcs11ReturnValues.BufferTooSmall);
+                return false;
+            }
+
+            CK_ATTRIBUTE attribute = new()
+            {
+                Type = attributeType,
+                ValueLength = (CK_ULONG)(nuint)destination.Length,
+            };
+
+            CK_RV result;
+            if (destination.IsEmpty)
+            {
+                attribute.Value = null;
                 result = FunctionList->C_GetAttributeValue(sessionHandle, objectHandle, &attribute, 1);
             }
-        }
+            else
+            {
+                fixed (byte* destinationPointer = destination)
+                {
+                    attribute.Value = destinationPointer;
+                    result = FunctionList->C_GetAttributeValue(sessionHandle, objectHandle, &attribute, 1);
+                }
+            }
 
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(attribute.ValueLength, "attribute length");
+                query = new Pkcs11NativeAttributeQuery(result, (nuint)attribute.ValueLength);
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfAttributeQueryFailed(result, "C_GetAttributeValue");
             written = ToInt32Checked(attribute.ValueLength, "attribute length");
             query = new Pkcs11NativeAttributeQuery(result, (nuint)attribute.ValueLength);
-            return false;
+            telemetry.Succeeded(result);
+            return true;
         }
-
-        ThrowIfAttributeQueryFailed(result, "C_GetAttributeValue");
-        written = ToInt32Checked(attribute.ValueLength, "attribute length");
-        query = new Pkcs11NativeAttributeQuery(result, (nuint)attribute.ValueLength);
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public unsafe Pkcs11NativeAttributeValue[] GetAttributeValues(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, ReadOnlySpan<CK_ATTRIBUTE_TYPE> attributeTypes)
@@ -857,242 +1183,343 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public CK_OBJECT_HANDLE CreateObject(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_CreateObject, "C_CreateObject");
-
-        CK_OBJECT_HANDLE objectHandle = default;
-        CK_RV result;
-
-        if (template.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(CreateObject), "C_CreateObject", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_CreateObject(sessionHandle, null, 0, &objectHandle);
-        }
-        else
-        {
-            fixed (CK_ATTRIBUTE* templatePointer = template)
-            {
-                result = FunctionList->C_CreateObject(sessionHandle, templatePointer, (CK_ULONG)(nuint)template.Length, &objectHandle);
-            }
-        }
+            EnsureInitialized();
 
-        ThrowIfFailed(result, "C_CreateObject");
-        return objectHandle;
-    }
+            EnsureFunctionAvailable((void*)FunctionList->C_CreateObject, "C_CreateObject");
 
-    public CK_OBJECT_HANDLE CopyObject(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE sourceObjectHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
-    {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_CopyObject, "C_CopyObject");
-
-        CK_OBJECT_HANDLE objectHandle = default;
-        CK_RV result;
-
-        if (template.IsEmpty)
-        {
-            result = FunctionList->C_CopyObject(sessionHandle, sourceObjectHandle, null, 0, &objectHandle);
-        }
-        else
-        {
-            fixed (CK_ATTRIBUTE* templatePointer = template)
-            {
-                result = FunctionList->C_CopyObject(sessionHandle, sourceObjectHandle, templatePointer, (CK_ULONG)(nuint)template.Length, &objectHandle);
-            }
-        }
-
-        ThrowIfFailed(result, "C_CopyObject");
-        return objectHandle;
-    }
-
-    public void SetAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
-    {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_SetAttributeValue, "C_SetAttributeValue");
-
-        CK_RV result;
-
-        if (template.IsEmpty)
-        {
-            result = FunctionList->C_SetAttributeValue(sessionHandle, objectHandle, null, 0);
-        }
-        else
-        {
-            fixed (CK_ATTRIBUTE* templatePointer = template)
-            {
-                result = FunctionList->C_SetAttributeValue(sessionHandle, objectHandle, templatePointer, (CK_ULONG)(nuint)template.Length);
-            }
-        }
-
-        ThrowIfFailed(result, "C_SetAttributeValue");
-    }
-
-    public void DestroyObject(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle)
-    {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_DestroyObject, "C_DestroyObject");
-
-        CK_RV result = FunctionList->C_DestroyObject(sessionHandle, objectHandle);
-        ThrowIfFailed(result, "C_DestroyObject");
-    }
-
-    public CK_OBJECT_HANDLE GenerateKey(CK_SESSION_HANDLE sessionHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> template)
-    {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GenerateKey, "C_GenerateKey");
-
-        CK_OBJECT_HANDLE keyHandle = default;
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
-        {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+            CK_OBJECT_HANDLE objectHandle = default;
             CK_RV result;
 
             if (template.IsEmpty)
             {
-                result = FunctionList->C_GenerateKey(sessionHandle, &mechanism, null, 0, &keyHandle);
+                result = FunctionList->C_CreateObject(sessionHandle, null, 0, &objectHandle);
             }
             else
             {
                 fixed (CK_ATTRIBUTE* templatePointer = template)
                 {
-                    result = FunctionList->C_GenerateKey(sessionHandle, &mechanism, templatePointer, (CK_ULONG)(nuint)template.Length, &keyHandle);
+                    result = FunctionList->C_CreateObject(sessionHandle, templatePointer, (CK_ULONG)(nuint)template.Length, &objectHandle);
                 }
             }
 
-            ThrowIfFailed(result, "C_GenerateKey");
+            ThrowIfFailed(result, "C_CreateObject");
+            telemetry.Succeeded(result);
+            return objectHandle;
         }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
+    }
 
-        return keyHandle;
+    public CK_OBJECT_HANDLE CopyObject(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE sourceObjectHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
+    {
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(CopyObject), "C_CopyObject", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_CopyObject, "C_CopyObject");
+
+            CK_OBJECT_HANDLE objectHandle = default;
+            CK_RV result;
+
+            if (template.IsEmpty)
+            {
+                result = FunctionList->C_CopyObject(sessionHandle, sourceObjectHandle, null, 0, &objectHandle);
+            }
+            else
+            {
+                fixed (CK_ATTRIBUTE* templatePointer = template)
+                {
+                    result = FunctionList->C_CopyObject(sessionHandle, sourceObjectHandle, templatePointer, (CK_ULONG)(nuint)template.Length, &objectHandle);
+                }
+            }
+
+            ThrowIfFailed(result, "C_CopyObject");
+            telemetry.Succeeded(result);
+            return objectHandle;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
+    }
+
+    public void SetAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
+    {
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SetAttributeValue), "C_SetAttributeValue", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_SetAttributeValue, "C_SetAttributeValue");
+
+            CK_RV result;
+
+            if (template.IsEmpty)
+            {
+                result = FunctionList->C_SetAttributeValue(sessionHandle, objectHandle, null, 0);
+            }
+            else
+            {
+                fixed (CK_ATTRIBUTE* templatePointer = template)
+                {
+                    result = FunctionList->C_SetAttributeValue(sessionHandle, objectHandle, templatePointer, (CK_ULONG)(nuint)template.Length);
+                }
+            }
+
+            ThrowIfFailed(result, "C_SetAttributeValue");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
+    }
+
+    public void DestroyObject(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle)
+    {
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(DestroyObject), "C_DestroyObject", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_DestroyObject, "C_DestroyObject");
+
+            CK_RV result = FunctionList->C_DestroyObject(sessionHandle, objectHandle);
+            ThrowIfFailed(result, "C_DestroyObject");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
+    }
+
+    public CK_OBJECT_HANDLE GenerateKey(CK_SESSION_HANDLE sessionHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> template)
+    {
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GenerateKey), "C_GenerateKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
+        {
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_GenerateKey, "C_GenerateKey");
+
+            CK_OBJECT_HANDLE keyHandle = default;
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                CK_RV result;
+
+                if (template.IsEmpty)
+                {
+                    result = FunctionList->C_GenerateKey(sessionHandle, &mechanism, null, 0, &keyHandle);
+                }
+                else
+                {
+                    fixed (CK_ATTRIBUTE* templatePointer = template)
+                    {
+                        result = FunctionList->C_GenerateKey(sessionHandle, &mechanism, templatePointer, (CK_ULONG)(nuint)template.Length, &keyHandle);
+                    }
+                }
+
+                ThrowIfFailed(result, "C_GenerateKey");
+                telemetry.Succeeded(result);
+            }
+
+            return keyHandle;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public (CK_OBJECT_HANDLE PublicKeyHandle, CK_OBJECT_HANDLE PrivateKeyHandle) GenerateKeyPair(CK_SESSION_HANDLE sessionHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> publicKeyTemplate, ReadOnlySpan<CK_ATTRIBUTE> privateKeyTemplate)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GenerateKeyPair, "C_GenerateKeyPair");
-
-        CK_OBJECT_HANDLE publicKeyHandle = default;
-        CK_OBJECT_HANDLE privateKeyHandle = default;
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GenerateKeyPair), "C_GenerateKeyPair", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            fixed (CK_ATTRIBUTE* publicTemplatePointer = publicKeyTemplate)
-            fixed (CK_ATTRIBUTE* privateTemplatePointer = privateKeyTemplate)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_GenerateKeyPair, "C_GenerateKeyPair");
+
+            CK_OBJECT_HANDLE publicKeyHandle = default;
+            CK_OBJECT_HANDLE privateKeyHandle = default;
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
             {
-                CK_RV result = FunctionList->C_GenerateKeyPair(
-                    sessionHandle,
-                    &mechanism,
-                    publicKeyTemplate.IsEmpty ? null : publicTemplatePointer,
-                    (CK_ULONG)(nuint)publicKeyTemplate.Length,
-                    privateKeyTemplate.IsEmpty ? null : privateTemplatePointer,
-                    (CK_ULONG)(nuint)privateKeyTemplate.Length,
-                    &publicKeyHandle,
-                    &privateKeyHandle);
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                fixed (CK_ATTRIBUTE* publicTemplatePointer = publicKeyTemplate)
+                fixed (CK_ATTRIBUTE* privateTemplatePointer = privateKeyTemplate)
+                {
+                    CK_RV result = FunctionList->C_GenerateKeyPair(
+                        sessionHandle,
+                        &mechanism,
+                        publicKeyTemplate.IsEmpty ? null : publicTemplatePointer,
+                        (CK_ULONG)(nuint)publicKeyTemplate.Length,
+                        privateKeyTemplate.IsEmpty ? null : privateTemplatePointer,
+                        (CK_ULONG)(nuint)privateKeyTemplate.Length,
+                        &publicKeyHandle,
+                        &privateKeyHandle);
 
-                ThrowIfFailed(result, "C_GenerateKeyPair");
+                    ThrowIfFailed(result, "C_GenerateKeyPair");
+                    telemetry.Succeeded(result);
+                }
             }
-        }
 
-        return (publicKeyHandle, privateKeyHandle);
+            return (publicKeyHandle, privateKeyHandle);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public int GetWrapKeyOutputLength(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE wrappingKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, CK_OBJECT_HANDLE keyHandle)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_WrapKey, "C_WrapKey");
-
-        CK_ULONG wrappedKeyLength = default;
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetWrapKeyOutputLength), "C_WrapKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            CK_RV result = FunctionList->C_WrapKey(sessionHandle, &mechanism, wrappingKeyHandle, keyHandle, null, &wrappedKeyLength);
-            ThrowIfFailed(result, "C_WrapKey");
-        }
+            EnsureInitialized();
 
-        return ToInt32Checked(wrappedKeyLength, "wrapped key length");
+            EnsureFunctionAvailable((void*)FunctionList->C_WrapKey, "C_WrapKey");
+
+            CK_ULONG wrappedKeyLength = default;
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                CK_RV result = FunctionList->C_WrapKey(sessionHandle, &mechanism, wrappingKeyHandle, keyHandle, null, &wrappedKeyLength);
+                ThrowIfFailed(result, "C_WrapKey");
+                telemetry.Succeeded(result);
+            }
+
+            return ToInt32Checked(wrappedKeyLength, "wrapped key length");
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryWrapKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE wrappingKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, CK_OBJECT_HANDLE keyHandle, Span<byte> wrappedKey, out int written)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_WrapKey, "C_WrapKey");
-
-        CK_ULONG wrappedKeyLength = (CK_ULONG)(nuint)wrappedKey.Length;
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
-        fixed (byte* wrappedKeyPointer = wrappedKey)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryWrapKey), "C_WrapKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            CK_RV result = FunctionList->C_WrapKey(sessionHandle, &mechanism, wrappingKeyHandle, keyHandle, wrappedKey.IsEmpty ? null : wrappedKeyPointer, &wrappedKeyLength);
-            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_WrapKey, "C_WrapKey");
+
+            CK_ULONG wrappedKeyLength = (CK_ULONG)(nuint)wrappedKey.Length;
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            fixed (byte* wrappedKeyPointer = wrappedKey)
             {
-                written = ToInt32Checked(wrappedKeyLength, "wrapped key length");
-                return false;
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                CK_RV result = FunctionList->C_WrapKey(sessionHandle, &mechanism, wrappingKeyHandle, keyHandle, wrappedKey.IsEmpty ? null : wrappedKeyPointer, &wrappedKeyLength);
+                if (result == Pkcs11ReturnValues.BufferTooSmall)
+                {
+                    written = ToInt32Checked(wrappedKeyLength, "wrapped key length");
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, "C_WrapKey");
+                telemetry.Succeeded(result);
             }
 
-            ThrowIfFailed(result, "C_WrapKey");
+            written = ToInt32Checked(wrappedKeyLength, "wrapped key length");
+            return true;
         }
-
-        written = ToInt32Checked(wrappedKeyLength, "wrapped key length");
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public CK_OBJECT_HANDLE UnwrapKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE unwrappingKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<byte> wrappedKey, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_UnwrapKey, "C_UnwrapKey");
-
-        CK_OBJECT_HANDLE keyHandle = default;
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
-        fixed (byte* wrappedKeyPointer = wrappedKey)
-        fixed (CK_ATTRIBUTE* templatePointer = template)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(UnwrapKey), "C_UnwrapKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            CK_RV result = FunctionList->C_UnwrapKey(
-                sessionHandle,
-                &mechanism,
-                unwrappingKeyHandle,
-                wrappedKey.IsEmpty ? null : wrappedKeyPointer,
-                (CK_ULONG)(nuint)wrappedKey.Length,
-                template.IsEmpty ? null : templatePointer,
-                (CK_ULONG)(nuint)template.Length,
-                &keyHandle);
+            EnsureInitialized();
 
-            ThrowIfFailed(result, "C_UnwrapKey");
+            EnsureFunctionAvailable((void*)FunctionList->C_UnwrapKey, "C_UnwrapKey");
+
+            CK_OBJECT_HANDLE keyHandle = default;
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            fixed (byte* wrappedKeyPointer = wrappedKey)
+            fixed (CK_ATTRIBUTE* templatePointer = template)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                CK_RV result = FunctionList->C_UnwrapKey(
+                    sessionHandle,
+                    &mechanism,
+                    unwrappingKeyHandle,
+                    wrappedKey.IsEmpty ? null : wrappedKeyPointer,
+                    (CK_ULONG)(nuint)wrappedKey.Length,
+                    template.IsEmpty ? null : templatePointer,
+                    (CK_ULONG)(nuint)template.Length,
+                    &keyHandle);
+
+                ThrowIfFailed(result, "C_UnwrapKey");
+                telemetry.Succeeded(result);
+            }
+
+            return keyHandle;
         }
-
-        return keyHandle;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public CK_OBJECT_HANDLE DeriveKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE baseKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_DeriveKey, "C_DeriveKey");
-
-        CK_OBJECT_HANDLE keyHandle = default;
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
-        fixed (CK_ATTRIBUTE* templatePointer = template)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(DeriveKey), "C_DeriveKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            CK_RV result = FunctionList->C_DeriveKey(
-                sessionHandle,
-                &mechanism,
-                baseKeyHandle,
-                template.IsEmpty ? null : templatePointer,
-                (CK_ULONG)(nuint)template.Length,
-                &keyHandle);
+            EnsureInitialized();
 
-            ThrowIfFailed(result, "C_DeriveKey");
+            EnsureFunctionAvailable((void*)FunctionList->C_DeriveKey, "C_DeriveKey");
+
+            CK_OBJECT_HANDLE keyHandle = default;
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            fixed (CK_ATTRIBUTE* templatePointer = template)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                CK_RV result = FunctionList->C_DeriveKey(
+                    sessionHandle,
+                    &mechanism,
+                    baseKeyHandle,
+                    template.IsEmpty ? null : templatePointer,
+                    (CK_ULONG)(nuint)template.Length,
+                    &keyHandle);
+
+                ThrowIfFailed(result, "C_DeriveKey");
+                telemetry.Succeeded(result);
+            }
+
+            return keyHandle;
         }
-
-        return keyHandle;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private static CK_MECHANISM CreateMechanism(CK_MECHANISM_TYPE mechanismType, byte* mechanismParameterPointer, int mechanismParameterLength, out MarshalledMechanismParameters marshalledMechanismParameters)
@@ -1171,14 +1598,24 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public nuint GetObjectSize(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetObjectSize), "C_GetObjectSize", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_GetObjectSize, "C_GetObjectSize");
+            EnsureFunctionAvailable((void*)FunctionList->C_GetObjectSize, "C_GetObjectSize");
 
-        CK_ULONG objectSize = default;
-        CK_RV result = FunctionList->C_GetObjectSize(sessionHandle, objectHandle, &objectSize);
-        ThrowIfFailed(result, "C_GetObjectSize");
-        return (nuint)objectSize;
+            CK_ULONG objectSize = default;
+            CK_RV result = FunctionList->C_GetObjectSize(sessionHandle, objectHandle, &objectSize);
+            ThrowIfFailed(result, "C_GetObjectSize");
+            telemetry.Succeeded(result);
+            return (nuint)objectSize;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public int GetEncryptOutputLength(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<byte> plaintext)
@@ -1278,12 +1715,22 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void DigestKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(DigestKey), "C_DigestKey", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_DigestKey, "C_DigestKey");
+            EnsureFunctionAvailable((void*)FunctionList->C_DigestKey, "C_DigestKey");
 
-        CK_RV result = FunctionList->C_DigestKey(sessionHandle, keyHandle);
-        ThrowIfFailed(result, "C_DigestKey");
+            CK_RV result = FunctionList->C_DigestKey(sessionHandle, keyHandle);
+            ThrowIfFailed(result, "C_DigestKey");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TrySign(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<byte> data, Span<byte> signature, out int written)
@@ -1303,14 +1750,33 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public bool Verify(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature)
     {
-        EnsureInitialized();
-        EnsureVerifyFunctions(FunctionList->C_VerifyInit, FunctionList->C_Verify, "C_VerifyInit", "C_Verify");
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(Verify), "C_Verify", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, FunctionList->C_VerifyInit, "C_VerifyInit");
-            return InvokeVerify(sessionHandle, data, signature, FunctionList->C_Verify, "C_Verify");
+            EnsureInitialized();
+            EnsureVerifyFunctions(FunctionList->C_VerifyInit, FunctionList->C_Verify, "C_VerifyInit", "C_Verify");
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, FunctionList->C_VerifyInit, "C_VerifyInit");
+                bool verified = InvokeVerify(sessionHandle, data, signature, FunctionList->C_Verify, "C_Verify");
+                if (verified)
+                {
+                    telemetry.Succeeded(CK_RV.Ok);
+                }
+                else
+                {
+                    telemetry.ReturnedFalse(Pkcs11ReturnValues.SignatureInvalid);
+                }
+
+                return verified;
+            }
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -1325,20 +1791,31 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void SignUpdate(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> data)
     {
-        EnsureDataUpdateFunction(FunctionList->C_SignUpdate, "C_SignUpdate");
-
-        if (data.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SignUpdate), "C_SignUpdate", sessionHandle: sessionHandle);
+        try
         {
-            return;
-        }
+            EnsureDataUpdateFunction(FunctionList->C_SignUpdate, "C_SignUpdate");
 
-        CK_RV result;
-        fixed (byte* dataPointer = data)
+            if (data.IsEmpty)
+            {
+                telemetry.Succeeded(CK_RV.Ok);
+                return;
+            }
+
+            CK_RV result;
+            fixed (byte* dataPointer = data)
+            {
+                result = FunctionList->C_SignUpdate(sessionHandle, dataPointer, (CK_ULONG)(nuint)data.Length);
+            }
+
+            ThrowIfFailed(result, "C_SignUpdate");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
         {
-            result = FunctionList->C_SignUpdate(sessionHandle, dataPointer, (CK_ULONG)(nuint)data.Length);
+            telemetry.Failed(ex);
+            throw;
         }
-
-        ThrowIfFailed(result, "C_SignUpdate");
     }
 
     public bool TrySignFinal(CK_SESSION_HANDLE sessionHandle, Span<byte> signature, out int written)
@@ -1388,48 +1865,70 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void VerifyUpdate(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> data)
     {
-        EnsureDataUpdateFunction(FunctionList->C_VerifyUpdate, "C_VerifyUpdate");
-
-        if (data.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(VerifyUpdate), "C_VerifyUpdate", sessionHandle: sessionHandle);
+        try
         {
-            return;
-        }
+            EnsureDataUpdateFunction(FunctionList->C_VerifyUpdate, "C_VerifyUpdate");
 
-        CK_RV result;
-        fixed (byte* dataPointer = data)
+            if (data.IsEmpty)
+            {
+                telemetry.Succeeded(CK_RV.Ok);
+                return;
+            }
+
+            CK_RV result;
+            fixed (byte* dataPointer = data)
+            {
+                result = FunctionList->C_VerifyUpdate(sessionHandle, dataPointer, (CK_ULONG)(nuint)data.Length);
+            }
+
+            ThrowIfFailed(result, "C_VerifyUpdate");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
         {
-            result = FunctionList->C_VerifyUpdate(sessionHandle, dataPointer, (CK_ULONG)(nuint)data.Length);
+            telemetry.Failed(ex);
+            throw;
         }
-
-        ThrowIfFailed(result, "C_VerifyUpdate");
     }
 
     public bool VerifyFinal(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> signature)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_VerifyFinal, "C_VerifyFinal");
-
-        CK_RV result;
-        if (signature.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(VerifyFinal), "C_VerifyFinal", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_VerifyFinal(sessionHandle, null, 0);
-        }
-        else
-        {
-            fixed (byte* signaturePointer = signature)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_VerifyFinal, "C_VerifyFinal");
+
+            CK_RV result;
+            if (signature.IsEmpty)
             {
-                result = FunctionList->C_VerifyFinal(sessionHandle, signaturePointer, (CK_ULONG)(nuint)signature.Length);
+                result = FunctionList->C_VerifyFinal(sessionHandle, null, 0);
             }
-        }
+            else
+            {
+                fixed (byte* signaturePointer = signature)
+                {
+                    result = FunctionList->C_VerifyFinal(sessionHandle, signaturePointer, (CK_ULONG)(nuint)signature.Length);
+                }
+            }
 
-        if (result == Pkcs11ReturnValues.SignatureInvalid || result == Pkcs11ReturnValues.SignatureLenRange)
+            if (result == Pkcs11ReturnValues.SignatureInvalid || result == Pkcs11ReturnValues.SignatureLenRange)
+            {
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_VerifyFinal");
+            telemetry.Succeeded(result);
+            return true;
+        }
+        catch (Exception ex)
         {
-            return false;
+            telemetry.Failed(ex);
+            throw;
         }
-
-        ThrowIfFailed(result, "C_VerifyFinal");
-        return true;
     }
 
     public void VerifyRecoverInit(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter)
@@ -1469,20 +1968,31 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void DigestUpdate(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> data)
     {
-        EnsureDataUpdateFunction(FunctionList->C_DigestUpdate, "C_DigestUpdate");
-
-        if (data.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(DigestUpdate), "C_DigestUpdate", sessionHandle: sessionHandle);
+        try
         {
-            return;
-        }
+            EnsureDataUpdateFunction(FunctionList->C_DigestUpdate, "C_DigestUpdate");
 
-        CK_RV result;
-        fixed (byte* dataPointer = data)
+            if (data.IsEmpty)
+            {
+                telemetry.Succeeded(CK_RV.Ok);
+                return;
+            }
+
+            CK_RV result;
+            fixed (byte* dataPointer = data)
+            {
+                result = FunctionList->C_DigestUpdate(sessionHandle, dataPointer, (CK_ULONG)(nuint)data.Length);
+            }
+
+            ThrowIfFailed(result, "C_DigestUpdate");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
         {
-            result = FunctionList->C_DigestUpdate(sessionHandle, dataPointer, (CK_ULONG)(nuint)data.Length);
+            telemetry.Failed(ex);
+            throw;
         }
-
-        ThrowIfFailed(result, "C_DigestUpdate");
     }
 
     public bool TryDigestFinal(CK_SESSION_HANDLE sessionHandle, Span<byte> digest, out int written)
@@ -1496,77 +2006,118 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void GenerateRandom(CK_SESSION_HANDLE sessionHandle, Span<byte> destination)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GenerateRandom, "C_GenerateRandom");
-
-        CK_RV result;
-        if (destination.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GenerateRandom), "C_GenerateRandom", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_GenerateRandom(sessionHandle, null, 0);
-        }
-        else
-        {
-            fixed (byte* destinationPointer = destination)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_GenerateRandom, "C_GenerateRandom");
+
+            CK_RV result;
+            if (destination.IsEmpty)
             {
-                result = FunctionList->C_GenerateRandom(sessionHandle, destinationPointer, (CK_ULONG)(nuint)destination.Length);
+                result = FunctionList->C_GenerateRandom(sessionHandle, null, 0);
             }
-        }
+            else
+            {
+                fixed (byte* destinationPointer = destination)
+                {
+                    result = FunctionList->C_GenerateRandom(sessionHandle, destinationPointer, (CK_ULONG)(nuint)destination.Length);
+                }
+            }
 
-        ThrowIfFailed(result, "C_GenerateRandom");
+            ThrowIfFailed(result, "C_GenerateRandom");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void SeedRandom(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> seed)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_SeedRandom, "C_SeedRandom");
-
-        CK_RV result;
-        if (seed.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SeedRandom), "C_SeedRandom", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_SeedRandom(sessionHandle, null, 0);
-        }
-        else
-        {
-            fixed (byte* seedPointer = seed)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_SeedRandom, "C_SeedRandom");
+
+            CK_RV result;
+            if (seed.IsEmpty)
             {
-                result = FunctionList->C_SeedRandom(sessionHandle, seedPointer, (CK_ULONG)(nuint)seed.Length);
+                result = FunctionList->C_SeedRandom(sessionHandle, null, 0);
             }
-        }
+            else
+            {
+                fixed (byte* seedPointer = seed)
+                {
+                    result = FunctionList->C_SeedRandom(sessionHandle, seedPointer, (CK_ULONG)(nuint)seed.Length);
+                }
+            }
 
-        ThrowIfFailed(result, "C_SeedRandom");
+            ThrowIfFailed(result, "C_SeedRandom");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public CK_SLOT_ID WaitForSlotEvent()
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(WaitForSlotEvent), "C_WaitForSlotEvent");
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_WaitForSlotEvent, "C_WaitForSlotEvent");
+            EnsureFunctionAvailable((void*)FunctionList->C_WaitForSlotEvent, "C_WaitForSlotEvent");
 
-        CK_SLOT_ID slotId = default;
-        CK_RV result = FunctionList->C_WaitForSlotEvent(new CK_FLAGS(0), &slotId, null);
-        ThrowIfFailed(result, "C_WaitForSlotEvent");
-        return slotId;
+            CK_SLOT_ID slotId = default;
+            CK_RV result = FunctionList->C_WaitForSlotEvent(new CK_FLAGS(0), &slotId, null);
+            ThrowIfFailed(result, "C_WaitForSlotEvent");
+            telemetry.Succeeded(result);
+            return slotId;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryWaitForSlotEvent(out CK_SLOT_ID slotId)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_WaitForSlotEvent, "C_WaitForSlotEvent");
-
-        CK_SLOT_ID nativeSlotId = default;
-        CK_RV result = FunctionList->C_WaitForSlotEvent(new CK_FLAGS(Pkcs11SlotEventFlags.DontBlock), &nativeSlotId, null);
-        if (result == Pkcs11ReturnValues.NoEvent)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryWaitForSlotEvent), "C_WaitForSlotEvent");
+        try
         {
-            slotId = default;
-            return false;
-        }
+            EnsureInitialized();
 
-        ThrowIfFailed(result, "C_WaitForSlotEvent");
-        slotId = nativeSlotId;
-        return true;
+            EnsureFunctionAvailable((void*)FunctionList->C_WaitForSlotEvent, "C_WaitForSlotEvent");
+
+            CK_SLOT_ID nativeSlotId = default;
+            CK_RV result = FunctionList->C_WaitForSlotEvent(new CK_FLAGS(Pkcs11SlotEventFlags.DontBlock), &nativeSlotId, null);
+            if (result == Pkcs11ReturnValues.NoEvent)
+            {
+                slotId = default;
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_WaitForSlotEvent");
+            slotId = nativeSlotId;
+            telemetry.Succeeded(result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void EncryptInit(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter)
@@ -1667,139 +2218,212 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public int GetOperationStateLength(CK_SESSION_HANDLE sessionHandle)
     {
-        EnsureInitialized();
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetOperationStateLength), "C_GetOperationState", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
 
-        EnsureFunctionAvailable((void*)FunctionList->C_GetOperationState, "C_GetOperationState");
+            EnsureFunctionAvailable((void*)FunctionList->C_GetOperationState, "C_GetOperationState");
 
-        CK_ULONG stateLength = default;
-        CK_RV result = FunctionList->C_GetOperationState(sessionHandle, null, &stateLength);
-        ThrowIfFailed(result, "C_GetOperationState");
-        return ToInt32Checked(stateLength, "operation state length");
+            CK_ULONG stateLength = default;
+            CK_RV result = FunctionList->C_GetOperationState(sessionHandle, null, &stateLength);
+            ThrowIfFailed(result, "C_GetOperationState");
+            telemetry.Succeeded(result);
+            return ToInt32Checked(stateLength, "operation state length");
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetOperationState(CK_SESSION_HANDLE sessionHandle, Span<byte> destination, out int written)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GetOperationState, "C_GetOperationState");
-
-        CK_ULONG stateLength = (CK_ULONG)(nuint)destination.Length;
-        CK_RV result;
-
-        if (destination.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetOperationState), "C_GetOperationState", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_GetOperationState(sessionHandle, null, &stateLength);
-        }
-        else
-        {
-            fixed (byte* destinationPointer = destination)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_GetOperationState, "C_GetOperationState");
+
+            CK_ULONG stateLength = (CK_ULONG)(nuint)destination.Length;
+            CK_RV result;
+
+            if (destination.IsEmpty)
             {
-                result = FunctionList->C_GetOperationState(sessionHandle, destinationPointer, &stateLength);
+                result = FunctionList->C_GetOperationState(sessionHandle, null, &stateLength);
             }
-        }
+            else
+            {
+                fixed (byte* destinationPointer = destination)
+                {
+                    result = FunctionList->C_GetOperationState(sessionHandle, destinationPointer, &stateLength);
+                }
+            }
 
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(stateLength, "operation state length");
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetOperationState");
             written = ToInt32Checked(stateLength, "operation state length");
-            return false;
+            telemetry.Succeeded(result);
+            return true;
         }
-
-        ThrowIfFailed(result, "C_GetOperationState");
-        written = ToInt32Checked(stateLength, "operation state length");
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void SetOperationState(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> state, CK_OBJECT_HANDLE encryptionKeyHandle, CK_OBJECT_HANDLE authenticationKeyHandle)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_SetOperationState, "C_SetOperationState");
-
-        CK_RV result;
-        if (state.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SetOperationState), "C_SetOperationState", sessionHandle: sessionHandle);
+        try
         {
-            result = FunctionList->C_SetOperationState(sessionHandle, null, 0, encryptionKeyHandle, authenticationKeyHandle);
-        }
-        else
-        {
-            fixed (byte* statePointer = state)
+            EnsureInitialized();
+
+            EnsureFunctionAvailable((void*)FunctionList->C_SetOperationState, "C_SetOperationState");
+
+            CK_RV result;
+            if (state.IsEmpty)
             {
-                result = FunctionList->C_SetOperationState(sessionHandle, statePointer, (CK_ULONG)(nuint)state.Length, encryptionKeyHandle, authenticationKeyHandle);
+                result = FunctionList->C_SetOperationState(sessionHandle, null, 0, encryptionKeyHandle, authenticationKeyHandle);
             }
-        }
+            else
+            {
+                fixed (byte* statePointer = state)
+                {
+                    result = FunctionList->C_SetOperationState(sessionHandle, statePointer, (CK_ULONG)(nuint)state.Length, encryptionKeyHandle, authenticationKeyHandle);
+                }
+            }
 
-        ThrowIfFailed(result, "C_SetOperationState");
+            ThrowIfFailed(result, "C_SetOperationState");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryGetFunctionStatus(CK_SESSION_HANDLE sessionHandle)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_GetFunctionStatus, "C_GetFunctionStatus");
-
-        CK_RV result = FunctionList->C_GetFunctionStatus(sessionHandle);
-        if (result == Pkcs11ReturnValues.FunctionNotParallel || result == Pkcs11ReturnValues.FunctionNotSupported)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetFunctionStatus), "C_GetFunctionStatus", sessionHandle: sessionHandle);
+        try
         {
-            return false;
-        }
+            EnsureInitialized();
 
-        ThrowIfFailed(result, "C_GetFunctionStatus");
-        return true;
+            EnsureFunctionAvailable((void*)FunctionList->C_GetFunctionStatus, "C_GetFunctionStatus");
+
+            CK_RV result = FunctionList->C_GetFunctionStatus(sessionHandle);
+            if (result == Pkcs11ReturnValues.FunctionNotParallel || result == Pkcs11ReturnValues.FunctionNotSupported)
+            {
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_GetFunctionStatus");
+            telemetry.Succeeded(result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TryCancelFunction(CK_SESSION_HANDLE sessionHandle)
     {
-        EnsureInitialized();
-
-        EnsureFunctionAvailable((void*)FunctionList->C_CancelFunction, "C_CancelFunction");
-
-        CK_RV result = FunctionList->C_CancelFunction(sessionHandle);
-        if (result == Pkcs11ReturnValues.FunctionNotParallel || result == Pkcs11ReturnValues.FunctionNotSupported)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryCancelFunction), "C_CancelFunction", sessionHandle: sessionHandle);
+        try
         {
-            return false;
-        }
+            EnsureInitialized();
 
-        ThrowIfFailed(result, "C_CancelFunction");
-        return true;
+            EnsureFunctionAvailable((void*)FunctionList->C_CancelFunction, "C_CancelFunction");
+
+            CK_RV result = FunctionList->C_CancelFunction(sessionHandle);
+            if (result == Pkcs11ReturnValues.FunctionNotParallel || result == Pkcs11ReturnValues.FunctionNotSupported)
+            {
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, "C_CancelFunction");
+            telemetry.Succeeded(result);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void LoginUser(CK_SESSION_HANDLE sessionHandle, CK_USER_TYPE userType, ReadOnlySpan<byte> pinUtf8, ReadOnlySpan<byte> usernameUtf8)
     {
-        EnsureInitialized();
-
-        CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
-        EnsureFunctionAvailable((void*)functionList->C_LoginUser, "C_LoginUser");
-
-        CK_RV result;
-        if (pinUtf8.IsEmpty && usernameUtf8.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(LoginUser), "C_LoginUser", sessionHandle: sessionHandle);
+        try
         {
-            result = functionList->C_LoginUser(sessionHandle, userType, null, 0, null, 0);
-        }
-        else
-        {
-            fixed (byte* pinPointer = pinUtf8)
-            fixed (byte* usernamePointer = usernameUtf8)
+            EnsureInitialized();
+
+            CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
+            EnsureFunctionAvailable((void*)functionList->C_LoginUser, "C_LoginUser");
+
+            CK_RV result;
+            if (pinUtf8.IsEmpty && usernameUtf8.IsEmpty)
             {
-                result = functionList->C_LoginUser(
-                    sessionHandle,
-                    userType,
-                    pinUtf8.IsEmpty ? null : pinPointer,
-                    (CK_ULONG)(nuint)pinUtf8.Length,
-                    usernameUtf8.IsEmpty ? null : usernamePointer,
-                    (CK_ULONG)(nuint)usernameUtf8.Length);
+                result = functionList->C_LoginUser(sessionHandle, userType, null, 0, null, 0);
             }
-        }
+            else
+            {
+                fixed (byte* pinPointer = pinUtf8)
+                fixed (byte* usernamePointer = usernameUtf8)
+                {
+                    result = functionList->C_LoginUser(
+                        sessionHandle,
+                        userType,
+                        pinUtf8.IsEmpty ? null : pinPointer,
+                        (CK_ULONG)(nuint)pinUtf8.Length,
+                        usernameUtf8.IsEmpty ? null : usernamePointer,
+                        (CK_ULONG)(nuint)usernameUtf8.Length);
+                }
+            }
 
-        ThrowIfFailed(result, "C_LoginUser");
+            ThrowIfFailed(result, "C_LoginUser");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void SessionCancel(CK_SESSION_HANDLE sessionHandle, CK_FLAGS flags)
     {
-        EnsureInitialized();
-        CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
-        EnsureFunctionAvailable((void*)functionList->C_SessionCancel, "C_SessionCancel");
-        CK_RV result = functionList->C_SessionCancel(sessionHandle, flags);
-        ThrowIfFailed(result, "C_SessionCancel");
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SessionCancel), "C_SessionCancel", sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+            CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
+            EnsureFunctionAvailable((void*)functionList->C_SessionCancel, "C_SessionCancel");
+            CK_RV result = functionList->C_SessionCancel(sessionHandle, flags);
+            ThrowIfFailed(result, "C_SessionCancel");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public void MessageEncryptInit(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter)
@@ -1961,14 +2585,24 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, CK_MECHANISM*, CK_OBJECT_HANDLE, CK_RV> init,
         string operation)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)init, operation);
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            CK_RV result = init(sessionHandle, &mechanism, keyHandle);
-            ThrowIfFailed(result, operation);
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)init, operation);
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                CK_RV result = init(sessionHandle, &mechanism, keyHandle);
+                ThrowIfFailed(result, operation);
+                telemetry.Succeeded(result);
+            }
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -1981,11 +2615,21 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string operation,
         string outputName)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)invoke, operation);
-        CK_ULONG outputLength = default;
-        InvokeMessage(sessionHandle, parameter, associatedData, input, null, &outputLength, invoke, operation);
-        return ToInt32Checked(outputLength, outputName);
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)invoke, operation);
+            CK_ULONG outputLength = default;
+            CK_RV result = InvokeMessage(sessionHandle, parameter, associatedData, input, null, &outputLength, invoke, operation);
+            telemetry.Succeeded(result);
+            return ToInt32Checked(outputLength, outputName);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private bool TryMessageInvoke(
@@ -1999,140 +2643,215 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string operation,
         string outputName)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)invoke, operation);
-        CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
-
-        fixed (byte* outputPointer = output)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
         {
-            CK_RV result = InvokeMessage(sessionHandle, parameter, associatedData, input, output.IsEmpty ? null : outputPointer, &outputLength, invoke, operation, throwOnError: false);
-            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)invoke, operation);
+            CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
+
+            fixed (byte* outputPointer = output)
             {
-                written = ToInt32Checked(outputLength, outputName);
-                return false;
+                CK_RV result = InvokeMessage(sessionHandle, parameter, associatedData, input, output.IsEmpty ? null : outputPointer, &outputLength, invoke, operation, throwOnError: false);
+                if (result == Pkcs11ReturnValues.BufferTooSmall)
+                {
+                    written = ToInt32Checked(outputLength, outputName);
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, operation);
+                telemetry.Succeeded(result);
             }
 
-            ThrowIfFailed(result, operation);
+            written = ToInt32Checked(outputLength, outputName);
+            return true;
         }
-
-        written = ToInt32Checked(outputLength, outputName);
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private void MessageBegin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> associatedData, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, CK_RV> begin, string operation)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)begin, operation);
-
-        fixed (byte* parameterPointer = parameter)
-        fixed (byte* associatedDataPointer = associatedData)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
         {
-            CK_RV result = begin(
-                sessionHandle,
-                parameter.IsEmpty ? null : parameterPointer,
-                (CK_ULONG)(nuint)parameter.Length,
-                associatedData.IsEmpty ? null : associatedDataPointer,
-                (CK_ULONG)(nuint)associatedData.Length);
-            ThrowIfFailed(result, operation);
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)begin, operation);
+
+            fixed (byte* parameterPointer = parameter)
+            fixed (byte* associatedDataPointer = associatedData)
+            {
+                CK_RV result = begin(
+                    sessionHandle,
+                    parameter.IsEmpty ? null : parameterPointer,
+                    (CK_ULONG)(nuint)parameter.Length,
+                    associatedData.IsEmpty ? null : associatedDataPointer,
+                    (CK_ULONG)(nuint)associatedData.Length);
+                ThrowIfFailed(result, operation);
+                telemetry.Succeeded(result);
+            }
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
     private bool TryMessageNext(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> input, Span<byte> output, CK_FLAGS flags, out int written, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG*, CK_FLAGS, CK_RV> next, string operation, string outputName)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)next, operation);
-
-        CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
-        fixed (byte* parameterPointer = parameter)
-        fixed (byte* inputPointer = input)
-        fixed (byte* outputPointer = output)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
         {
-            CK_RV result = next(
-                sessionHandle,
-                parameter.IsEmpty ? null : parameterPointer,
-                (CK_ULONG)(nuint)parameter.Length,
-                input.IsEmpty ? null : inputPointer,
-                (CK_ULONG)(nuint)input.Length,
-                output.IsEmpty ? null : outputPointer,
-                &outputLength,
-                flags);
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)next, operation);
 
-            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
+            fixed (byte* parameterPointer = parameter)
+            fixed (byte* inputPointer = input)
+            fixed (byte* outputPointer = output)
             {
-                written = ToInt32Checked(outputLength, outputName);
-                return false;
+                CK_RV result = next(
+                    sessionHandle,
+                    parameter.IsEmpty ? null : parameterPointer,
+                    (CK_ULONG)(nuint)parameter.Length,
+                    input.IsEmpty ? null : inputPointer,
+                    (CK_ULONG)(nuint)input.Length,
+                    output.IsEmpty ? null : outputPointer,
+                    &outputLength,
+                    flags);
+
+                if (result == Pkcs11ReturnValues.BufferTooSmall)
+                {
+                    written = ToInt32Checked(outputLength, outputName);
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, operation);
+                telemetry.Succeeded(result);
             }
 
-            ThrowIfFailed(result, operation);
+            written = ToInt32Checked(outputLength, outputName);
+            return true;
         }
-
-        written = ToInt32Checked(outputLength, outputName);
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private void MessageFinal(CK_SESSION_HANDLE sessionHandle, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, CK_RV> final, string operation)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)final, operation);
-        ThrowIfFailed(final(sessionHandle), operation);
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)final, operation);
+            CK_RV result = final(sessionHandle);
+            ThrowIfFailed(result, operation);
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private int GetSignMessageOutputLengthCore(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG*, CK_RV> invoke, string operation)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)invoke, operation);
-        CK_ULONG signatureLength = default;
-        InvokeSignMessage(sessionHandle, parameter, data, null, &signatureLength, invoke, operation);
-        return ToInt32Checked(signatureLength, "signature length");
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
+        {
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)invoke, operation);
+            CK_ULONG signatureLength = default;
+            CK_RV result = InvokeSignMessage(sessionHandle, parameter, data, null, &signatureLength, invoke, operation);
+            telemetry.Succeeded(result);
+            return ToInt32Checked(signatureLength, "signature length");
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private bool TrySignMessageCore(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, Span<byte> signature, out int written, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG*, CK_RV> invoke, string operation)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)invoke, operation);
-        CK_ULONG signatureLength = (CK_ULONG)(nuint)signature.Length;
-
-        fixed (byte* signaturePointer = signature)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
         {
-            CK_RV result = InvokeSignMessage(sessionHandle, parameter, data, signature.IsEmpty ? null : signaturePointer, &signatureLength, invoke, operation, throwOnError: false);
-            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)invoke, operation);
+            CK_ULONG signatureLength = (CK_ULONG)(nuint)signature.Length;
+
+            fixed (byte* signaturePointer = signature)
             {
-                written = ToInt32Checked(signatureLength, "signature length");
-                return false;
+                CK_RV result = InvokeSignMessage(sessionHandle, parameter, data, signature.IsEmpty ? null : signaturePointer, &signatureLength, invoke, operation, throwOnError: false);
+                if (result == Pkcs11ReturnValues.BufferTooSmall)
+                {
+                    written = ToInt32Checked(signatureLength, "signature length");
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, operation);
+                telemetry.Succeeded(result);
             }
 
-            ThrowIfFailed(result, operation);
+            written = ToInt32Checked(signatureLength, "signature length");
+            return true;
         }
-
-        written = ToInt32Checked(signatureLength, "signature length");
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private bool VerifyMessageCore(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG, CK_RV> verify, string operation)
     {
-        EnsureInitialized();
-        EnsureFunctionAvailable((void*)verify, operation);
-
-        fixed (byte* parameterPointer = parameter)
-        fixed (byte* dataPointer = data)
-        fixed (byte* signaturePointer = signature)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        try
         {
-            CK_RV result = verify(
-                sessionHandle,
-                parameter.IsEmpty ? null : parameterPointer,
-                (CK_ULONG)(nuint)parameter.Length,
-                data.IsEmpty ? null : dataPointer,
-                (CK_ULONG)(nuint)data.Length,
-                signature.IsEmpty ? null : signaturePointer,
-                (CK_ULONG)(nuint)signature.Length);
+            EnsureInitialized();
+            EnsureFunctionAvailable((void*)verify, operation);
 
-            if (result == Pkcs11ReturnValues.SignatureInvalid || result == Pkcs11ReturnValues.SignatureLenRange)
+            fixed (byte* parameterPointer = parameter)
+            fixed (byte* dataPointer = data)
+            fixed (byte* signaturePointer = signature)
             {
-                return false;
-            }
+                CK_RV result = verify(
+                    sessionHandle,
+                    parameter.IsEmpty ? null : parameterPointer,
+                    (CK_ULONG)(nuint)parameter.Length,
+                    data.IsEmpty ? null : dataPointer,
+                    (CK_ULONG)(nuint)data.Length,
+                    signature.IsEmpty ? null : signaturePointer,
+                    (CK_ULONG)(nuint)signature.Length);
 
-            ThrowIfFailed(result, operation);
-            return true;
+                if (result == Pkcs11ReturnValues.SignatureInvalid || result == Pkcs11ReturnValues.SignatureLenRange)
+                {
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, operation);
+                telemetry.Succeeded(result);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -2251,20 +2970,30 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string invokeOperation,
         string outputName)
     {
-        EnsureInitialized();
-        EnsureCryptFunctions(init, invoke, initOperation, invokeOperation);
-
-        CK_ULONG outputLength = default;
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, init, initOperation);
-            InvokeCrypt(sessionHandle, input, null, &outputLength, invoke, invokeOperation);
-            DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
-        }
+            EnsureInitialized();
+            EnsureCryptFunctions(init, invoke, initOperation, invokeOperation);
 
-        return ToInt32Checked(outputLength, outputName);
+            CK_ULONG outputLength = default;
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, init, initOperation);
+                InvokeCrypt(sessionHandle, input, null, &outputLength, invoke, invokeOperation);
+                DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+            }
+
+            telemetry.Succeeded(CK_RV.Ok);
+            return ToInt32Checked(outputLength, outputName);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private int GetSinglePartDigestOutputLength(
@@ -2278,20 +3007,30 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string invokeOperation,
         string outputName)
     {
-        EnsureInitialized();
-        EnsureMechanismFunctions(init, invoke, initOperation, invokeOperation);
-
-        CK_ULONG outputLength = default;
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeMechanismOperation(sessionHandle, &mechanism, init, initOperation);
-            InvokeCrypt(sessionHandle, input, null, &outputLength, invoke, invokeOperation);
-            DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
-        }
+            EnsureInitialized();
+            EnsureMechanismFunctions(init, invoke, initOperation, invokeOperation);
 
-        return ToInt32Checked(outputLength, outputName);
+            CK_ULONG outputLength = default;
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeMechanismOperation(sessionHandle, &mechanism, init, initOperation);
+                InvokeCrypt(sessionHandle, input, null, &outputLength, invoke, invokeOperation);
+                DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+            }
+
+            telemetry.Succeeded(CK_RV.Ok);
+            return ToInt32Checked(outputLength, outputName);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private bool TrySinglePartCrypt(
@@ -2308,33 +3047,44 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string invokeOperation,
         string outputName)
     {
-        EnsureInitialized();
-        EnsureCryptFunctions(init, invoke, initOperation, invokeOperation);
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, init, initOperation);
+            EnsureInitialized();
+            EnsureCryptFunctions(init, invoke, initOperation, invokeOperation);
 
-            CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
-            CK_RV result;
-
-            fixed (byte* inputPointer = input)
-            fixed (byte* outputPointer = output)
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
             {
-                result = invoke(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, outputPointer, &outputLength);
-            }
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, init, initOperation);
 
-            if (result == Pkcs11ReturnValues.BufferTooSmall)
-            {
+                CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
+                CK_RV result;
+
+                fixed (byte* inputPointer = input)
+                fixed (byte* outputPointer = output)
+                {
+                    result = invoke(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, outputPointer, &outputLength);
+                }
+
+                if (result == Pkcs11ReturnValues.BufferTooSmall)
+                {
+                    written = ToInt32Checked(outputLength, outputName);
+                    DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, invokeOperation);
                 written = ToInt32Checked(outputLength, outputName);
-                DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
-                return false;
+                telemetry.Succeeded(result);
+                return true;
             }
-
-            ThrowIfFailed(result, invokeOperation);
-            written = ToInt32Checked(outputLength, outputName);
-            return true;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -2351,33 +3101,44 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string invokeOperation,
         string outputName)
     {
-        EnsureInitialized();
-        EnsureMechanismFunctions(init, invoke, initOperation, invokeOperation);
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeMechanismOperation(sessionHandle, &mechanism, init, initOperation);
+            EnsureInitialized();
+            EnsureMechanismFunctions(init, invoke, initOperation, invokeOperation);
 
-            CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
-            CK_RV result;
-
-            fixed (byte* inputPointer = input)
-            fixed (byte* outputPointer = output)
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
             {
-                result = invoke(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, outputPointer, &outputLength);
-            }
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeMechanismOperation(sessionHandle, &mechanism, init, initOperation);
 
-            if (result == Pkcs11ReturnValues.BufferTooSmall)
-            {
+                CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
+                CK_RV result;
+
+                fixed (byte* inputPointer = input)
+                fixed (byte* outputPointer = output)
+                {
+                    result = invoke(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, outputPointer, &outputLength);
+                }
+
+                if (result == Pkcs11ReturnValues.BufferTooSmall)
+                {
+                    written = ToInt32Checked(outputLength, outputName);
+                    DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+                    telemetry.ReturnedFalse(result);
+                    return false;
+                }
+
+                ThrowIfFailed(result, invokeOperation);
                 written = ToInt32Checked(outputLength, outputName);
-                DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
-                return false;
+                telemetry.Succeeded(result);
+                return true;
             }
-
-            ThrowIfFailed(result, invokeOperation);
-            written = ToInt32Checked(outputLength, outputName);
-            return true;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -2570,17 +3331,28 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, CK_MECHANISM*, CK_OBJECT_HANDLE, CK_RV> init,
         string initOperation)
     {
-        EnsureInitialized();
-
-        if (init is null)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(initOperation, initOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            throw new InvalidOperationException($"The PKCS#11 function list does not expose {initOperation}.");
+            EnsureInitialized();
+
+            if (init is null)
+            {
+                throw new InvalidOperationException($"The PKCS#11 function list does not expose {initOperation}.");
+            }
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, init, initOperation);
+            }
+
+            telemetry.Succeeded(CK_RV.Ok);
         }
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        catch (Exception ex)
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeCryptOperation(sessionHandle, keyHandle, &mechanism, init, initOperation);
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -2591,17 +3363,28 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, CK_MECHANISM*, CK_RV> init,
         string initOperation)
     {
-        EnsureInitialized();
-
-        if (init is null)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(initOperation, initOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        try
         {
-            throw new InvalidOperationException($"The PKCS#11 function list does not expose {initOperation}.");
+            EnsureInitialized();
+
+            if (init is null)
+            {
+                throw new InvalidOperationException($"The PKCS#11 function list does not expose {initOperation}.");
+            }
+
+            fixed (byte* mechanismParameterPointer = mechanismParameter)
+            {
+                CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
+                InitializeMechanismOperation(sessionHandle, &mechanism, init, initOperation);
+            }
+
+            telemetry.Succeeded(CK_RV.Ok);
         }
-
-        fixed (byte* mechanismParameterPointer = mechanismParameter)
+        catch (Exception ex)
         {
-            CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
-            InitializeMechanismOperation(sessionHandle, &mechanism, init, initOperation);
+            telemetry.Failed(ex);
+            throw;
         }
     }
 
@@ -2644,36 +3427,47 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string updateOperation,
         string outputName)
     {
-        EnsureUpdateFunction(update, updateOperation);
-
-        CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
-        CK_RV result;
-
-        if (input.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(updateOperation, updateOperation, sessionHandle: sessionHandle);
+        try
         {
-            fixed (byte* outputPointer = output)
+            EnsureUpdateFunction(update, updateOperation);
+
+            CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
+            CK_RV result;
+
+            if (input.IsEmpty)
             {
-                result = update(sessionHandle, null, 0, outputPointer, &outputLength);
+                fixed (byte* outputPointer = output)
+                {
+                    result = update(sessionHandle, null, 0, outputPointer, &outputLength);
+                }
             }
-        }
-        else
-        {
-            fixed (byte* inputPointer = input)
-            fixed (byte* outputPointer = output)
+            else
             {
-                result = update(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, outputPointer, &outputLength);
+                fixed (byte* inputPointer = input)
+                fixed (byte* outputPointer = output)
+                {
+                    result = update(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, outputPointer, &outputLength);
+                }
             }
-        }
 
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(outputLength, outputName);
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, updateOperation);
             written = ToInt32Checked(outputLength, outputName);
-            return false;
+            telemetry.Succeeded(result);
+            return true;
         }
-
-        ThrowIfFailed(result, updateOperation);
-        written = ToInt32Checked(outputLength, outputName);
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private bool TryCryptFinal(
@@ -2684,32 +3478,43 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string finalOperation,
         string outputName)
     {
-        EnsureFinalFunction(final, finalOperation);
-
-        CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
-        CK_RV result;
-
-        if (output.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(finalOperation, finalOperation, sessionHandle: sessionHandle);
+        try
         {
-            result = final(sessionHandle, null, &outputLength);
-        }
-        else
-        {
-            fixed (byte* outputPointer = output)
+            EnsureFinalFunction(final, finalOperation);
+
+            CK_ULONG outputLength = (CK_ULONG)(nuint)output.Length;
+            CK_RV result;
+
+            if (output.IsEmpty)
             {
-                result = final(sessionHandle, outputPointer, &outputLength);
+                result = final(sessionHandle, null, &outputLength);
             }
-        }
+            else
+            {
+                fixed (byte* outputPointer = output)
+                {
+                    result = final(sessionHandle, outputPointer, &outputLength);
+                }
+            }
 
-        if (result == Pkcs11ReturnValues.BufferTooSmall)
-        {
+            if (result == Pkcs11ReturnValues.BufferTooSmall)
+            {
+                written = ToInt32Checked(outputLength, outputName);
+                telemetry.ReturnedFalse(result);
+                return false;
+            }
+
+            ThrowIfFailed(result, finalOperation);
             written = ToInt32Checked(outputLength, outputName);
-            return false;
+            telemetry.Succeeded(result);
+            return true;
         }
-
-        ThrowIfFailed(result, finalOperation);
-        written = ToInt32Checked(outputLength, outputName);
-        return true;
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private int GetCryptInvokeOutputLength(
@@ -2719,26 +3524,36 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string invokeOperation,
         string outputName)
     {
-        EnsureUpdateFunction(invoke, invokeOperation);
-
-        CK_ULONG outputLength = default;
-        CK_RV result;
-
-        if (input.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle);
+        try
         {
-            result = invoke(sessionHandle, null, 0, null, &outputLength);
-        }
-        else
-        {
-            fixed (byte* inputPointer = input)
+            EnsureUpdateFunction(invoke, invokeOperation);
+
+            CK_ULONG outputLength = default;
+            CK_RV result;
+
+            if (input.IsEmpty)
             {
-                result = invoke(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, null, &outputLength);
+                result = invoke(sessionHandle, null, 0, null, &outputLength);
             }
-        }
+            else
+            {
+                fixed (byte* inputPointer = input)
+                {
+                    result = invoke(sessionHandle, inputPointer, (CK_ULONG)(nuint)input.Length, null, &outputLength);
+                }
+            }
 
-        ThrowIfFailed(result, invokeOperation);
-        DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
-        return ToInt32Checked(outputLength, outputName);
+            ThrowIfFailed(result, invokeOperation);
+            DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+            telemetry.Succeeded(result);
+            return ToInt32Checked(outputLength, outputName);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     private static void EnsureCryptFunctions(

--- a/src/Pkcs11Wrapper.Native/Pkcs11OperationTelemetry.cs
+++ b/src/Pkcs11Wrapper.Native/Pkcs11OperationTelemetry.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics;
+using Pkcs11Wrapper.Native.Interop;
+
+namespace Pkcs11Wrapper.Native;
+
+public enum Pkcs11OperationTelemetryStatus
+{
+    Succeeded = 0,
+    ReturnedFalse = 1,
+    Failed = 2,
+}
+
+public readonly record struct Pkcs11OperationTelemetryEvent(
+    string OperationName,
+    string? NativeOperationName,
+    Pkcs11OperationTelemetryStatus Status,
+    TimeSpan Duration,
+    CK_RV? ReturnValue,
+    nuint? SlotId,
+    nuint? SessionHandle,
+    nuint? MechanismType,
+    Exception? Exception)
+{
+    public bool IsSuccess => Status == Pkcs11OperationTelemetryStatus.Succeeded;
+}
+
+public interface IPkcs11OperationTelemetryListener
+{
+    void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent);
+}
+
+internal readonly ref struct Pkcs11OperationTelemetryScope
+{
+    private readonly IPkcs11OperationTelemetryListener? _listener;
+    private readonly string _operationName;
+    private readonly string? _nativeOperationName;
+    private readonly nuint? _slotId;
+    private readonly nuint? _sessionHandle;
+    private readonly nuint? _mechanismType;
+    private readonly long _startTimestamp;
+
+    public Pkcs11OperationTelemetryScope(
+        IPkcs11OperationTelemetryListener? listener,
+        string operationName,
+        string? nativeOperationName,
+        CK_SLOT_ID? slotId = null,
+        CK_SESSION_HANDLE? sessionHandle = null,
+        CK_MECHANISM_TYPE? mechanismType = null)
+    {
+        _listener = listener;
+        _operationName = operationName;
+        _nativeOperationName = nativeOperationName;
+        _slotId = slotId?.Value;
+        _sessionHandle = sessionHandle?.Value;
+        _mechanismType = mechanismType?.Value;
+        _startTimestamp = listener is null ? 0 : Stopwatch.GetTimestamp();
+    }
+
+    public void Succeeded(CK_RV returnValue)
+        => Emit(Pkcs11OperationTelemetryStatus.Succeeded, returnValue, null);
+
+    public void ReturnedFalse(CK_RV returnValue)
+        => Emit(Pkcs11OperationTelemetryStatus.ReturnedFalse, returnValue, null);
+
+    public void Failed(Exception exception)
+        => Emit(
+            Pkcs11OperationTelemetryStatus.Failed,
+            exception is Pkcs11Exception pkcs11Exception ? pkcs11Exception.Result : null,
+            exception);
+
+    private void Emit(Pkcs11OperationTelemetryStatus status, CK_RV? returnValue, Exception? exception)
+    {
+        if (_listener is null)
+        {
+            return;
+        }
+
+        Pkcs11OperationTelemetryEvent operationEvent = new(
+            _operationName,
+            _nativeOperationName,
+            status,
+            Stopwatch.GetElapsedTime(_startTimestamp),
+            returnValue,
+            _slotId,
+            _sessionHandle,
+            _mechanismType,
+            exception);
+
+        try
+        {
+            _listener.OnOperationCompleted(in operationEvent);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/Pkcs11Wrapper/Pkcs11Module.cs
+++ b/src/Pkcs11Wrapper/Pkcs11Module.cs
@@ -27,7 +27,16 @@ public sealed class Pkcs11Module : IDisposable
 
     public bool SupportsInterfaceDiscovery => _nativeModule.SupportsInterfaceDiscovery;
 
+    public IPkcs11OperationTelemetryListener? TelemetryListener
+    {
+        get => _nativeModule.TelemetryListener;
+        set => _nativeModule.TelemetryListener = value;
+    }
+
     public static Pkcs11Module Load(string libraryPath) => new(Pkcs11NativeModule.Load(libraryPath));
+
+    public static Pkcs11Module Load(string libraryPath, IPkcs11OperationTelemetryListener? telemetryListener)
+        => new(Pkcs11NativeModule.Load(libraryPath, telemetryListener));
 
     public void Initialize() => Initialize(default);
 

--- a/tests/Pkcs11Wrapper.Native.Tests/ManagedApiSurfaceTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/ManagedApiSurfaceTests.cs
@@ -27,6 +27,33 @@ public sealed class ManagedApiSurfaceTests
     }
 
     [Fact]
+    public void TelemetryApisAreExposedOnManagedAndNativeSurfaces()
+    {
+        Assert.NotNull(typeof(Pkcs11Module).GetMethod(nameof(Pkcs11Module.Load), [typeof(string), typeof(IPkcs11OperationTelemetryListener)]));
+        Assert.NotNull(typeof(Pkcs11Module).GetProperty(nameof(Pkcs11Module.TelemetryListener)));
+        Assert.NotNull(typeof(Pkcs11NativeModule).GetProperty(nameof(Pkcs11NativeModule.TelemetryListener)));
+        Assert.NotNull(typeof(IPkcs11OperationTelemetryListener).GetMethod(nameof(IPkcs11OperationTelemetryListener.OnOperationCompleted)));
+
+        Pkcs11OperationTelemetryEvent operationEvent = new(
+            OperationName: "TestOperation",
+            NativeOperationName: "C_TestOperation",
+            Status: Pkcs11OperationTelemetryStatus.Succeeded,
+            Duration: TimeSpan.FromMilliseconds(1),
+            ReturnValue: CK_RV.Ok,
+            SlotId: 7,
+            SessionHandle: 11,
+            MechanismType: 13,
+            Exception: null);
+
+        Assert.True(operationEvent.IsSuccess);
+        Assert.Equal("TestOperation", operationEvent.OperationName);
+        Assert.Equal("C_TestOperation", operationEvent.NativeOperationName);
+        Assert.Equal((nuint)7, operationEvent.SlotId);
+        Assert.Equal((nuint)11, operationEvent.SessionHandle);
+        Assert.Equal((nuint)13, operationEvent.MechanismType);
+    }
+
+    [Fact]
     public void ModulePathDefaultsExposeSoftHsmCandidates()
     {
         Assert.NotNull(typeof(Pkcs11ModulePathDefaults).GetMethod(nameof(Pkcs11ModulePathDefaults.GetSoftHsmModuleCandidates), Type.EmptyTypes));

--- a/tests/Pkcs11Wrapper.Native.Tests/Pkcs11RuntimeCollection.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/Pkcs11RuntimeCollection.cs
@@ -1,0 +1,7 @@
+namespace Pkcs11Wrapper.Native.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class Pkcs11RuntimeCollection
+{
+    public const string Name = "pkcs11-runtime";
+}

--- a/tests/Pkcs11Wrapper.Native.Tests/Pkcs11V3ShimRuntimeTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/Pkcs11V3ShimRuntimeTests.cs
@@ -5,6 +5,7 @@ using Pkcs11Wrapper.Native.Interop;
 
 namespace Pkcs11Wrapper.Native.Tests;
 
+[Collection(Pkcs11RuntimeCollection.Name)]
 public sealed class Pkcs11V3ShimRuntimeTests
 {
     private static readonly byte[] ExpectedPinUtf8 = "123456"u8.ToArray();

--- a/tests/Pkcs11Wrapper.Native.Tests/SoftHsmCryptRegressionTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/SoftHsmCryptRegressionTests.cs
@@ -10,6 +10,7 @@ using Pkcs11Wrapper.Native.Interop;
 
 namespace Pkcs11Wrapper.Native.Tests;
 
+[Collection(Pkcs11RuntimeCollection.Name)]
 public sealed class SoftHsmCryptRegressionTests
 {
     private static readonly Pkcs11AttributeType SignRecoverAttributeType = new(0x00000109u);

--- a/tests/Pkcs11Wrapper.Native.Tests/TelemetryRegressionTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/TelemetryRegressionTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Pkcs11Wrapper;
+using Pkcs11Wrapper.Native;
+using Pkcs11Wrapper.Native.Interop;
+
+namespace Pkcs11Wrapper.Native.Tests;
+
+[Collection(Pkcs11RuntimeCollection.Name)]
+public sealed class TelemetryRegressionTests
+{
+    [Fact]
+    public void ModuleAndSessionOperationsEmitStructuredTelemetry()
+    {
+        string? modulePath = Environment.GetEnvironmentVariable("PKCS11_MODULE_PATH");
+        string? tokenLabel = Environment.GetEnvironmentVariable("PKCS11_TOKEN_LABEL");
+        string? userPin = Environment.GetEnvironmentVariable("PKCS11_USER_PIN");
+
+        if (string.IsNullOrWhiteSpace(modulePath) || string.IsNullOrWhiteSpace(tokenLabel) || string.IsNullOrWhiteSpace(userPin))
+        {
+            return;
+        }
+
+        RecordingTelemetryListener listener = new();
+
+        using (Pkcs11Module module = Pkcs11Module.Load(modulePath, listener))
+        {
+            Assert.Same(listener, module.TelemetryListener);
+
+            module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+            Pkcs11SlotId slotId = FindSlotByTokenLabel(module, tokenLabel);
+            using Pkcs11Session session = module.OpenSession(slotId);
+            session.Login(Pkcs11UserType.User, Encoding.UTF8.GetBytes(userPin));
+
+            byte[] digest = new byte[32];
+            bool digested = session.TryDigest(new Pkcs11Mechanism(Pkcs11MechanismTypes.Sha256), "telemetry-payload"u8, digest, out int written);
+            Assert.True(digested);
+            Assert.Equal(32, written);
+
+            byte[] random = new byte[16];
+            session.GenerateRandom(random);
+            session.Logout();
+        }
+
+        Pkcs11OperationTelemetryEvent[] events = listener.Events.ToArray();
+        Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.Load) && e.NativeOperationName == "C_GetFunctionList" && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+        Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.Initialize) && e.NativeOperationName == "C_Initialize" && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+        Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.OpenSession) && e.NativeOperationName == "C_OpenSession" && e.SlotId.HasValue && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+        Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.Login) && e.NativeOperationName == "C_Login" && e.SessionHandle.HasValue && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+        Assert.Contains(events, e => e.OperationName == "C_Digest" && e.NativeOperationName == "C_Digest" && e.SessionHandle.HasValue && e.MechanismType == Pkcs11MechanismTypes.Sha256.Value && e.Status == Pkcs11OperationTelemetryStatus.Succeeded && e.Duration >= TimeSpan.Zero);
+        Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.GenerateRandom) && e.NativeOperationName == "C_GenerateRandom" && e.SessionHandle.HasValue && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+        Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.CloseSession) && e.NativeOperationName == "C_CloseSession" && e.SessionHandle.HasValue && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+    }
+
+    [Fact]
+    public void ListenerFailuresDoNotBreakObservedOperations()
+    {
+        string? modulePath = Environment.GetEnvironmentVariable("PKCS11_MODULE_PATH");
+        if (string.IsNullOrWhiteSpace(modulePath))
+        {
+            return;
+        }
+
+        using Pkcs11Module module = Pkcs11Module.Load(modulePath, new ThrowingTelemetryListener());
+        module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+        CK_VERSION version = module.GetInfo().LibraryVersion;
+        Assert.True(version.Major > 0 || version.Minor >= 0);
+
+        module.FinalizeModule();
+    }
+
+    private static Pkcs11SlotId FindSlotByTokenLabel(Pkcs11Module module, string tokenLabel)
+    {
+        int slotCount = module.GetSlotCount(tokenPresentOnly: true);
+        Pkcs11SlotId[] slots = new Pkcs11SlotId[slotCount];
+        Assert.True(module.TryGetSlots(slots, out int written, tokenPresentOnly: true));
+        Assert.Equal(slotCount, written);
+
+        for (int i = 0; i < written; i++)
+        {
+            if (module.TryGetTokenInfo(slots[i], out Pkcs11TokenInfo tokenInfo) && string.Equals(tokenInfo.Label, tokenLabel, StringComparison.Ordinal))
+            {
+                return slots[i];
+            }
+        }
+
+        throw new InvalidOperationException($"Token '{tokenLabel}' was not found in the configured PKCS#11 fixture.");
+    }
+
+    private sealed class RecordingTelemetryListener : IPkcs11OperationTelemetryListener
+    {
+        public List<Pkcs11OperationTelemetryEvent> Events { get; } = [];
+
+        public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+            => Events.Add(operationEvent);
+    }
+
+    private sealed class ThrowingTelemetryListener : IPkcs11OperationTelemetryListener
+    {
+        public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+            => throw new InvalidOperationException($"Telemetry listener failure for {operationEvent.OperationName}");
+    }
+}


### PR DESCRIPTION
## Summary
Add structured PKCS#11 operation telemetry to the core wrapper.

## Included work
- opt-in structured telemetry/event model
- native/core + managed wrapper integration
- low-overhead disabled path
- docs and regression coverage

## Notes
- telemetry is observational and opt-in
- listener failures are swallowed so telemetry cannot break normal wrapper operations

## Closes
Closes #37
