### PR TITLE
Add ILogger and OpenTelemetry support for PKCS#11 telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperating
 
 You can also swap the listener at runtime through `Pkcs11Module.TelemetryListener`.
 
+Built-in opt-in adapters let you project the same redacted event stream into `ILogger` and `ActivitySource` / OpenTelemetry-style tracing without coupling the PKCS#11 call path to a specific logging stack:
+
+```csharp
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Pkcs11Wrapper;
+
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+ILogger logger = loggerFactory.CreateLogger("Pkcs11");
+using ActivitySource activitySource = new("MyCompany.Security.Pkcs11");
+
+IPkcs11OperationTelemetryListener? telemetry = Pkcs11TelemetryListeners.Create(
+    logger: logger,
+    activitySource: activitySource);
+
+using Pkcs11Module module = Pkcs11Module.Load("/path/to/pkcs11/module", telemetry);
+module.Initialize();
+```
+
+- `Pkcs11LoggerTelemetryListener` maps success / returned-false / failure outcomes to `Information` / `Warning` / `Error` by default and emits structured scope properties for slot, session, mechanism, return value, and redacted fields.
+- `Pkcs11ActivityTelemetryListener` creates short-lived internal activities (`pkcs11.{OperationName}` by default), attaches the same redacted metadata as tags, and records failures as errored activities with an exception event when applicable.
+- `Pkcs11CompositeTelemetryListener` and `Pkcs11TelemetryListeners.Combine/Create(...)` let you fan out to multiple sinks while keeping the core wrapper telemetry listener model unchanged.
+
+See [docs/telemetry-integrations.md](docs/telemetry-integrations.md) for detailed examples and the emitted scope/tag shape.
+
 ### 2) Run the admin panel
 
 ```bash
@@ -233,6 +258,8 @@ Current capabilities include:
 - [docs/luna-compatibility-audit.md](docs/luna-compatibility-audit.md) - public-doc audit of Thales Luna standard compatibility vs current wrapper/admin/runtime scope
 - [docs/luna-vendor-extension-design.md](docs/luna-vendor-extension-design.md) - proposed package/boundary/loading/test strategy for future Luna-only `CA_*` support
 - [docs/smoke.md](docs/smoke.md) - smoke sample behavior and troubleshooting
+- [docs/telemetry-redaction.md](docs/telemetry-redaction.md) - PKCS#11 telemetry redaction policy
+- [docs/telemetry-integrations.md](docs/telemetry-integrations.md) - `ILogger` and `ActivitySource` / OpenTelemetry integration guidance
 - [docs/release.md](docs/release.md) - release checklist and packaging discipline
 - [docs/versioning.md](docs/versioning.md) - centralized versioning model and tag strategy
 - [docs/admin-panel-roadmap.md](docs/admin-panel-roadmap.md) - admin panel roadmap

--- a/docs/nuget/README.nuget.md
+++ b/docs/nuget/README.nuget.md
@@ -38,6 +38,16 @@ Console.WriteLine($"Discovered {slotCount} slot(s).");
 - Windows runtime validation with SoftHSM-for-Windows
 - BenchmarkDotNet baseline and CI reporting
 
+## Telemetry integrations
+
+The wrapper exposes opt-in structured PKCS#11 telemetry through `IPkcs11OperationTelemetryListener`. On top of that listener model, the main `Pkcs11Wrapper` package also includes ready-made adapters for:
+
+- `ILogger` via `Pkcs11LoggerTelemetryListener`
+- `ActivitySource` / OpenTelemetry-style tracing via `Pkcs11ActivityTelemetryListener`
+- fan-out composition via `Pkcs11CompositeTelemetryListener` and `Pkcs11TelemetryListeners.Create(...)`
+
+Those adapters reuse the same redacted metadata emitted by the native telemetry layer, so credentials, payloads, and secret-bearing attributes stay masked/hashed/length-only.
+
 ## Documentation
 
 - Repository: https://github.com/EbubekirERGUN/Pkcs11Wrapper

--- a/docs/telemetry-integrations.md
+++ b/docs/telemetry-integrations.md
@@ -1,0 +1,131 @@
+# PKCS#11 telemetry integrations
+
+`Pkcs11Wrapper` keeps the core PKCS#11 telemetry pipeline intentionally small:
+
+- the native layer emits a single redacted `Pkcs11OperationTelemetryEvent`
+- consumers opt in by attaching an `IPkcs11OperationTelemetryListener`
+- higher-level logging / tracing stacks are adapters on top of that event stream, not hard dependencies in the PKCS#11 call path
+
+That design keeps the wrapper decoupled while still making it easy to plug into `ILogger`, `ActivitySource`, and OpenTelemetry-style collectors.
+
+## Available adapters
+
+The main `Pkcs11Wrapper` package exposes these ready-made listeners:
+
+- `Pkcs11LoggerTelemetryListener`
+- `Pkcs11ActivityTelemetryListener`
+- `Pkcs11CompositeTelemetryListener`
+- `Pkcs11TelemetryListeners.Combine(...)`
+- `Pkcs11TelemetryListeners.Create(...)`
+
+All of them reuse the same telemetry events and the same redaction policy documented in [telemetry-redaction.md](telemetry-redaction.md).
+
+## `ILogger` integration
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Pkcs11Wrapper;
+
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+ILogger logger = loggerFactory.CreateLogger("Pkcs11");
+
+IPkcs11OperationTelemetryListener telemetry = new Pkcs11LoggerTelemetryListener(logger);
+using Pkcs11Module module = Pkcs11Module.Load("/path/to/pkcs11/module", telemetry);
+module.Initialize();
+```
+
+Default log-level mapping:
+
+- `Succeeded` -> `Information`
+- `ReturnedFalse` -> `Warning`
+- `Failed` -> `Error`
+
+The listener writes a compact log message and, by default, adds structured scope properties such as:
+
+- `pkcs11.operation.name`
+- `pkcs11.native.operation`
+- `pkcs11.status`
+- `pkcs11.duration_ms`
+- `pkcs11.return_value`
+- `pkcs11.slot_id`
+- `pkcs11.session_handle`
+- `pkcs11.mechanism_type`
+- `pkcs11.field.<fieldName>`
+- `pkcs11.field_classification.<fieldName>`
+
+Example scope entries for a login call:
+
+- `pkcs11.field.credential.userType = CKU_USER`
+- `pkcs11.field.credential.pin = set(len=6)`
+- `pkcs11.field_classification.credential.pin = Masked`
+
+You can override the defaults with `Pkcs11LoggerTelemetryOptions` if you want different levels or less scope detail.
+
+## `ActivitySource` / OpenTelemetry-style tracing
+
+```csharp
+using System.Diagnostics;
+using Pkcs11Wrapper;
+
+using ActivitySource activitySource = new("MyCompany.Security.Pkcs11");
+
+IPkcs11OperationTelemetryListener telemetry = new Pkcs11ActivityTelemetryListener(activitySource);
+using Pkcs11Module module = Pkcs11Module.Load("/path/to/pkcs11/module", telemetry);
+module.Initialize();
+```
+
+Default activity behavior:
+
+- activity name: `pkcs11.{OperationName}`
+- activity kind: `Internal`
+- tags: core PKCS#11 metadata + redacted telemetry fields
+- status mapping:
+  - `Succeeded` -> `Ok`
+  - `ReturnedFalse` -> `Error` with description `returned_false`
+  - `Failed` -> `Error` with the exception message (or PKCS#11 return value when no exception is attached)
+- exception handling: when an exception is present, the listener adds an `exception` activity event with type/message/stack-trace tags
+
+This makes the emitted activities straightforward for OpenTelemetry SDKs/exporters to pick up once your process has an `ActivityListener` or OpenTelemetry tracing pipeline configured.
+
+## Combining sinks
+
+If you want logs and traces at the same time, either compose manually or use the helper factory:
+
+```csharp
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Pkcs11Wrapper;
+
+using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+ILogger logger = loggerFactory.CreateLogger("Pkcs11");
+using ActivitySource activitySource = new("MyCompany.Security.Pkcs11");
+
+IPkcs11OperationTelemetryListener? telemetry = Pkcs11TelemetryListeners.Create(
+    logger: logger,
+    activitySource: activitySource);
+
+using Pkcs11Module module = Pkcs11Module.Load("/path/to/pkcs11/module", telemetry);
+module.Initialize();
+```
+
+`Pkcs11TelemetryListeners.Create(...)` returns:
+
+- `null` when no sink is requested
+- the single listener directly when only one sink is requested
+- a `Pkcs11CompositeTelemetryListener` when multiple sinks are requested
+
+The composite listener isolates child-listener failures from each other, matching the wrapper's general rule that observation must not break the underlying PKCS#11 operation flow.
+
+## Redaction still applies
+
+The adapters do **not** bypass the existing redaction layer.
+
+That means the emitted logs / activity tags keep the same guarantees as the raw telemetry events:
+
+- no raw PIN values
+- no plaintext / ciphertext payload capture
+- no secret key material
+- no secret-bearing PKCS#11 attribute values
+- only safe metadata, hashed identifiers, masked credentials, and length-only payload summaries
+
+If you need the exact classification policy, see [telemetry-redaction.md](telemetry-redaction.md).

--- a/src/Pkcs11Wrapper/Pkcs11ActivityTelemetryListener.cs
+++ b/src/Pkcs11Wrapper/Pkcs11ActivityTelemetryListener.cs
@@ -1,0 +1,124 @@
+using System.Diagnostics;
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper;
+
+public sealed record Pkcs11ActivityTelemetryOptions
+{
+    public string ActivityNamePrefix { get; init; } = "pkcs11.";
+
+    public ActivityKind Kind { get; init; } = ActivityKind.Internal;
+
+    public bool IncludeFieldsAsTags { get; init; } = true;
+
+    public bool IncludeFieldClassifications { get; init; } = true;
+
+    public bool IncludeExceptionEvent { get; init; } = true;
+}
+
+public sealed class Pkcs11ActivityTelemetryListener : IPkcs11OperationTelemetryListener
+{
+    private readonly ActivitySource _activitySource;
+    private readonly Pkcs11ActivityTelemetryOptions _options;
+
+    public Pkcs11ActivityTelemetryListener(ActivitySource activitySource)
+        : this(activitySource, options: null)
+    {
+    }
+
+    public Pkcs11ActivityTelemetryListener(ActivitySource activitySource, Pkcs11ActivityTelemetryOptions? options)
+    {
+        _activitySource = activitySource ?? throw new ArgumentNullException(nameof(activitySource));
+        _options = options ?? new Pkcs11ActivityTelemetryOptions();
+    }
+
+    public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+    {
+        Activity? activity = _activitySource.CreateActivity(_options.ActivityNamePrefix + operationEvent.OperationName, _options.Kind);
+        if (activity is null)
+        {
+            return;
+        }
+
+        DateTime startTimeUtc = DateTime.UtcNow - operationEvent.Duration;
+        DateTime endTimeUtc = startTimeUtc + operationEvent.Duration;
+
+        activity.SetStartTime(startTimeUtc);
+        activity.SetTag("pkcs11.operation.name", operationEvent.OperationName);
+        activity.SetTag("pkcs11.status", operationEvent.Status.ToString());
+        activity.SetTag("pkcs11.duration_ms", operationEvent.Duration.TotalMilliseconds);
+
+        if (!string.IsNullOrWhiteSpace(operationEvent.NativeOperationName))
+        {
+            activity.SetTag("pkcs11.native.operation", operationEvent.NativeOperationName);
+        }
+
+        if (operationEvent.ReturnValue is { } returnValue)
+        {
+            activity.SetTag("pkcs11.return_value", returnValue.ToString());
+        }
+
+        if (operationEvent.SlotId is { } slotId)
+        {
+            activity.SetTag("pkcs11.slot_id", slotId);
+        }
+
+        if (operationEvent.SessionHandle is { } sessionHandle)
+        {
+            activity.SetTag("pkcs11.session_handle", sessionHandle);
+        }
+
+        if (operationEvent.MechanismType is { } mechanismType)
+        {
+            activity.SetTag("pkcs11.mechanism_type", $"0x{mechanismType:x}");
+        }
+
+        if (_options.IncludeFieldsAsTags)
+        {
+            for (int i = 0; i < operationEvent.Fields.Count; i++)
+            {
+                Pkcs11OperationTelemetryField field = operationEvent.Fields[i];
+                activity.SetTag($"pkcs11.field.{field.Name}", field.Value);
+
+                if (_options.IncludeFieldClassifications)
+                {
+                    activity.SetTag($"pkcs11.field_classification.{field.Name}", field.Classification.ToString());
+                }
+            }
+        }
+
+        activity.Start();
+
+        if (operationEvent.Status == Pkcs11OperationTelemetryStatus.Succeeded)
+        {
+            activity.SetStatus(ActivityStatusCode.Ok);
+        }
+        else if (operationEvent.Status == Pkcs11OperationTelemetryStatus.ReturnedFalse)
+        {
+            activity.SetStatus(ActivityStatusCode.Error, "returned_false");
+        }
+        else
+        {
+            activity.SetStatus(ActivityStatusCode.Error, operationEvent.Exception?.Message ?? operationEvent.ReturnValue?.ToString());
+        }
+
+        if (_options.IncludeExceptionEvent && operationEvent.Exception is not null)
+        {
+            ActivityTagsCollection tags =
+            [
+                new KeyValuePair<string, object?>("exception.type", operationEvent.Exception.GetType().FullName),
+                new KeyValuePair<string, object?>("exception.message", operationEvent.Exception.Message),
+            ];
+
+            if (!string.IsNullOrWhiteSpace(operationEvent.Exception.StackTrace))
+            {
+                tags.Add("exception.stacktrace", operationEvent.Exception.StackTrace);
+            }
+
+            activity.AddEvent(new ActivityEvent("exception", endTimeUtc, tags));
+        }
+
+        activity.SetEndTime(endTimeUtc);
+        activity.Stop();
+    }
+}

--- a/src/Pkcs11Wrapper/Pkcs11CompositeTelemetryListener.cs
+++ b/src/Pkcs11Wrapper/Pkcs11CompositeTelemetryListener.cs
@@ -1,0 +1,28 @@
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper;
+
+public sealed class Pkcs11CompositeTelemetryListener : IPkcs11OperationTelemetryListener
+{
+    private readonly IPkcs11OperationTelemetryListener[] _listeners;
+
+    public Pkcs11CompositeTelemetryListener(params IPkcs11OperationTelemetryListener?[] listeners)
+    {
+        ArgumentNullException.ThrowIfNull(listeners);
+        _listeners = listeners.Where(static listener => listener is not null).Cast<IPkcs11OperationTelemetryListener>().ToArray();
+    }
+
+    public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+    {
+        for (int i = 0; i < _listeners.Length; i++)
+        {
+            try
+            {
+                _listeners[i].OnOperationCompleted(in operationEvent);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/Pkcs11Wrapper/Pkcs11LoggerTelemetryListener.cs
+++ b/src/Pkcs11Wrapper/Pkcs11LoggerTelemetryListener.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.Logging;
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper;
+
+public sealed record Pkcs11LoggerTelemetryOptions
+{
+    public LogLevel SuccessLevel { get; init; } = LogLevel.Information;
+
+    public LogLevel ReturnedFalseLevel { get; init; } = LogLevel.Warning;
+
+    public LogLevel FailureLevel { get; init; } = LogLevel.Error;
+
+    public bool IncludeStructuredScope { get; init; } = true;
+
+    public bool IncludeFieldClassifications { get; init; } = true;
+}
+
+public sealed class Pkcs11LoggerTelemetryListener : IPkcs11OperationTelemetryListener
+{
+    private readonly ILogger _logger;
+    private readonly Pkcs11LoggerTelemetryOptions _options;
+
+    public Pkcs11LoggerTelemetryListener(ILogger logger)
+        : this(logger, options: null)
+    {
+    }
+
+    public Pkcs11LoggerTelemetryListener(ILogger logger, Pkcs11LoggerTelemetryOptions? options)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? new Pkcs11LoggerTelemetryOptions();
+    }
+
+    public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+    {
+        LogLevel level = operationEvent.Status switch
+        {
+            Pkcs11OperationTelemetryStatus.Succeeded => _options.SuccessLevel,
+            Pkcs11OperationTelemetryStatus.ReturnedFalse => _options.ReturnedFalseLevel,
+            Pkcs11OperationTelemetryStatus.Failed => _options.FailureLevel,
+            _ => _options.FailureLevel,
+        };
+
+        if (!_logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        IDisposable? scope = null;
+        if (_options.IncludeStructuredScope)
+        {
+            scope = _logger.BeginScope(Pkcs11TelemetryScopeState.Create(operationEvent, _options.IncludeFieldClassifications));
+        }
+
+        try
+        {
+            _logger.Log(
+                level,
+                operationEvent.Exception,
+                "PKCS#11 {OperationName} ({NativeOperationName}) completed with {Status} in {DurationMs} ms.",
+                operationEvent.OperationName,
+                operationEvent.NativeOperationName ?? string.Empty,
+                operationEvent.Status,
+                operationEvent.Duration.TotalMilliseconds);
+        }
+        finally
+        {
+            scope?.Dispose();
+        }
+    }
+}
+
+internal static class Pkcs11TelemetryScopeState
+{
+    public static IReadOnlyList<KeyValuePair<string, object?>> Create(in Pkcs11OperationTelemetryEvent operationEvent, bool includeFieldClassifications)
+    {
+        List<KeyValuePair<string, object?>> scope =
+        [
+            new("pkcs11.operation.name", operationEvent.OperationName),
+            new("pkcs11.status", operationEvent.Status.ToString()),
+            new("pkcs11.duration_ms", operationEvent.Duration.TotalMilliseconds),
+        ];
+
+        if (!string.IsNullOrWhiteSpace(operationEvent.NativeOperationName))
+        {
+            scope.Add(new KeyValuePair<string, object?>("pkcs11.native.operation", operationEvent.NativeOperationName));
+        }
+
+        if (operationEvent.ReturnValue is { } returnValue)
+        {
+            scope.Add(new KeyValuePair<string, object?>("pkcs11.return_value", returnValue.ToString()));
+        }
+
+        if (operationEvent.SlotId is { } slotId)
+        {
+            scope.Add(new KeyValuePair<string, object?>("pkcs11.slot_id", slotId));
+        }
+
+        if (operationEvent.SessionHandle is { } sessionHandle)
+        {
+            scope.Add(new KeyValuePair<string, object?>("pkcs11.session_handle", sessionHandle));
+        }
+
+        if (operationEvent.MechanismType is { } mechanismType)
+        {
+            scope.Add(new KeyValuePair<string, object?>("pkcs11.mechanism_type", $"0x{mechanismType:x}"));
+        }
+
+        for (int i = 0; i < operationEvent.Fields.Count; i++)
+        {
+            Pkcs11OperationTelemetryField field = operationEvent.Fields[i];
+            scope.Add(new KeyValuePair<string, object?>($"pkcs11.field.{field.Name}", field.Value));
+
+            if (includeFieldClassifications)
+            {
+                scope.Add(new KeyValuePair<string, object?>($"pkcs11.field_classification.{field.Name}", field.Classification.ToString()));
+            }
+        }
+
+        return scope;
+    }
+}

--- a/src/Pkcs11Wrapper/Pkcs11TelemetryListeners.cs
+++ b/src/Pkcs11Wrapper/Pkcs11TelemetryListeners.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper;
+
+public static class Pkcs11TelemetryListeners
+{
+    public static IPkcs11OperationTelemetryListener? Combine(params IPkcs11OperationTelemetryListener?[] listeners)
+    {
+        ArgumentNullException.ThrowIfNull(listeners);
+
+        IPkcs11OperationTelemetryListener[] materialized = listeners.Where(static listener => listener is not null).Cast<IPkcs11OperationTelemetryListener>().ToArray();
+        return materialized.Length switch
+        {
+            0 => null,
+            1 => materialized[0],
+            _ => new Pkcs11CompositeTelemetryListener(materialized),
+        };
+    }
+
+    public static IPkcs11OperationTelemetryListener? Create(
+        ILogger? logger = null,
+        ActivitySource? activitySource = null,
+        Pkcs11LoggerTelemetryOptions? loggerOptions = null,
+        Pkcs11ActivityTelemetryOptions? activityOptions = null)
+        => Combine(
+            logger is null ? null : new Pkcs11LoggerTelemetryListener(logger, loggerOptions),
+            activitySource is null ? null : new Pkcs11ActivityTelemetryListener(activitySource, activityOptions));
+}

--- a/src/Pkcs11Wrapper/Pkcs11Wrapper.csproj
+++ b/src/Pkcs11Wrapper/Pkcs11Wrapper.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\docs\nuget\README.nuget.md" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/tests/Pkcs11Wrapper.Native.Tests/ManagedApiSurfaceTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/ManagedApiSurfaceTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Pkcs11Wrapper;
 using Pkcs11Wrapper.Native;
 using Pkcs11Wrapper.Native.Interop;
@@ -33,6 +35,13 @@ public sealed class ManagedApiSurfaceTests
         Assert.NotNull(typeof(Pkcs11Module).GetProperty(nameof(Pkcs11Module.TelemetryListener)));
         Assert.NotNull(typeof(Pkcs11NativeModule).GetProperty(nameof(Pkcs11NativeModule.TelemetryListener)));
         Assert.NotNull(typeof(IPkcs11OperationTelemetryListener).GetMethod(nameof(IPkcs11OperationTelemetryListener.OnOperationCompleted)));
+        Assert.NotNull(typeof(Pkcs11CompositeTelemetryListener).GetConstructor([typeof(IPkcs11OperationTelemetryListener[])]));
+        Assert.NotNull(typeof(Pkcs11LoggerTelemetryListener).GetConstructor([typeof(ILogger)]));
+        Assert.NotNull(typeof(Pkcs11LoggerTelemetryListener).GetConstructor([typeof(ILogger), typeof(Pkcs11LoggerTelemetryOptions)]));
+        Assert.NotNull(typeof(Pkcs11ActivityTelemetryListener).GetConstructor([typeof(ActivitySource)]));
+        Assert.NotNull(typeof(Pkcs11ActivityTelemetryListener).GetConstructor([typeof(ActivitySource), typeof(Pkcs11ActivityTelemetryOptions)]));
+        Assert.NotNull(typeof(Pkcs11TelemetryListeners).GetMethod(nameof(Pkcs11TelemetryListeners.Combine), [typeof(IPkcs11OperationTelemetryListener[])]));
+        Assert.NotNull(typeof(Pkcs11TelemetryListeners).GetMethod(nameof(Pkcs11TelemetryListeners.Create), [typeof(ILogger), typeof(ActivitySource), typeof(Pkcs11LoggerTelemetryOptions), typeof(Pkcs11ActivityTelemetryOptions)]));
 
         Pkcs11OperationTelemetryField field = new(
             Name: "credential.pin",

--- a/tests/Pkcs11Wrapper.Native.Tests/TelemetryIntegrationListenerTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/TelemetryIntegrationListenerTests.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Pkcs11Wrapper;
+using Pkcs11Wrapper.Native;
+using Pkcs11Wrapper.Native.Interop;
+
+namespace Pkcs11Wrapper.Native.Tests;
+
+public sealed class TelemetryIntegrationListenerTests
+{
+    [Fact]
+    public void LoggerListenerWritesStructuredScopeWithRedactedFields()
+    {
+        RecordingLogger logger = new();
+        Pkcs11LoggerTelemetryListener listener = new(logger);
+
+        listener.OnOperationCompleted(CreateOperationEvent());
+
+        LogEntry entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        Assert.Contains("PKCS#11 Load (C_GetFunctionList) completed with Succeeded", entry.Message, StringComparison.Ordinal);
+
+        IReadOnlyList<KeyValuePair<string, object?>> scope = Assert.Single(logger.Scopes);
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.operation.name" && Equals(kvp.Value, "Load"));
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.native.operation" && Equals(kvp.Value, "C_GetFunctionList"));
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.return_value" && Equals(kvp.Value, CK_RV.Ok.ToString()));
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.slot_id" && Equals(kvp.Value, (nuint)7));
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.mechanism_type" && Equals(kvp.Value, $"0x{Pkcs11MechanismTypes.Sha256.Value:x}"));
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.field.credential.pin" && Equals(kvp.Value, "set(len=6)"));
+        Assert.Contains(scope, kvp => kvp.Key == "pkcs11.field_classification.credential.pin" && Equals(kvp.Value, nameof(Pkcs11TelemetryFieldClassification.Masked)));
+    }
+
+    [Fact]
+    public void ActivityListenerCreatesTraceableActivityWithTagsAndExceptionEvent()
+    {
+        using ActivitySource activitySource = new("Pkcs11Wrapper.Tests.Telemetry");
+        Activity? stoppedActivity = null;
+
+        using ActivityListener listener = new()
+        {
+            ShouldListenTo = source => source.Name == activitySource.Name,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => stoppedActivity = activity,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        Pkcs11ActivityTelemetryListener telemetryListener = new(activitySource);
+        telemetryListener.OnOperationCompleted(CreateOperationEvent(
+            status: Pkcs11OperationTelemetryStatus.Failed,
+            exception: new InvalidOperationException("boom"),
+            duration: TimeSpan.FromMilliseconds(12)));
+
+        Assert.NotNull(stoppedActivity);
+        Activity activity = stoppedActivity!;
+        Assert.Equal("pkcs11.Load", activity.OperationName);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("boom", activity.StatusDescription);
+        Assert.Equal(TimeSpan.FromMilliseconds(12), activity.Duration);
+        Assert.Equal("Load", activity.GetTagItem("pkcs11.operation.name"));
+        Assert.Equal("C_GetFunctionList", activity.GetTagItem("pkcs11.native.operation"));
+        Assert.Equal("Failed", activity.GetTagItem("pkcs11.status"));
+        Assert.Equal("set(len=6)", activity.GetTagItem("pkcs11.field.credential.pin"));
+        Assert.Equal(nameof(Pkcs11TelemetryFieldClassification.Masked), activity.GetTagItem("pkcs11.field_classification.credential.pin"));
+
+        ActivityEvent exceptionEvent = Assert.Single(activity.Events, evt => evt.Name == "exception");
+        Assert.Contains(exceptionEvent.Tags, kvp => kvp.Key == "exception.type" && Equals(kvp.Value, typeof(InvalidOperationException).FullName));
+        Assert.Contains(exceptionEvent.Tags, kvp => kvp.Key == "exception.message" && Equals(kvp.Value, "boom"));
+    }
+
+    [Fact]
+    public void CompositeListenerSwallowsChildFailuresAndFactoryBuildsExpectedShape()
+    {
+        RecordingForwardingListener recordingListener = new();
+        Pkcs11CompositeTelemetryListener composite = new(new ThrowingListener(), recordingListener);
+
+        composite.OnOperationCompleted(CreateOperationEvent());
+
+        Assert.Single(recordingListener.Events);
+        Assert.Null(Pkcs11TelemetryListeners.Create());
+        Assert.Same(recordingListener, Pkcs11TelemetryListeners.Combine(recordingListener));
+
+        RecordingLogger logger = new();
+        using ActivitySource activitySource = new("Pkcs11Wrapper.Tests.Factory");
+        IPkcs11OperationTelemetryListener? created = Pkcs11TelemetryListeners.Create(logger, activitySource);
+        Assert.IsType<Pkcs11CompositeTelemetryListener>(created);
+    }
+
+    private static Pkcs11OperationTelemetryEvent CreateOperationEvent(
+        Pkcs11OperationTelemetryStatus status = Pkcs11OperationTelemetryStatus.Succeeded,
+        Exception? exception = null,
+        TimeSpan? duration = null)
+        => new(
+            OperationName: "Load",
+            NativeOperationName: "C_GetFunctionList",
+            Status: status,
+            Duration: duration ?? TimeSpan.FromMilliseconds(5),
+            ReturnValue: exception is null ? CK_RV.Ok : new CK_RV(0x00000005u),
+            SlotId: 7,
+            SessionHandle: 11,
+            MechanismType: Pkcs11MechanismTypes.Sha256.Value,
+            Exception: exception)
+        {
+            Fields =
+            [
+                new Pkcs11OperationTelemetryField("credential.pin", Pkcs11TelemetryFieldClassification.Masked, "set(len=6)"),
+                new Pkcs11OperationTelemetryField("input", Pkcs11TelemetryFieldClassification.LengthOnly, "len=32"),
+            ]
+        };
+
+    private sealed class ThrowingListener : IPkcs11OperationTelemetryListener
+    {
+        public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+            => throw new InvalidOperationException("listener failure");
+    }
+
+    private sealed class RecordingForwardingListener : IPkcs11OperationTelemetryListener
+    {
+        public List<Pkcs11OperationTelemetryEvent> Events { get; } = [];
+
+        public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+            => Events.Add(operationEvent);
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public List<IReadOnlyList<KeyValuePair<string, object?>>> Scopes { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        {
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> scope)
+            {
+                Scopes.Add(scope);
+            }
+            else if (state is IEnumerable<KeyValuePair<string, object?>> enumerable)
+            {
+                Scopes.Add(enumerable.ToList());
+            }
+            else
+            {
+                Scopes.Add([new KeyValuePair<string, object?>("state", state)]);
+            }
+
+            return NoopDisposable.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static NoopDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add ILogger and OpenTelemetry integration for PKCS#11 telemetry.

## Included work
- `ILogger` adapter listener
- `ActivitySource` / OTel-style adapter listener
- composite/fan-out listener helpers
- docs and integration-style test coverage

## Notes
- keeps telemetry opt-in and decoupled
- reuses the existing redacted telemetry event stream

## Closes
Closes #39
