### PR TITLE
Add a safe redaction policy for PKCS#11 telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ Telemetry is opt-in and disabled by default. When you attach a listener, the wra
 - success / returned-false / failure status
 - native return value when available
 - optional slot, session, and mechanism context
+- redacted `Fields` for safe metadata, masked credentials, hashed identifiers, and length-only payload summaries
 - captured exception for faulted operations
 
-Listener failures are swallowed so observational code does not break the underlying PKCS#11 call flow.
+Listener failures are swallowed so observational code does not break the underlying PKCS#11 call flow. The wrapper never emits raw PINs, key material, plaintext/ciphertext payloads, unwrap/import blobs, or secret PKCS#11 attributes. See `docs/telemetry-redaction.md` for the full policy.
 
 ```csharp
 using Pkcs11Wrapper;

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,7 @@ The wrapper surface implemented through the current phase set includes:
 - multipart operations and operation-state APIs
 - optional PKCS#11 v3 interface discovery and message-based API surface
 - optional `C_LoginUser` / `C_SessionCancel` through the discovered v3 interface
-- opt-in structured operation telemetry with duration, result/exception, and slot/session/mechanism context
+- opt-in structured operation telemetry with duration, result/exception, slot/session/mechanism context, and redacted field summaries for sensitive PKCS#11 inputs
 - administrative operations for session invalidation and token/PIN provisioning
 - NativeAOT smoke validation through the sample app on Linux and Windows
 
@@ -97,13 +97,15 @@ Notable current assumptions:
 ### Telemetry contract
 
 - Telemetry is disabled unless a consumer provides `IPkcs11OperationTelemetryListener`.
-- Emitted events carry operation/native-operation names, duration, status, raw return value when available, plus optional slot/session/mechanism metadata.
+- Emitted events carry operation/native-operation names, duration, status, raw return value when available, plus optional slot/session/mechanism metadata and redacted `Fields`.
+- The redaction contract distinguishes `SafeMetadata`, `LengthOnly`, `Masked`, `Hashed`, and `NeverLog` buckets so future tooling can render telemetry without leaking PKCS#11 secrets.
 - Listener exceptions are swallowed so telemetry remains observational and cannot break the primary PKCS#11 operation flow.
 
 ## Related docs
 
 - Fixture contract: `docs/softhsm-fixture.md`
 - CI behavior: `docs/ci.md`
+- Telemetry redaction policy: `docs/telemetry-redaction.md`
 - Smoke sample usage: `docs/smoke.md`
 - Compatibility matrix: `docs/compatibility-matrix.md`
 - Thales Luna integration guide: `docs/luna-integration.md`

--- a/docs/telemetry-redaction.md
+++ b/docs/telemetry-redaction.md
@@ -1,0 +1,74 @@
+# PKCS#11 telemetry redaction policy
+
+Telemetry in `Pkcs11Wrapper` is intentionally conservative. It is designed for diagnostics and correlation, not for payload capture.
+
+## Classification buckets
+
+Each `Pkcs11OperationTelemetryEvent` can expose redacted `Fields`. Every field carries a `Pkcs11TelemetryFieldClassification`:
+
+- `SafeMetadata` — non-secret metadata that is safe to log directly.
+  - examples: PKCS#11 user/object/mechanism identifiers, boolean capability flags, object class, key type, salt/tag/counter sizes
+- `LengthOnly` — raw bytes are never logged; only their size is emitted.
+  - examples: plaintext/ciphertext buffers, wrapped-key payloads, random seeds/output, multipart message chunks, AEAD IV/AAD lengths, operation-state blobs
+- `Masked` — secret credentials are represented as presence/length only.
+  - examples: PINs as `set(len=n)` or `empty`
+- `Hashed` — non-secret but potentially identifying byte values are replaced with a stable SHA-256 prefix.
+  - examples: usernames, labels, IDs, OAEP source data, ECDH public data, EC point/parameter blobs
+- `NeverLog` — the value itself must never be emitted. Telemetry only reports that it was suppressed, optionally with length metadata.
+  - examples: `CKA_VALUE`, private exponents, RSA/DSA/DH secret components, imported secret attribute payloads
+
+## Default policy by data type
+
+### Never log raw values
+
+These are always suppressed and never copied into telemetry:
+
+- PIN bytes
+- secret/private key material and secret-bearing attributes
+- imported/unwrapped key payload attributes (`CKA_VALUE`, private CRT components, DH/DSA secrets, similar standard secret attributes)
+- operation state blobs
+
+### Length-only
+
+These payloads keep operational usefulness without leaking contents:
+
+- plaintext / ciphertext / digest / signature inputs and outputs
+- wrapped-key blobs and unwrap/import payload byte arrays
+- random seeds and generated random output buffers
+- AEAD IV / nonce / AAD lengths
+- multipart message fragments and generic byte-span inputs
+
+### Hashed
+
+These values can help correlate calls without exposing raw data:
+
+- object labels and IDs
+- usernames passed to `C_LoginUser`
+- OAEP `sourceData`
+- ECDH public data
+- EC point / EC params / other identifying public attribute blobs
+
+### Safe metadata
+
+These values are emitted directly:
+
+- slot/session/mechanism identifiers already attached to telemetry events
+- user type, object class, key type
+- boolean object flags such as token/private/sensitive/extractable/wrap/unwrap/sign/verify/derive
+- scalar mechanism metadata such as hash algorithm IDs, MGF IDs, salt lengths, tag bits, counter bits, nonce lengths, AAD lengths
+- attribute/template counts and destination buffer sizes
+
+## Implementation notes
+
+The native telemetry layer applies this policy at the PKCS#11 boundary so listeners do not need to guess which fields are safe.
+
+Current coverage includes:
+
+- login / PIN / token-init credential paths
+- object search templates and object attribute mutation templates
+- key generation, wrap/unwrap, derive, and mechanism parameter summaries
+- single-part and multipart digest/encrypt/decrypt/sign/verify flows
+- PKCS#11 v3 message-based operations
+- random seeding/generation and operation-state restore
+
+If a future API adds new byte payloads, the default should remain conservative: prefer `LengthOnly`, move to `Hashed` only for correlation-friendly public identifiers, and reserve `NeverLog` for secret-bearing attributes and key material.

--- a/src/Pkcs11Wrapper.Native/Pkcs11NativeModule.cs
+++ b/src/Pkcs11Wrapper.Native/Pkcs11NativeModule.cs
@@ -525,6 +525,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void InitToken(CK_SLOT_ID slotId, ReadOnlySpan<byte> soPinUtf8, ReadOnlySpan<byte> label)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(InitToken), "C_InitToken", slotId: slotId);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.InitToken(soPinUtf8, label));
+        }
+
         try
         {
             EnsureInitialized();
@@ -752,6 +757,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void Login(CK_SESSION_HANDLE sessionHandle, CK_USER_TYPE userType, ReadOnlySpan<byte> pinUtf8)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(Login), "C_Login", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Credentials(userType, pinUtf8));
+        }
+
         try
         {
             EnsureInitialized();
@@ -806,6 +816,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void InitPin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> pinUtf8)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(InitPin), "C_InitPIN", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.MaskedSecret("credential.pin", pinUtf8));
+        }
+
         try
         {
             EnsureInitialized();
@@ -840,6 +855,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void SetPin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> oldPinUtf8, ReadOnlySpan<byte> newPinUtf8)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SetPin), "C_SetPIN", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.PinChange(oldPinUtf8, newPinUtf8));
+        }
+
         try
         {
             EnsureInitialized();
@@ -890,6 +910,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public bool TryFindObjects(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<CK_ATTRIBUTE> template, Span<CK_OBJECT_HANDLE> destination, out int written, out bool hasMore)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryFindObjects), "C_FindObjects", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("searchTemplate", template));
+            telemetry.AddField(Pkcs11TelemetryRedaction.Safe("search.destinationCapacity", destination.Length));
+        }
+
         EnsureInitialized();
 
         EnsureFunctionAvailable((void*)FunctionList->C_FindObjectsInit, "C_FindObjectsInit");
@@ -981,6 +1007,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public Pkcs11NativeAttributeQuery QueryAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, CK_ATTRIBUTE_TYPE attributeType)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(QueryAttributeValue), "C_GetAttributeValue", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.AttributeType("attribute.type", attributeType));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1009,6 +1040,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public bool TryGetAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, CK_ATTRIBUTE_TYPE attributeType, Span<byte> destination, out int written, out Pkcs11NativeAttributeQuery query)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryGetAttributeValue), "C_GetAttributeValue", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.AttributeType("attribute.type", attributeType));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("attribute.destination", destination.Length));
+        }
+
         try
         {
             query = QueryAttributeValue(sessionHandle, objectHandle, attributeType);
@@ -1184,6 +1221,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public CK_OBJECT_HANDLE CreateObject(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(CreateObject), "C_CreateObject", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("template", template));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1219,6 +1261,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public CK_OBJECT_HANDLE CopyObject(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE sourceObjectHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(CopyObject), "C_CopyObject", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.Safe("sourceObjectHandle", sourceObjectHandle.Value));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("template", template));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1254,6 +1302,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void SetAttributeValue(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE objectHandle, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SetAttributeValue), "C_SetAttributeValue", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.Safe("objectHandle", objectHandle.Value));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("template", template));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1307,6 +1361,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public CK_OBJECT_HANDLE GenerateKey(CK_SESSION_HANDLE sessionHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GenerateKey), "C_GenerateKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("template", template));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1347,6 +1407,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public (CK_OBJECT_HANDLE PublicKeyHandle, CK_OBJECT_HANDLE PrivateKeyHandle) GenerateKeyPair(CK_SESSION_HANDLE sessionHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> publicKeyTemplate, ReadOnlySpan<CK_ATTRIBUTE> privateKeyTemplate)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GenerateKeyPair), "C_GenerateKeyPair", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("publicTemplate", publicKeyTemplate));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("privateTemplate", privateKeyTemplate));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1388,6 +1455,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public int GetWrapKeyOutputLength(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE wrappingKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, CK_OBJECT_HANDLE keyHandle)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GetWrapKeyOutputLength), "C_WrapKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1400,6 +1472,7 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 CK_MECHANISM mechanism = CreateMechanism(mechanismType, mechanismParameterPointer, mechanismParameter.Length, out MarshalledMechanismParameters marshalledMechanismParameters);
                 CK_RV result = FunctionList->C_WrapKey(sessionHandle, &mechanism, wrappingKeyHandle, keyHandle, null, &wrappedKeyLength);
                 ThrowIfFailed(result, "C_WrapKey");
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("wrappedKey", ToInt32Checked(wrappedKeyLength, "wrapped key length")));
                 telemetry.Succeeded(result);
             }
 
@@ -1415,6 +1488,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public bool TryWrapKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE wrappingKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, CK_OBJECT_HANDLE keyHandle, Span<byte> wrappedKey, out int written)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(TryWrapKey), "C_WrapKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("wrappedKey.destination", wrappedKey.Length));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1431,11 +1510,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 if (result == Pkcs11ReturnValues.BufferTooSmall)
                 {
                     written = ToInt32Checked(wrappedKeyLength, "wrapped key length");
+                    telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("wrappedKey", written));
                     telemetry.ReturnedFalse(result);
                     return false;
                 }
 
                 ThrowIfFailed(result, "C_WrapKey");
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("wrappedKey", ToInt32Checked(wrappedKeyLength, "wrapped key length")));
                 telemetry.Succeeded(result);
             }
 
@@ -1452,6 +1533,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public CK_OBJECT_HANDLE UnwrapKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE unwrappingKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<byte> wrappedKey, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(UnwrapKey), "C_UnwrapKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("wrappedKey", wrappedKey));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("template", template));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1490,6 +1578,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public CK_OBJECT_HANDLE DeriveKey(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE baseKeyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<CK_ATTRIBUTE> template)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(DeriveKey), "C_DeriveKey", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Template("template", template));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1751,6 +1845,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public bool Verify(CK_SESSION_HANDLE sessionHandle, CK_OBJECT_HANDLE keyHandle, CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(Verify), "C_Verify", sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature", signature));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1792,6 +1893,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void SignUpdate(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> data)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SignUpdate), "C_SignUpdate", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+        }
+
         try
         {
             EnsureDataUpdateFunction(FunctionList->C_SignUpdate, "C_SignUpdate");
@@ -1866,6 +1972,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void VerifyUpdate(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> data)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(VerifyUpdate), "C_VerifyUpdate", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+        }
+
         try
         {
             EnsureDataUpdateFunction(FunctionList->C_VerifyUpdate, "C_VerifyUpdate");
@@ -1895,6 +2006,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public bool VerifyFinal(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> signature)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(VerifyFinal), "C_VerifyFinal", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature", signature));
+        }
+
         try
         {
             EnsureInitialized();
@@ -1969,6 +2085,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void DigestUpdate(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> data)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(DigestUpdate), "C_DigestUpdate", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+        }
+
         try
         {
             EnsureDataUpdateFunction(FunctionList->C_DigestUpdate, "C_DigestUpdate");
@@ -2007,6 +2128,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void GenerateRandom(CK_SESSION_HANDLE sessionHandle, Span<byte> destination)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(GenerateRandom), "C_GenerateRandom", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("random.output", destination.Length));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2039,6 +2165,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void SeedRandom(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> seed)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SeedRandom), "C_SeedRandom", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("random.seed", seed));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2284,6 +2415,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void SetOperationState(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> state, CK_OBJECT_HANDLE encryptionKeyHandle, CK_OBJECT_HANDLE authenticationKeyHandle)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SetOperationState), "C_SetOperationState", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("operation.state", state));
+            telemetry.AddField(Pkcs11TelemetryRedaction.Safe("operation.encryptionKeyHandle", encryptionKeyHandle.Value));
+            telemetry.AddField(Pkcs11TelemetryRedaction.Safe("operation.authenticationKeyHandle", authenticationKeyHandle.Value));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2370,6 +2508,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     public void LoginUser(CK_SESSION_HANDLE sessionHandle, CK_USER_TYPE userType, ReadOnlySpan<byte> pinUtf8, ReadOnlySpan<byte> usernameUtf8)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(LoginUser), "C_LoginUser", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.Credentials(userType, pinUtf8, usernameUtf8));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2471,24 +2614,39 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void SignMessageBegin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter)
     {
-        EnsureInitialized();
-        CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
-        EnsureFunctionAvailable((void*)functionList->C_SignMessageBegin, "C_SignMessageBegin");
-
-        CK_RV result;
-        if (parameter.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(SignMessageBegin), "C_SignMessageBegin", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
         {
-            result = functionList->C_SignMessageBegin(sessionHandle, null, 0);
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
         }
-        else
+
+        try
         {
-            fixed (byte* parameterPointer = parameter)
+            EnsureInitialized();
+            CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
+            EnsureFunctionAvailable((void*)functionList->C_SignMessageBegin, "C_SignMessageBegin");
+
+            CK_RV result;
+            if (parameter.IsEmpty)
             {
-                result = functionList->C_SignMessageBegin(sessionHandle, parameterPointer, (CK_ULONG)(nuint)parameter.Length);
+                result = functionList->C_SignMessageBegin(sessionHandle, null, 0);
             }
-        }
+            else
+            {
+                fixed (byte* parameterPointer = parameter)
+                {
+                    result = functionList->C_SignMessageBegin(sessionHandle, parameterPointer, (CK_ULONG)(nuint)parameter.Length);
+                }
+            }
 
-        ThrowIfFailed(result, "C_SignMessageBegin");
+            ThrowIfFailed(result, "C_SignMessageBegin");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool TrySignMessageNext(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, Span<byte> signature, out int written)
@@ -2504,24 +2662,39 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
 
     public void VerifyMessageBegin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter)
     {
-        EnsureInitialized();
-        CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
-        EnsureFunctionAvailable((void*)functionList->C_VerifyMessageBegin, "C_VerifyMessageBegin");
-
-        CK_RV result;
-        if (parameter.IsEmpty)
+        Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(nameof(VerifyMessageBegin), "C_VerifyMessageBegin", sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
         {
-            result = functionList->C_VerifyMessageBegin(sessionHandle, null, 0);
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
         }
-        else
+
+        try
         {
-            fixed (byte* parameterPointer = parameter)
+            EnsureInitialized();
+            CK_FUNCTION_LIST_3_0* functionList = GetFunctionList30();
+            EnsureFunctionAvailable((void*)functionList->C_VerifyMessageBegin, "C_VerifyMessageBegin");
+
+            CK_RV result;
+            if (parameter.IsEmpty)
             {
-                result = functionList->C_VerifyMessageBegin(sessionHandle, parameterPointer, (CK_ULONG)(nuint)parameter.Length);
+                result = functionList->C_VerifyMessageBegin(sessionHandle, null, 0);
             }
-        }
+            else
+            {
+                fixed (byte* parameterPointer = parameter)
+                {
+                    result = functionList->C_VerifyMessageBegin(sessionHandle, parameterPointer, (CK_ULONG)(nuint)parameter.Length);
+                }
+            }
 
-        ThrowIfFailed(result, "C_VerifyMessageBegin");
+            ThrowIfFailed(result, "C_VerifyMessageBegin");
+            telemetry.Succeeded(result);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Failed(ex);
+            throw;
+        }
     }
 
     public bool VerifyMessageNext(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature)
@@ -2586,6 +2759,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string operation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2616,12 +2794,20 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.associatedData", associatedData));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.input", input));
+        }
+
         try
         {
             EnsureInitialized();
             EnsureFunctionAvailable((void*)invoke, operation);
             CK_ULONG outputLength = default;
             CK_RV result = InvokeMessage(sessionHandle, parameter, associatedData, input, null, &outputLength, invoke, operation);
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.output", ToInt32Checked(outputLength, outputName)));
             telemetry.Succeeded(result);
             return ToInt32Checked(outputLength, outputName);
         }
@@ -2644,6 +2830,14 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.associatedData", associatedData));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.input", input));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.outputDestination", output.Length));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2656,11 +2850,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 if (result == Pkcs11ReturnValues.BufferTooSmall)
                 {
                     written = ToInt32Checked(outputLength, outputName);
+                    telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.output", written));
                     telemetry.ReturnedFalse(result);
                     return false;
                 }
 
                 ThrowIfFailed(result, operation);
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.output", ToInt32Checked(outputLength, outputName)));
                 telemetry.Succeeded(result);
             }
 
@@ -2677,6 +2873,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     private void MessageBegin(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> associatedData, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, CK_RV> begin, string operation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.associatedData", associatedData));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2705,6 +2907,14 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     private bool TryMessageNext(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> input, Span<byte> output, CK_FLAGS flags, out int written, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG*, CK_FLAGS, CK_RV> next, string operation, string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.input", input));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.outputDestination", output.Length));
+            telemetry.AddField(Pkcs11TelemetryRedaction.SafeHex("message.flags", flags.Value));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2728,11 +2938,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 if (result == Pkcs11ReturnValues.BufferTooSmall)
                 {
                     written = ToInt32Checked(outputLength, outputName);
+                    telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.output", written));
                     telemetry.ReturnedFalse(result);
                     return false;
                 }
 
                 ThrowIfFailed(result, operation);
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.output", ToInt32Checked(outputLength, outputName)));
                 telemetry.Succeeded(result);
             }
 
@@ -2767,12 +2979,19 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     private int GetSignMessageOutputLengthCore(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG*, CK_RV> invoke, string operation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+        }
+
         try
         {
             EnsureInitialized();
             EnsureFunctionAvailable((void*)invoke, operation);
             CK_ULONG signatureLength = default;
             CK_RV result = InvokeSignMessage(sessionHandle, parameter, data, null, &signatureLength, invoke, operation);
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature", ToInt32Checked(signatureLength, "signature length")));
             telemetry.Succeeded(result);
             return ToInt32Checked(signatureLength, "signature length");
         }
@@ -2786,6 +3005,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     private bool TrySignMessageCore(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, Span<byte> signature, out int written, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG*, CK_RV> invoke, string operation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature.destination", signature.Length));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2798,11 +3024,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 if (result == Pkcs11ReturnValues.BufferTooSmall)
                 {
                     written = ToInt32Checked(signatureLength, "signature length");
+                    telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature", written));
                     telemetry.ReturnedFalse(result);
                     return false;
                 }
 
                 ThrowIfFailed(result, operation);
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature", ToInt32Checked(signatureLength, "signature length")));
                 telemetry.Succeeded(result);
             }
 
@@ -2819,6 +3047,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
     private bool VerifyMessageCore(CK_SESSION_HANDLE sessionHandle, ReadOnlySpan<byte> parameter, ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, delegate* unmanaged[Cdecl]<CK_SESSION_HANDLE, void*, CK_ULONG, byte*, CK_ULONG, byte*, CK_ULONG, CK_RV> verify, string operation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(operation, operation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("message.parameter", parameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("data", data));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("signature", signature));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2971,6 +3206,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("input", input));
+        }
+
         try
         {
             EnsureInitialized();
@@ -2986,6 +3227,7 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
             }
 
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output", ToInt32Checked(outputLength, outputName)));
             telemetry.Succeeded(CK_RV.Ok);
             return ToInt32Checked(outputLength, outputName);
         }
@@ -3008,6 +3250,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("input", input));
+        }
+
         try
         {
             EnsureInitialized();
@@ -3023,6 +3271,7 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
             }
 
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output", ToInt32Checked(outputLength, outputName)));
             telemetry.Succeeded(CK_RV.Ok);
             return ToInt32Checked(outputLength, outputName);
         }
@@ -3048,6 +3297,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("input", input));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output.destination", output.Length));
+        }
+
         try
         {
             EnsureInitialized();
@@ -3071,12 +3327,14 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 {
                     written = ToInt32Checked(outputLength, outputName);
                     DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+                    telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output", written));
                     telemetry.ReturnedFalse(result);
                     return false;
                 }
 
                 ThrowIfFailed(result, invokeOperation);
                 written = ToInt32Checked(outputLength, outputName);
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output", written));
                 telemetry.Succeeded(result);
                 return true;
             }
@@ -3102,6 +3360,13 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("input", input));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output.destination", output.Length));
+        }
+
         try
         {
             EnsureInitialized();
@@ -3125,12 +3390,14 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
                 {
                     written = ToInt32Checked(outputLength, outputName);
                     DrainActiveCryptOperation(sessionHandle, input, outputLength, invoke, invokeOperation, outputName);
+                    telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output", written));
                     telemetry.ReturnedFalse(result);
                     return false;
                 }
 
                 ThrowIfFailed(result, invokeOperation);
                 written = ToInt32Checked(outputLength, outputName);
+                telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output", written));
                 telemetry.Succeeded(result);
                 return true;
             }
@@ -3332,6 +3599,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string initOperation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(initOperation, initOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+        }
+
         try
         {
             EnsureInitialized();
@@ -3364,6 +3636,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string initOperation)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(initOperation, initOperation, sessionHandle: sessionHandle, mechanismType: mechanismType);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddFields(Pkcs11TelemetryRedaction.MechanismParameters(mechanismType, mechanismParameter));
+        }
+
         try
         {
             EnsureInitialized();
@@ -3428,6 +3705,12 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(updateOperation, updateOperation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("input", input));
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output.destination", output.Length));
+        }
+
         try
         {
             EnsureUpdateFunction(update, updateOperation);
@@ -3479,6 +3762,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(finalOperation, finalOperation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("output.destination", output.Length));
+        }
+
         try
         {
             EnsureFinalFunction(final, finalOperation);
@@ -3525,6 +3813,11 @@ public sealed unsafe class Pkcs11NativeModule : IDisposable
         string outputName)
     {
         Pkcs11OperationTelemetryScope telemetry = BeginTelemetry(invokeOperation, invokeOperation, sessionHandle: sessionHandle);
+        if (telemetry.IsEnabled)
+        {
+            telemetry.AddField(Pkcs11TelemetryRedaction.LengthOnly("input", input));
+        }
+
         try
         {
             EnsureUpdateFunction(invoke, invokeOperation);

--- a/src/Pkcs11Wrapper.Native/Pkcs11OperationTelemetry.cs
+++ b/src/Pkcs11Wrapper.Native/Pkcs11OperationTelemetry.cs
@@ -10,6 +10,20 @@ public enum Pkcs11OperationTelemetryStatus
     Failed = 2,
 }
 
+public enum Pkcs11TelemetryFieldClassification
+{
+    SafeMetadata = 0,
+    LengthOnly = 1,
+    Masked = 2,
+    Hashed = 3,
+    NeverLog = 4,
+}
+
+public readonly record struct Pkcs11OperationTelemetryField(
+    string Name,
+    Pkcs11TelemetryFieldClassification Classification,
+    string? Value);
+
 public readonly record struct Pkcs11OperationTelemetryEvent(
     string OperationName,
     string? NativeOperationName,
@@ -21,6 +35,8 @@ public readonly record struct Pkcs11OperationTelemetryEvent(
     nuint? MechanismType,
     Exception? Exception)
 {
+    public IReadOnlyList<Pkcs11OperationTelemetryField> Fields { get; init; } = Array.Empty<Pkcs11OperationTelemetryField>();
+
     public bool IsSuccess => Status == Pkcs11OperationTelemetryStatus.Succeeded;
 }
 
@@ -29,7 +45,7 @@ public interface IPkcs11OperationTelemetryListener
     void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent);
 }
 
-internal readonly ref struct Pkcs11OperationTelemetryScope
+internal ref struct Pkcs11OperationTelemetryScope
 {
     private readonly IPkcs11OperationTelemetryListener? _listener;
     private readonly string _operationName;
@@ -38,6 +54,7 @@ internal readonly ref struct Pkcs11OperationTelemetryScope
     private readonly nuint? _sessionHandle;
     private readonly nuint? _mechanismType;
     private readonly long _startTimestamp;
+    private List<Pkcs11OperationTelemetryField>? _fields;
 
     public Pkcs11OperationTelemetryScope(
         IPkcs11OperationTelemetryListener? listener,
@@ -54,6 +71,30 @@ internal readonly ref struct Pkcs11OperationTelemetryScope
         _sessionHandle = sessionHandle?.Value;
         _mechanismType = mechanismType?.Value;
         _startTimestamp = listener is null ? 0 : Stopwatch.GetTimestamp();
+        _fields = null;
+    }
+
+    public bool IsEnabled => _listener is not null;
+
+    public void AddField(Pkcs11OperationTelemetryField field)
+    {
+        if (_listener is null)
+        {
+            return;
+        }
+
+        (_fields ??= []).Add(field);
+    }
+
+    public void AddFields(IEnumerable<Pkcs11OperationTelemetryField> fields)
+    {
+        if (_listener is null)
+        {
+            return;
+        }
+
+        _fields ??= [];
+        _fields.AddRange(fields);
     }
 
     public void Succeeded(CK_RV returnValue)
@@ -84,7 +125,12 @@ internal readonly ref struct Pkcs11OperationTelemetryScope
             _slotId,
             _sessionHandle,
             _mechanismType,
-            exception);
+            exception)
+        {
+            Fields = _fields is { Count: > 0 }
+                ? _fields.ToArray()
+                : Array.Empty<Pkcs11OperationTelemetryField>()
+        };
 
         try
         {

--- a/src/Pkcs11Wrapper.Native/Pkcs11TelemetryRedaction.cs
+++ b/src/Pkcs11Wrapper.Native/Pkcs11TelemetryRedaction.cs
@@ -1,0 +1,430 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Pkcs11Wrapper.Native.Interop;
+
+namespace Pkcs11Wrapper.Native;
+
+internal static unsafe class Pkcs11TelemetryRedaction
+{
+    private const nuint CkaClass = 0x00000000u;
+    private const nuint CkaToken = 0x00000001u;
+    private const nuint CkaPrivate = 0x00000002u;
+    private const nuint CkaLabel = 0x00000003u;
+    private const nuint CkaApplication = 0x00000010u;
+    private const nuint CkaValue = 0x00000011u;
+    private const nuint CkaObjectId = 0x00000012u;
+    private const nuint CkaCertificateType = 0x00000080u;
+    private const nuint CkaKeyType = 0x00000100u;
+    private const nuint CkaId = 0x00000102u;
+    private const nuint CkaSensitive = 0x00000103u;
+    private const nuint CkaEncrypt = 0x00000104u;
+    private const nuint CkaDecrypt = 0x00000105u;
+    private const nuint CkaWrap = 0x00000106u;
+    private const nuint CkaUnwrap = 0x00000107u;
+    private const nuint CkaSign = 0x00000108u;
+    private const nuint CkaVerify = 0x0000010au;
+    private const nuint CkaDerive = 0x0000010cu;
+    private const nuint CkaModulus = 0x00000120u;
+    private const nuint CkaModulusBits = 0x00000121u;
+    private const nuint CkaPublicExponent = 0x00000122u;
+    private const nuint CkaPrivateExponent = 0x00000123u;
+    private const nuint CkaPrime1 = 0x00000124u;
+    private const nuint CkaPrime2 = 0x00000125u;
+    private const nuint CkaExponent1 = 0x00000126u;
+    private const nuint CkaExponent2 = 0x00000127u;
+    private const nuint CkaCoefficient = 0x00000128u;
+    private const nuint CkaPrime = 0x00000130u;
+    private const nuint CkaSubprime = 0x00000131u;
+    private const nuint CkaBase = 0x00000132u;
+    private const nuint CkaValueBits = 0x00000160u;
+    private const nuint CkaValueLen = 0x00000161u;
+    private const nuint CkaExtractable = 0x00000162u;
+    private const nuint CkaModifiable = 0x00000170u;
+    private const nuint CkaEcParams = 0x00000180u;
+    private const nuint CkaEcPoint = 0x00000181u;
+
+    private const nuint CkmEcdh1Derive = 0x00001050u;
+    private const nuint CkmAesCtr = 0x00001086u;
+    private const nuint CkmAesGcm = 0x00001087u;
+    private const nuint CkmAesCcm = 0x00001088u;
+    private const nuint CkmRsaPkcsOaep = 0x00000009u;
+    private const nuint CkmRsaPkcsPss = 0x0000000du;
+    private const nuint CkmSha1RsaPkcsPss = 0x0000000eu;
+    private const nuint CkmSha224RsaPkcsPss = 0x00000047u;
+    private const nuint CkmSha256RsaPkcsPss = 0x00000043u;
+    private const nuint CkmSha384RsaPkcsPss = 0x00000044u;
+    private const nuint CkmSha512RsaPkcsPss = 0x00000045u;
+
+    internal static Pkcs11OperationTelemetryField Safe(string name, string value)
+        => new(name, Pkcs11TelemetryFieldClassification.SafeMetadata, value);
+
+    internal static Pkcs11OperationTelemetryField Safe(string name, bool value)
+        => Safe(name, value ? "true" : "false");
+
+    internal static Pkcs11OperationTelemetryField Safe(string name, int value)
+        => Safe(name, value.ToString());
+
+    internal static Pkcs11OperationTelemetryField Safe(string name, nuint value)
+        => Safe(name, value.ToString());
+
+    internal static Pkcs11OperationTelemetryField SafeHex(string name, nuint value)
+        => Safe(name, $"0x{value:x}");
+
+    internal static Pkcs11OperationTelemetryField LengthOnly(string name, ReadOnlySpan<byte> value)
+        => LengthOnly(name, value.Length);
+
+    internal static Pkcs11OperationTelemetryField LengthOnly(string name, int length)
+        => new(name, Pkcs11TelemetryFieldClassification.LengthOnly, $"len={length}");
+
+    internal static Pkcs11OperationTelemetryField MaskedSecret(string name, ReadOnlySpan<byte> value)
+        => new(
+            name,
+            Pkcs11TelemetryFieldClassification.Masked,
+            value.IsEmpty ? "empty" : $"set(len={value.Length})");
+
+    internal static Pkcs11OperationTelemetryField HashedBytes(string name, ReadOnlySpan<byte> value)
+        => new(
+            name,
+            Pkcs11TelemetryFieldClassification.Hashed,
+            $"sha256:{Convert.ToHexString(SHA256.HashData(value))[..24]} len={value.Length}");
+
+    internal static Pkcs11OperationTelemetryField NeverLog(string name, int? length = null)
+        => new(
+            name,
+            Pkcs11TelemetryFieldClassification.NeverLog,
+            length.HasValue ? $"suppressed(len={length.Value})" : "suppressed");
+
+    internal static Pkcs11OperationTelemetryField[] Credentials(CK_USER_TYPE userType, ReadOnlySpan<byte> pinUtf8)
+        =>
+        [
+            Safe("credential.userType", FormatUserType(userType.Value)),
+            MaskedSecret("credential.pin", pinUtf8),
+        ];
+
+    internal static Pkcs11OperationTelemetryField[] Credentials(CK_USER_TYPE userType, ReadOnlySpan<byte> pinUtf8, ReadOnlySpan<byte> usernameUtf8)
+    {
+        List<Pkcs11OperationTelemetryField> fields =
+        [
+            Safe("credential.userType", FormatUserType(userType.Value)),
+            MaskedSecret("credential.pin", pinUtf8),
+        ];
+
+        fields.Add(usernameUtf8.IsEmpty
+            ? MaskedSecret("credential.username", usernameUtf8)
+            : HashedBytes("credential.username", usernameUtf8));
+
+        return fields.ToArray();
+    }
+
+    internal static Pkcs11OperationTelemetryField[] InitToken(ReadOnlySpan<byte> pinUtf8, ReadOnlySpan<byte> labelUtf8)
+        =>
+        [
+            MaskedSecret("token.soPin", pinUtf8),
+            labelUtf8.IsEmpty
+                ? MaskedSecret("token.label", labelUtf8)
+                : HashedBytes("token.label", labelUtf8),
+        ];
+
+    internal static Pkcs11OperationTelemetryField[] PinChange(ReadOnlySpan<byte> oldPinUtf8, ReadOnlySpan<byte> newPinUtf8)
+        =>
+        [
+            MaskedSecret("credential.oldPin", oldPinUtf8),
+            MaskedSecret("credential.newPin", newPinUtf8),
+        ];
+
+    internal static Pkcs11OperationTelemetryField[] AttributeType(string name, CK_ATTRIBUTE_TYPE attributeType)
+        => [Safe(name, GetAttributeName(attributeType.Value))];
+
+    internal static Pkcs11OperationTelemetryField[] Template(string prefix, ReadOnlySpan<CK_ATTRIBUTE> template)
+    {
+        List<Pkcs11OperationTelemetryField> fields = [Safe($"{prefix}.count", template.Length)];
+        Dictionary<string, int> nameCounts = new(StringComparer.Ordinal);
+
+        for (int i = 0; i < template.Length; i++)
+        {
+            ref readonly CK_ATTRIBUTE attribute = ref template[i];
+            string attributeName = GetAttributeName(attribute.Type.Value);
+            string uniqueName = BuildUniqueFieldName(prefix, attributeName, nameCounts);
+            nuint rawLength = attribute.ValueLength.Value;
+            int? length = TryToInt32(rawLength);
+            bool canRead = attribute.Value is not null && length.HasValue;
+            ReadOnlySpan<byte> value = canRead ? new ReadOnlySpan<byte>(attribute.Value, length!.Value) : default;
+
+            switch (ClassifyAttribute(attribute.Type.Value))
+            {
+                case AttributeClassification.SafeBoolean when canRead && value.Length > 0:
+                    fields.Add(Safe(uniqueName, value[0] != 0));
+                    break;
+                case AttributeClassification.SafeNuint when canRead && value.Length >= IntPtr.Size:
+                    fields.Add(Safe(uniqueName, ReadPackedNuint(value)));
+                    break;
+                case AttributeClassification.SafeObjectClass when canRead && value.Length >= IntPtr.Size:
+                    fields.Add(Safe(uniqueName, FormatObjectClass(ReadPackedNuint(value))));
+                    break;
+                case AttributeClassification.SafeKeyType when canRead && value.Length >= IntPtr.Size:
+                    fields.Add(Safe(uniqueName, FormatKeyType(ReadPackedNuint(value))));
+                    break;
+                case AttributeClassification.HashedBytes when canRead:
+                    fields.Add(HashedBytes(uniqueName, value));
+                    break;
+                case AttributeClassification.NeverLog:
+                    fields.Add(NeverLog(uniqueName, length));
+                    break;
+                default:
+                    fields.Add(length.HasValue ? LengthOnly(uniqueName, length.Value) : NeverLog(uniqueName));
+                    break;
+            }
+        }
+
+        return fields.ToArray();
+    }
+
+    internal static Pkcs11OperationTelemetryField[] MechanismParameters(CK_MECHANISM_TYPE mechanismType, ReadOnlySpan<byte> mechanismParameter)
+    {
+        List<Pkcs11OperationTelemetryField> fields = [LengthOnly("mechanism.parameter", mechanismParameter)];
+
+        try
+        {
+            switch (mechanismType.Value)
+            {
+                case CkmAesCtr:
+                    if (mechanismParameter.Length >= IntPtr.Size + 16)
+                    {
+                        fields.Add(Safe("mechanism.counterBits", ReadPackedNuint(mechanismParameter)));
+                        fields.Add(LengthOnly("mechanism.counterBlock", 16));
+                    }
+
+                    break;
+                case CkmAesGcm:
+                    if (mechanismParameter.Length >= IntPtr.Size * 4)
+                    {
+                        nuint ivLength = ReadPackedNuint(mechanismParameter);
+                        nuint ivBits = ReadPackedNuint(mechanismParameter[IntPtr.Size..]);
+                        nuint aadLength = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 2)..]);
+                        nuint tagBits = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 3)..]);
+
+                        fields.Add(Safe("mechanism.ivBits", ivBits));
+                        fields.Add(Safe("mechanism.tagBits", tagBits));
+
+                        if (TryToInt32(ivLength) is int ivLengthValue)
+                        {
+                            fields.Add(LengthOnly("mechanism.iv", ivLengthValue));
+                        }
+
+                        if (TryToInt32(aadLength) is int aadLengthValue)
+                        {
+                            fields.Add(LengthOnly("mechanism.aad", aadLengthValue));
+                        }
+                    }
+
+                    break;
+                case CkmAesCcm:
+                    if (mechanismParameter.Length >= IntPtr.Size * 4)
+                    {
+                        nuint dataLength = ReadPackedNuint(mechanismParameter);
+                        nuint nonceLength = ReadPackedNuint(mechanismParameter[IntPtr.Size..]);
+                        nuint aadLength = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 2)..]);
+                        nuint macLength = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 3)..]);
+
+                        fields.Add(Safe("mechanism.dataLength", dataLength));
+                        fields.Add(Safe("mechanism.macLength", macLength));
+
+                        if (TryToInt32(nonceLength) is int nonceLengthValue)
+                        {
+                            fields.Add(LengthOnly("mechanism.nonce", nonceLengthValue));
+                        }
+
+                        if (TryToInt32(aadLength) is int aadLengthValue)
+                        {
+                            fields.Add(LengthOnly("mechanism.aad", aadLengthValue));
+                        }
+                    }
+
+                    break;
+                case CkmRsaPkcsOaep:
+                    if (mechanismParameter.Length >= IntPtr.Size * 4)
+                    {
+                        nuint hashAlg = ReadPackedNuint(mechanismParameter);
+                        nuint mgf = ReadPackedNuint(mechanismParameter[IntPtr.Size..]);
+                        nuint source = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 2)..]);
+                        nuint sourceDataLength = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 3)..]);
+
+                        fields.Add(SafeHex("mechanism.hashAlg", hashAlg));
+                        fields.Add(SafeHex("mechanism.mgf", mgf));
+                        fields.Add(SafeHex("mechanism.source", source));
+
+                        if (TryToInt32(sourceDataLength) is int sourceDataLengthValue
+                            && mechanismParameter.Length >= (IntPtr.Size * 4) + sourceDataLengthValue)
+                        {
+                            fields.Add(HashedBytes("mechanism.sourceData", mechanismParameter[(IntPtr.Size * 4)..(IntPtr.Size * 4 + sourceDataLengthValue)]));
+                        }
+                    }
+
+                    break;
+                case CkmRsaPkcsPss:
+                case CkmSha1RsaPkcsPss:
+                case CkmSha224RsaPkcsPss:
+                case CkmSha256RsaPkcsPss:
+                case CkmSha384RsaPkcsPss:
+                case CkmSha512RsaPkcsPss:
+                    if (mechanismParameter.Length >= IntPtr.Size * 3)
+                    {
+                        fields.Add(SafeHex("mechanism.hashAlg", ReadPackedNuint(mechanismParameter)));
+                        fields.Add(SafeHex("mechanism.mgf", ReadPackedNuint(mechanismParameter[IntPtr.Size..])));
+                        fields.Add(Safe("mechanism.saltLength", ReadPackedNuint(mechanismParameter[(IntPtr.Size * 2)..])));
+                    }
+
+                    break;
+                case CkmEcdh1Derive:
+                    if (mechanismParameter.Length >= IntPtr.Size * 3)
+                    {
+                        nuint kdf = ReadPackedNuint(mechanismParameter);
+                        nuint sharedDataLength = ReadPackedNuint(mechanismParameter[IntPtr.Size..]);
+                        nuint publicDataLength = ReadPackedNuint(mechanismParameter[(IntPtr.Size * 2)..]);
+                        int headerLength = IntPtr.Size * 3;
+
+                        fields.Add(SafeHex("mechanism.kdf", kdf));
+
+                        if (TryToInt32(sharedDataLength) is int sharedDataLengthValue)
+                        {
+                            fields.Add(LengthOnly("mechanism.sharedData", sharedDataLengthValue));
+                        }
+
+                        if (TryToInt32(sharedDataLength + publicDataLength) is int payloadLength
+                            && mechanismParameter.Length >= headerLength + payloadLength
+                            && TryToInt32(sharedDataLength) is int sharedLength
+                            && TryToInt32(publicDataLength) is int publicLength)
+                        {
+                            fields.Add(HashedBytes("mechanism.publicData", mechanismParameter[(headerLength + sharedLength)..(headerLength + sharedLength + publicLength)]));
+                        }
+                    }
+
+                    break;
+            }
+        }
+        catch
+        {
+        }
+
+        return fields.ToArray();
+    }
+
+    private static string BuildUniqueFieldName(string prefix, string attributeName, Dictionary<string, int> nameCounts)
+    {
+        if (!nameCounts.TryGetValue(attributeName, out int count))
+        {
+            nameCounts[attributeName] = 1;
+            return $"{prefix}.{attributeName}";
+        }
+
+        count++;
+        nameCounts[attributeName] = count;
+        return $"{prefix}.{attributeName}#{count}";
+    }
+
+    private static int? TryToInt32(nuint value)
+        => value > int.MaxValue ? null : (int)value;
+
+    private static nuint ReadPackedNuint(ReadOnlySpan<byte> bytes)
+        => MemoryMarshal.Read<nuint>(bytes[..IntPtr.Size]);
+
+    private static AttributeClassification ClassifyAttribute(nuint attributeType)
+        => attributeType switch
+        {
+            CkaClass => AttributeClassification.SafeObjectClass,
+            CkaToken or CkaPrivate or CkaSensitive or CkaEncrypt or CkaDecrypt or CkaWrap or CkaUnwrap or CkaSign or CkaVerify or CkaDerive or CkaExtractable or CkaModifiable
+                => AttributeClassification.SafeBoolean,
+            CkaKeyType => AttributeClassification.SafeKeyType,
+            CkaCertificateType or CkaModulusBits or CkaValueBits or CkaValueLen => AttributeClassification.SafeNuint,
+            CkaLabel or CkaApplication or CkaObjectId or CkaId or CkaEcParams or CkaEcPoint or CkaModulus or CkaPublicExponent
+                => AttributeClassification.HashedBytes,
+            CkaValue or CkaPrivateExponent or CkaPrime1 or CkaPrime2 or CkaExponent1 or CkaExponent2 or CkaCoefficient or CkaPrime or CkaSubprime or CkaBase
+                => AttributeClassification.NeverLog,
+            _ => AttributeClassification.LengthOnly,
+        };
+
+    private static string GetAttributeName(nuint attributeType)
+        => attributeType switch
+        {
+            CkaClass => "CKA_CLASS",
+            CkaToken => "CKA_TOKEN",
+            CkaPrivate => "CKA_PRIVATE",
+            CkaLabel => "CKA_LABEL",
+            CkaApplication => "CKA_APPLICATION",
+            CkaValue => "CKA_VALUE",
+            CkaObjectId => "CKA_OBJECT_ID",
+            CkaCertificateType => "CKA_CERTIFICATE_TYPE",
+            CkaKeyType => "CKA_KEY_TYPE",
+            CkaId => "CKA_ID",
+            CkaSensitive => "CKA_SENSITIVE",
+            CkaEncrypt => "CKA_ENCRYPT",
+            CkaDecrypt => "CKA_DECRYPT",
+            CkaWrap => "CKA_WRAP",
+            CkaUnwrap => "CKA_UNWRAP",
+            CkaSign => "CKA_SIGN",
+            CkaVerify => "CKA_VERIFY",
+            CkaDerive => "CKA_DERIVE",
+            CkaModulus => "CKA_MODULUS",
+            CkaModulusBits => "CKA_MODULUS_BITS",
+            CkaPublicExponent => "CKA_PUBLIC_EXPONENT",
+            CkaPrivateExponent => "CKA_PRIVATE_EXPONENT",
+            CkaPrime1 => "CKA_PRIME_1",
+            CkaPrime2 => "CKA_PRIME_2",
+            CkaExponent1 => "CKA_EXPONENT_1",
+            CkaExponent2 => "CKA_EXPONENT_2",
+            CkaCoefficient => "CKA_COEFFICIENT",
+            CkaPrime => "CKA_PRIME",
+            CkaSubprime => "CKA_SUBPRIME",
+            CkaBase => "CKA_BASE",
+            CkaValueBits => "CKA_VALUE_BITS",
+            CkaValueLen => "CKA_VALUE_LEN",
+            CkaExtractable => "CKA_EXTRACTABLE",
+            CkaModifiable => "CKA_MODIFIABLE",
+            CkaEcParams => "CKA_EC_PARAMS",
+            CkaEcPoint => "CKA_EC_POINT",
+            _ => $"0x{attributeType:x}",
+        };
+
+    private static string FormatUserType(nuint userType)
+        => userType switch
+        {
+            0u => "CKU_SO",
+            1u => "CKU_USER",
+            2u => "CKU_CONTEXT_SPECIFIC",
+            _ => $"0x{userType:x}",
+        };
+
+    private static string FormatObjectClass(nuint objectClass)
+        => objectClass switch
+        {
+            0u => "CKO_DATA",
+            1u => "CKO_CERTIFICATE",
+            2u => "CKO_PUBLIC_KEY",
+            3u => "CKO_PRIVATE_KEY",
+            4u => "CKO_SECRET_KEY",
+            _ => $"0x{objectClass:x}",
+        };
+
+    private static string FormatKeyType(nuint keyType)
+        => keyType switch
+        {
+            0u => "CKK_RSA",
+            1u => "CKK_DSA",
+            2u => "CKK_DH",
+            3u => "CKK_EC",
+            0x10u => "CKK_GENERIC_SECRET",
+            0x1fu => "CKK_AES",
+            _ => $"0x{keyType:x}",
+        };
+
+    private enum AttributeClassification
+    {
+        SafeBoolean,
+        SafeNuint,
+        SafeObjectClass,
+        SafeKeyType,
+        HashedBytes,
+        LengthOnly,
+        NeverLog,
+    }
+}

--- a/src/Pkcs11Wrapper.Native/Properties/AssemblyInfo.cs
+++ b/src/Pkcs11Wrapper.Native/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Pkcs11Wrapper.Native.Tests")]

--- a/tests/Pkcs11Wrapper.Native.Tests/ManagedApiSurfaceTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/ManagedApiSurfaceTests.cs
@@ -34,6 +34,11 @@ public sealed class ManagedApiSurfaceTests
         Assert.NotNull(typeof(Pkcs11NativeModule).GetProperty(nameof(Pkcs11NativeModule.TelemetryListener)));
         Assert.NotNull(typeof(IPkcs11OperationTelemetryListener).GetMethod(nameof(IPkcs11OperationTelemetryListener.OnOperationCompleted)));
 
+        Pkcs11OperationTelemetryField field = new(
+            Name: "credential.pin",
+            Classification: Pkcs11TelemetryFieldClassification.Masked,
+            Value: "set(len=4)");
+
         Pkcs11OperationTelemetryEvent operationEvent = new(
             OperationName: "TestOperation",
             NativeOperationName: "C_TestOperation",
@@ -43,7 +48,10 @@ public sealed class ManagedApiSurfaceTests
             SlotId: 7,
             SessionHandle: 11,
             MechanismType: 13,
-            Exception: null);
+            Exception: null)
+        {
+            Fields = [field]
+        };
 
         Assert.True(operationEvent.IsSuccess);
         Assert.Equal("TestOperation", operationEvent.OperationName);
@@ -51,6 +59,9 @@ public sealed class ManagedApiSurfaceTests
         Assert.Equal((nuint)7, operationEvent.SlotId);
         Assert.Equal((nuint)11, operationEvent.SessionHandle);
         Assert.Equal((nuint)13, operationEvent.MechanismType);
+        Assert.Single(operationEvent.Fields);
+        Assert.Equal(Pkcs11TelemetryFieldClassification.Masked, operationEvent.Fields[0].Classification);
+        Assert.Equal("credential.pin", operationEvent.Fields[0].Name);
     }
 
     [Fact]

--- a/tests/Pkcs11Wrapper.Native.Tests/TelemetryRedactionPolicyTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/TelemetryRedactionPolicyTests.cs
@@ -1,0 +1,118 @@
+using System.Text;
+using Pkcs11Wrapper;
+using Pkcs11Wrapper.Native;
+using Pkcs11Wrapper.Native.Interop;
+
+namespace Pkcs11Wrapper.Native.Tests;
+
+public sealed class TelemetryRedactionPolicyTests
+{
+    [Fact]
+    public unsafe void TemplateSummaryClassifiesSafeHashedAndNeverLogAttributes()
+    {
+        byte[] classValue = PackNuint(Pkcs11ObjectClasses.SecretKey.Value);
+        byte[] keyTypeValue = PackNuint(Pkcs11KeyTypes.Aes.Value);
+        byte[] valueLen = PackNuint(32);
+        byte[] token = [1];
+        byte[] label = Encoding.UTF8.GetBytes("prod-aes-key");
+        byte[] id = [0xA1, 0xB2];
+        byte[] secretValue = [0x11, 0x22, 0x33, 0x44];
+
+        fixed (byte* classPtr = classValue)
+        fixed (byte* keyTypePtr = keyTypeValue)
+        fixed (byte* valueLenPtr = valueLen)
+        fixed (byte* tokenPtr = token)
+        fixed (byte* labelPtr = label)
+        fixed (byte* idPtr = id)
+        fixed (byte* secretValuePtr = secretValue)
+        {
+            CK_ATTRIBUTE[] template =
+            [
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.Class.Value), Value = classPtr, ValueLength = (CK_ULONG)(nuint)classValue.Length },
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.KeyType.Value), Value = keyTypePtr, ValueLength = (CK_ULONG)(nuint)keyTypeValue.Length },
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.ValueLen.Value), Value = valueLenPtr, ValueLength = (CK_ULONG)(nuint)valueLen.Length },
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.Token.Value), Value = tokenPtr, ValueLength = (CK_ULONG)(nuint)token.Length },
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.Label.Value), Value = labelPtr, ValueLength = (CK_ULONG)(nuint)label.Length },
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.Id.Value), Value = idPtr, ValueLength = (CK_ULONG)(nuint)id.Length },
+                new() { Type = new CK_ATTRIBUTE_TYPE(Pkcs11AttributeTypes.Value.Value), Value = secretValuePtr, ValueLength = (CK_ULONG)(nuint)secretValue.Length },
+            ];
+
+            Pkcs11OperationTelemetryField[] fields = Pkcs11TelemetryRedaction.Template("template", template);
+
+            Assert.Contains(fields, f => f.Name == "template.count" && f.Classification == Pkcs11TelemetryFieldClassification.SafeMetadata && f.Value == "7");
+            Assert.Contains(fields, f => f.Name == "template.CKA_CLASS" && f.Value == "CKO_SECRET_KEY");
+            Assert.Contains(fields, f => f.Name == "template.CKA_KEY_TYPE" && f.Value == "CKK_AES");
+            Assert.Contains(fields, f => f.Name == "template.CKA_VALUE_LEN" && f.Value == "32");
+            Assert.Contains(fields, f => f.Name == "template.CKA_TOKEN" && f.Value == "true");
+
+            Pkcs11OperationTelemetryField labelField = Assert.Single(fields, f => f.Name == "template.CKA_LABEL");
+            Assert.Equal(Pkcs11TelemetryFieldClassification.Hashed, labelField.Classification);
+            Assert.Contains("sha256:", labelField.Value, StringComparison.Ordinal);
+            Assert.DoesNotContain("prod-aes-key", labelField.Value, StringComparison.Ordinal);
+
+            Pkcs11OperationTelemetryField idField = Assert.Single(fields, f => f.Name == "template.CKA_ID");
+            Assert.Equal(Pkcs11TelemetryFieldClassification.Hashed, idField.Classification);
+            Assert.DoesNotContain("A1", idField.Value, StringComparison.OrdinalIgnoreCase);
+
+            Pkcs11OperationTelemetryField secretField = Assert.Single(fields, f => f.Name == "template.CKA_VALUE");
+            Assert.Equal(Pkcs11TelemetryFieldClassification.NeverLog, secretField.Classification);
+            Assert.Equal("suppressed(len=4)", secretField.Value);
+        }
+    }
+
+    [Fact]
+    public void MechanismSummaryKeepsScalarsAndRedactsBytePayloads()
+    {
+        byte[] gcm = Pkcs11MechanismParameters.AesGcm([0x01, 0x02, 0x03, 0x04], [0xAA, 0xBB], tagBits: 96);
+        byte[] oaep = Pkcs11MechanismParameters.RsaOaep(Pkcs11MechanismTypes.Sha256, Pkcs11RsaMgfTypes.Mgf1Sha256, [0x10, 0x20]);
+        byte[] ecdh = Pkcs11MechanismParameters.Ecdh1Derive(Pkcs11EcKdfTypes.Null, [0x04, 0xAA, 0xBB], [0x99, 0x88]);
+
+        Pkcs11OperationTelemetryField[] gcmFields = Pkcs11TelemetryRedaction.MechanismParameters(new CK_MECHANISM_TYPE(Pkcs11MechanismTypes.AesGcm.Value), gcm);
+        Assert.Contains(gcmFields, f => f.Name == "mechanism.ivBits" && f.Value == "32");
+        Assert.Contains(gcmFields, f => f.Name == "mechanism.tagBits" && f.Value == "96");
+        Assert.Contains(gcmFields, f => f.Name == "mechanism.iv" && f.Classification == Pkcs11TelemetryFieldClassification.LengthOnly && f.Value == "len=4");
+        Assert.Contains(gcmFields, f => f.Name == "mechanism.aad" && f.Classification == Pkcs11TelemetryFieldClassification.LengthOnly && f.Value == "len=2");
+
+        Pkcs11OperationTelemetryField[] oaepFields = Pkcs11TelemetryRedaction.MechanismParameters(new CK_MECHANISM_TYPE(Pkcs11MechanismTypes.RsaPkcsOaep.Value), oaep);
+        Assert.Contains(oaepFields, f => f.Name == "mechanism.hashAlg" && f.Value == $"0x{Pkcs11MechanismTypes.Sha256.Value:x}");
+        Assert.Contains(oaepFields, f => f.Name == "mechanism.mgf" && f.Value == $"0x{Pkcs11RsaMgfTypes.Mgf1Sha256.Value:x}");
+        Pkcs11OperationTelemetryField sourceDataField = Assert.Single(oaepFields, f => f.Name == "mechanism.sourceData");
+        Assert.Equal(Pkcs11TelemetryFieldClassification.Hashed, sourceDataField.Classification);
+        Assert.DoesNotContain("1020", sourceDataField.Value, StringComparison.OrdinalIgnoreCase);
+
+        Pkcs11OperationTelemetryField[] ecdhFields = Pkcs11TelemetryRedaction.MechanismParameters(new CK_MECHANISM_TYPE(Pkcs11MechanismTypes.Ecdh1Derive.Value), ecdh);
+        Assert.Contains(ecdhFields, f => f.Name == "mechanism.kdf" && f.Value == $"0x{Pkcs11EcKdfTypes.Null.Value:x}");
+        Assert.Contains(ecdhFields, f => f.Name == "mechanism.sharedData" && f.Classification == Pkcs11TelemetryFieldClassification.LengthOnly && f.Value == "len=2");
+        Pkcs11OperationTelemetryField publicDataField = Assert.Single(ecdhFields, f => f.Name == "mechanism.publicData");
+        Assert.Equal(Pkcs11TelemetryFieldClassification.Hashed, publicDataField.Classification);
+        Assert.DoesNotContain("04AABB", publicDataField.Value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CredentialHelpersUseMaskedAndHashedBuckets()
+    {
+        Pkcs11OperationTelemetryField[] loginFields = Pkcs11TelemetryRedaction.Credentials(new CK_USER_TYPE((nuint)Pkcs11UserType.User), "123456"u8);
+        Assert.Contains(loginFields, f => f.Name == "credential.userType" && f.Value == "CKU_USER");
+        Assert.Contains(loginFields, f => f.Name == "credential.pin" && f.Classification == Pkcs11TelemetryFieldClassification.Masked && f.Value == "set(len=6)");
+
+        Pkcs11OperationTelemetryField[] loginUserFields = Pkcs11TelemetryRedaction.Credentials(new CK_USER_TYPE((nuint)Pkcs11UserType.User), "123456"u8, "alice"u8);
+        Pkcs11OperationTelemetryField usernameField = Assert.Single(loginUserFields, f => f.Name == "credential.username");
+        Assert.Equal(Pkcs11TelemetryFieldClassification.Hashed, usernameField.Classification);
+        Assert.DoesNotContain("alice", usernameField.Value, StringComparison.Ordinal);
+    }
+
+    private static byte[] PackNuint(nuint value)
+    {
+        byte[] bytes = new byte[IntPtr.Size];
+        if (IntPtr.Size == 8)
+        {
+            BitConverter.GetBytes((ulong)value).CopyTo(bytes, 0);
+        }
+        else
+        {
+            BitConverter.GetBytes((uint)value).CopyTo(bytes, 0);
+        }
+
+        return bytes;
+    }
+}

--- a/tests/Pkcs11Wrapper.Native.Tests/TelemetryRegressionTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/TelemetryRegressionTests.cs
@@ -50,6 +50,21 @@ public sealed class TelemetryRegressionTests
         Assert.Contains(events, e => e.OperationName == "C_Digest" && e.NativeOperationName == "C_Digest" && e.SessionHandle.HasValue && e.MechanismType == Pkcs11MechanismTypes.Sha256.Value && e.Status == Pkcs11OperationTelemetryStatus.Succeeded && e.Duration >= TimeSpan.Zero);
         Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.GenerateRandom) && e.NativeOperationName == "C_GenerateRandom" && e.SessionHandle.HasValue && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
         Assert.Contains(events, e => e.OperationName == nameof(Pkcs11NativeModule.CloseSession) && e.NativeOperationName == "C_CloseSession" && e.SessionHandle.HasValue && e.Status == Pkcs11OperationTelemetryStatus.Succeeded);
+
+        Pkcs11OperationTelemetryEvent loginEvent = Assert.Single(events, e => e.OperationName == nameof(Pkcs11NativeModule.Login) && e.NativeOperationName == "C_Login");
+        Pkcs11OperationTelemetryField loginPin = Assert.Single(loginEvent.Fields, f => f.Name == "credential.pin");
+        Assert.Equal(Pkcs11TelemetryFieldClassification.Masked, loginPin.Classification);
+        Assert.Equal($"set(len={Encoding.UTF8.GetByteCount(userPin)})", loginPin.Value);
+
+        Pkcs11OperationTelemetryEvent digestEvent = Assert.Single(events, e => e.OperationName == "C_Digest" && e.NativeOperationName == "C_Digest");
+        Assert.Contains(digestEvent.Fields, f => f.Name == "input" && f.Classification == Pkcs11TelemetryFieldClassification.LengthOnly && f.Value == "len=17");
+        Assert.Contains(digestEvent.Fields, f => f.Name == "output" && f.Classification == Pkcs11TelemetryFieldClassification.LengthOnly && f.Value == "len=32");
+
+        Pkcs11OperationTelemetryEvent randomEvent = Assert.Single(events, e => e.OperationName == nameof(Pkcs11NativeModule.GenerateRandom) && e.NativeOperationName == "C_GenerateRandom");
+        Assert.Contains(randomEvent.Fields, f => f.Name == "random.output" && f.Classification == Pkcs11TelemetryFieldClassification.LengthOnly && f.Value == "len=16");
+
+        Assert.DoesNotContain(events.SelectMany(e => e.Fields), f => (f.Value ?? string.Empty).Contains(userPin, StringComparison.Ordinal));
+        Assert.DoesNotContain(events.SelectMany(e => e.Fields), f => (f.Value ?? string.Empty).Contains("telemetry-payload", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Add a safe redaction policy for PKCS#11 telemetry and logging.

## Included work
- structured redaction model for telemetry fields
- centralized redaction at the PKCS#11 boundary
- additive redacted field payloads on telemetry events
- docs and regression coverage

## Notes
- listeners only receive sanitized fields
- sensitive payloads remain suppressed/redacted according to policy

## Closes
Closes #38
