### PR TITLE
Add the admin PKCS#11 telemetry viewer

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -60,6 +60,11 @@
   - dashboard için failure-category, invalidated-device ve recovery widget genişletmeleri
   - configuration export freshness, bootstrap notice ve saved lab template görünürlüğü
   - `AdminDashboardView` helper + testler ile recovery-oriented dashboard hesaplarının testlenebilir hale getirilmesi
+- Admin panel Phase E yedinci polish dilimi teslim edildi:
+  - admin panel içinde JSONL-backed PKCS#11 telemetry store + viewer
+  - device / slot / operation / mechanism / status / time-window filtreleri
+  - wrapper redaction policy ile uyumlu safe field rendering; raw exception messages intentionally persist edilmiyor
+  - `Pkcs11TelemetryView` helper + telemetry store/service testleri ile filtre/saklama davranışı doğrulandı
 - Çözüm doğrulaması temiz:
   - `dotnet build Pkcs11Wrapper.sln -c Release`
   - `dotnet test Pkcs11Wrapper.sln -c Release`
@@ -70,7 +75,7 @@
 - Belgeleme senkronizasyonu yapıldı; README'ler artık admin panelin auth/users/config-transfer/PKCS#11 Lab gerçek durumunu ve benchmark baseline tarihini yansıtıyor.
 
 ## Sıradaki işler
-- Admin panel UX/product polish'in sonraki dilimleri (dashboard quick-action refinements, gerekiyorsa Lab için favorites import/export veya pin-to-navigation ergonomisi, daha derin operator playbook yüzeyleri).
+- Admin panel UX/product polish'in sonraki dilimleri (dashboard quick-action refinements, gerekiyorsa telemetry trend/top-operation widget'ları, Lab için favorites import/export veya pin-to-navigation ergonomisi, daha derin operator playbook yüzeyleri).
 - PKCS#11 v3 interface yüzeyini gerçekten export eden vendor/modül ile ek runtime regression.
 - Benchmark suite'i performans hassas değişikliklerden sonra ve release öncesinde tekrar çalıştırıp en güncel baseline'ı tazelemek.
 - GitHub vitrin materyallerini zenginleştirmek (ekran görüntüsü, demo media, release notes).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 - key/object browsing, detail, edit, copy, generate, import, and destroy flows
 - tracked session visibility and control (`login` / `logout` / `cancel` / `close-all` + invalidation visibility)
 - PKCS#11 Lab diagnostics, crypto experiments, object workflows, and scenario replay helpers
+- PKCS#11 telemetry viewer with redacted device / slot / mechanism / status filtering
 - protected PIN cache + append-only chained audit log integrity
 
 ## Platform & validation status
@@ -243,6 +244,7 @@ Current capabilities include:
 - protected PIN caching for repeat operations
 - device-profile configuration export/import
 - PKCS#11 Lab for diagnostics, crypto operations, object inspection, wrap/unwrap, raw attribute reads, and scenario replay
+- PKCS#11 telemetry viewer for redacted wrapper-level operation traces and failure correlation
 - append-only chained audit entries with integrity verification
 
 ## Documentation map

--- a/docs/admin-ops-recovery.md
+++ b/docs/admin-ops-recovery.md
@@ -91,7 +91,25 @@ If integrity is reported as invalid:
 
 In the current app shape, integrity warnings should be treated as operationally significant.
 
-## 6. Protected PIN cache expectations
+## 6. PKCS#11 telemetry review
+
+Use `PKCS#11 Telemetry` when a workflow fails but you still need the underlying wrapper-level context.
+
+What this page is good for:
+
+- correlating failures to a specific device, slot, or mechanism
+- checking whether the wrapper is returning `Succeeded`, `ReturnedFalse`, or `Failed`
+- reviewing the safe redacted field set emitted by the PKCS#11 telemetry pipeline
+
+Important limits:
+
+- the viewer only stores the latest redacted PKCS#11 event stream written by the admin host
+- raw PINs, payloads, wrapped blobs, and secret-bearing attributes are never persisted there
+- raw exception messages are intentionally not retained in this viewer because they are outside the explicit field-redaction contract
+
+Use `Audit Logs` for actor/action accountability and `PKCS#11 Telemetry` for low-level call correlation.
+
+## 7. Protected PIN cache expectations
 
 Protected PIN storage is designed for convenience on the same host, not as a centralized secret-management solution.
 
@@ -102,7 +120,7 @@ Important limits:
 - they depend on local ASP.NET Core Data Protection material
 - moving the app to another host does not carry this cache with it automatically
 
-## 7. What this does not replace
+## 8. What this does not replace
 
 Current admin hardening is strong for a local embedded deployment, but it does not replace:
 

--- a/docs/admin-panel-roadmap.md
+++ b/docs/admin-panel-roadmap.md
@@ -116,6 +116,7 @@ Goals:
 - Phase E fourth polish slice delivered: configuration-page summary/safety affordances plus PKCS#11 Lab quick-operation palette, summary cards, and filterable scenario-history UX backed by a reusable/tested `Pkcs11LabView` helper
 - Phase E fifth polish slice delivered: persistent PKCS#11 Lab saved templates/favorites with App_Data-backed storage, search/category filters, quick apply/delete actions, and explicit PIN stripping via a tested `Pkcs11LabTemplateStore`
 - Phase E sixth polish slice delivered: dashboard/widget expansion for failure categories, invalidated-session grouping, configuration-export freshness, bootstrap hardening visibility, and recent Lab-template awareness via a reusable/tested `AdminDashboardView` helper
+- Phase E seventh polish slice delivered: admin-facing PKCS#11 telemetry viewer backed by a local JSONL store, with redacted field rendering plus device/slot/operation/mechanism/status/time-window filtering via a reusable/tested `Pkcs11TelemetryView` helper
 - capability/mechanism-aware key-management UX: slot-level mechanism probing, pre-submit warnings, and disabled generate/import actions when the selected slot obviously cannot satisfy them
 - object edit affordances are now more object-aware: obvious unsupported toggles are disabled based on object class + `CKA_MODIFIABLE` visibility
 - object copy workflow delivered via `C_CopyObject`, including label/ID/capability override template fields and admin-layer validation

--- a/src/Pkcs11Wrapper.Admin.Application/Abstractions/IPkcs11TelemetryStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Abstractions/IPkcs11TelemetryStore.cs
@@ -1,0 +1,10 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Application.Abstractions;
+
+public interface IPkcs11TelemetryStore
+{
+    Task AppendAsync(AdminPkcs11TelemetryEntry entry, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default);
+}

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryEntry.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryEntry.cs
@@ -1,0 +1,22 @@
+namespace Pkcs11Wrapper.Admin.Application.Models;
+
+public sealed record AdminPkcs11TelemetryField(
+    string Name,
+    string Classification,
+    string? Value);
+
+public sealed record AdminPkcs11TelemetryEntry(
+    Guid Id,
+    DateTimeOffset TimestampUtc,
+    Guid DeviceId,
+    string DeviceName,
+    string OperationName,
+    string? NativeOperationName,
+    string Status,
+    double DurationMilliseconds,
+    string? ReturnValue,
+    ulong? SlotId,
+    ulong? SessionHandle,
+    ulong? MechanismType,
+    string? ExceptionType,
+    AdminPkcs11TelemetryField[] Fields);

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -9,7 +9,7 @@ using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.Admin.Application.Services;
 
-public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLogService auditLog, AdminSessionRegistry sessionRegistry, IAdminAuthorizationService authorization, IDeviceDependencyCleanupService? dependencyCleanup = null)
+public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLogService auditLog, AdminSessionRegistry sessionRegistry, IAdminAuthorizationService authorization, IDeviceDependencyCleanupService? dependencyCleanup = null, Pkcs11TelemetryService? pkcs11Telemetry = null)
 {
     private const string DestroyConfirmationPrefix = "DESTROY ";
     private const string ConfigurationFormat = "Pkcs11Wrapper.Admin.Configuration";
@@ -131,6 +131,12 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandViewer();
         return auditLog.VerifyIntegrityAsync(forceVerification, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> GetPkcs11TelemetryAsync(int take = 500, CancellationToken cancellationToken = default)
+    {
+        authorization.DemandViewer();
+        return pkcs11Telemetry?.GetRecentAsync(take, cancellationToken) ?? Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([]);
     }
 
     public async Task<DashboardSummary> GetDashboardAsync(CancellationToken cancellationToken = default)
@@ -2618,9 +2624,9 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
             Pkcs11ObjectAttribute.Bytes(Pkcs11AttributeTypes.Id, id)
         ];
 
-    private static Pkcs11Module CreateInitializedModule(HsmDeviceProfile device)
+    private Pkcs11Module CreateInitializedModule(HsmDeviceProfile device)
     {
-        Pkcs11Module module = Pkcs11Module.Load(device.ModulePath);
+        Pkcs11Module module = Pkcs11Module.Load(device.ModulePath, pkcs11Telemetry?.CreateListener(device));
         module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
         return module;
     }

--- a/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryService.cs
@@ -1,0 +1,44 @@
+using Pkcs11Wrapper.Admin.Application.Abstractions;
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper.Admin.Application.Services;
+
+public sealed class Pkcs11TelemetryService(IPkcs11TelemetryStore store)
+{
+    public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> GetRecentAsync(int take = 500, CancellationToken cancellationToken = default)
+        => store.ReadRecentAsync(take, cancellationToken);
+
+    public IPkcs11OperationTelemetryListener CreateListener(HsmDeviceProfile device)
+        => new AdminPkcs11TelemetryListener(store, device);
+
+    private sealed class AdminPkcs11TelemetryListener(IPkcs11TelemetryStore store, HsmDeviceProfile device) : IPkcs11OperationTelemetryListener
+    {
+        public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+        {
+            AdminPkcs11TelemetryEntry entry = new(
+                Guid.NewGuid(),
+                DateTimeOffset.UtcNow,
+                device.Id,
+                device.Name,
+                operationEvent.OperationName,
+                operationEvent.NativeOperationName,
+                operationEvent.Status.ToString(),
+                operationEvent.Duration.TotalMilliseconds,
+                operationEvent.ReturnValue?.ToString(),
+                operationEvent.SlotId.HasValue ? (ulong)operationEvent.SlotId.Value : null,
+                operationEvent.SessionHandle.HasValue ? (ulong)operationEvent.SessionHandle.Value : null,
+                operationEvent.MechanismType.HasValue ? (ulong)operationEvent.MechanismType.Value : null,
+                operationEvent.Exception?.GetType().Name,
+                [.. operationEvent.Fields.Select(field => new AdminPkcs11TelemetryField(field.Name, field.Classification.ToString(), field.Value))]);
+
+            try
+            {
+                store.AppendAsync(entry).GetAwaiter().GetResult();
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/AdminJsonContext.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/AdminJsonContext.cs
@@ -5,6 +5,7 @@ namespace Pkcs11Wrapper.Admin.Infrastructure;
 
 [JsonSerializable(typeof(List<HsmDeviceProfile>))]
 [JsonSerializable(typeof(AdminAuditLogEntry))]
+[JsonSerializable(typeof(AdminPkcs11TelemetryEntry))]
 [JsonSerializable(typeof(List<ProtectedPinRecord>))]
 internal sealed partial class AdminJsonContext : JsonSerializerContext
 {

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/AdminStorageOptions.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/AdminStorageOptions.cs
@@ -8,5 +8,7 @@ public sealed class AdminStorageOptions
 
     public string AuditLogFileName { get; set; } = "audit-log.jsonl";
 
+    public string TelemetryLogFileName { get; set; } = "pkcs11-telemetry.jsonl";
+
     public string LabTemplatesFileName { get; set; } = "lab-templates.json";
 }

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLinePkcs11TelemetryStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLinePkcs11TelemetryStore.cs
@@ -1,0 +1,144 @@
+using System.Text;
+using System.Text.Json;
+using Pkcs11Wrapper.Admin.Application.Abstractions;
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Infrastructure;
+
+public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions options) : IPkcs11TelemetryStore
+{
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+
+    public async Task AppendAsync(AdminPkcs11TelemetryEntry entry, CancellationToken cancellationToken = default)
+    {
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            string path = GetPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+            string line = JsonSerializer.Serialize(entry, AdminJsonContext.Default.AdminPkcs11TelemetryEntry) + Environment.NewLine;
+
+            await using FileStream stream = new(path, FileMode.Append, FileAccess.Write, FileShare.Read, 64 * 1024, FileOptions.Asynchronous);
+            await using StreamWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+            await writer.WriteAsync(line.AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default)
+    {
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            string path = GetPath();
+            if (!File.Exists(path))
+            {
+                return [];
+            }
+
+            return (await ReadTailLinesAsync(path, Math.Max(1, take), cancellationToken))
+                .Select(line => DeserializeEntry(line, path))
+                .ToArray();
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private string GetPath() => Path.Combine(options.DataRoot, options.TelemetryLogFileName);
+
+    private static AdminPkcs11TelemetryEntry DeserializeEntry(string line, string path)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize(line, AdminJsonContext.Default.AdminPkcs11TelemetryEntry)
+                ?? throw new InvalidOperationException($"Telemetry log '{path}' contains an unreadable JSON line.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Telemetry log '{path}' contains an unreadable JSON line.", ex);
+        }
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadTailLinesAsync(string path, int take, CancellationToken cancellationToken)
+    {
+        List<string> lines = [];
+        await using FileStream stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        if (stream.Length == 0)
+        {
+            return lines;
+        }
+
+        long position = stream.Length;
+        byte[] buffer = new byte[4096];
+        StringBuilder reversed = new();
+        bool skippedTrailingNewline = false;
+
+        while (position > 0 && lines.Count < take)
+        {
+            int bytesToRead = (int)Math.Min(buffer.Length, position);
+            position -= bytesToRead;
+            stream.Position = position;
+            int read = await stream.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken);
+
+            for (int index = read - 1; index >= 0; index--)
+            {
+                char current = (char)buffer[index];
+                if (current == '\n')
+                {
+                    if (!skippedTrailingNewline && reversed.Length == 0)
+                    {
+                        skippedTrailingNewline = true;
+                        continue;
+                    }
+
+                    AddCompletedLine(lines, reversed);
+                    if (lines.Count >= take)
+                    {
+                        break;
+                    }
+
+                    skippedTrailingNewline = true;
+                }
+                else
+                {
+                    reversed.Append(current);
+                }
+            }
+        }
+
+        if (lines.Count < take && reversed.Length > 0)
+        {
+            AddCompletedLine(lines, reversed);
+        }
+
+        return lines;
+    }
+
+    private static void AddCompletedLine(List<string> lines, StringBuilder reversed)
+    {
+        if (reversed.Length == 0)
+        {
+            return;
+        }
+
+        char[] chars = new char[reversed.Length];
+        for (int i = 0; i < reversed.Length; i++)
+        {
+            chars[i] = reversed[reversed.Length - 1 - i];
+        }
+
+        string line = new string(chars).TrimEnd('\r');
+        reversed.Clear();
+        if (!string.IsNullOrWhiteSpace(line))
+        {
+            lines.Add(line);
+        }
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor
@@ -95,6 +95,16 @@
                 </AuthorizeView>
 
                 <div class="app-nav-item">
+                    <NavLink class="app-nav-link" href="telemetry">
+                        <span class="app-nav-icon">P</span>
+                        <span class="app-nav-copy">
+                            <span class="app-nav-title">PKCS#11 Telemetry</span>
+                            <span class="app-nav-caption">Redacted device/slot/mechanism traces</span>
+                        </span>
+                    </NavLink>
+                </div>
+
+                <div class="app-nav-item">
                     <NavLink class="app-nav-link" href="sessions">
                         <span class="app-nav-icon">T</span>
                         <span class="app-nav-copy">

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Home.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Home.razor
@@ -154,6 +154,7 @@ else
                             {
                                 <a class="btn btn-outline-dark" href="lab">PKCS#11 Lab</a>
                             }
+                            <a class="btn btn-outline-secondary" href="telemetry">PKCS#11 Telemetry</a>
                             <a class="btn btn-outline-secondary" href="sessions">Sessions</a>
                             <a class="btn btn-outline-secondary" href="audit">Audit Logs</a>
                         </div>
@@ -190,6 +191,7 @@ else
                         {
                             <li>Use <a href="lab">PKCS#11 Lab</a> for diagnostics and controlled experiments instead of ad-hoc raw PKCS#11 shelling.</li>
                         }
+                        <li>If a device/slot/mechanism path misbehaves, open <a href="telemetry">PKCS#11 Telemetry</a> to correlate redacted PKCS#11 calls before assuming the higher-level workflow is at fault.</li>
                     </ol>
                 </div>
             </div>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryView.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryView.cs
@@ -1,0 +1,139 @@
+using System.Globalization;
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Web.Components.Pages;
+
+public static class Pkcs11TelemetryView
+{
+    public static IReadOnlyList<AdminPkcs11TelemetryEntry> Apply(
+        IReadOnlyList<AdminPkcs11TelemetryEntry> items,
+        string? searchText,
+        string? deviceFilter,
+        string? slotFilter,
+        string? operationFilter,
+        string? mechanismFilter,
+        string statusFilter,
+        string timeRangeFilter,
+        DateTimeOffset nowUtc)
+    {
+        IEnumerable<AdminPkcs11TelemetryEntry> query = items;
+
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            string term = searchText.Trim();
+            query = query.Where(item =>
+                Contains(item.DeviceName, term)
+                || Contains(item.OperationName, term)
+                || Contains(item.NativeOperationName, term)
+                || Contains(item.Status, term)
+                || Contains(item.ReturnValue, term)
+                || Contains(item.ExceptionType, term)
+                || Contains(FormatDecimal(item.SlotId), term)
+                || Contains(FormatDecimal(item.SessionHandle), term)
+                || Contains(FormatMechanism(item.MechanismType), term)
+                || item.Fields.Any(field =>
+                    Contains(field.Name, term)
+                    || Contains(field.Classification, term)
+                    || Contains(field.Value, term)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(deviceFilter))
+        {
+            query = query.Where(item => string.Equals(item.DeviceName, deviceFilter, StringComparison.Ordinal));
+        }
+
+        if (!string.IsNullOrWhiteSpace(slotFilter))
+        {
+            string slotTerm = slotFilter.Trim();
+            query = query.Where(item => MatchesNumericFilter(item.SlotId, slotTerm));
+        }
+
+        if (!string.IsNullOrWhiteSpace(operationFilter))
+        {
+            query = query.Where(item => string.Equals(item.OperationName, operationFilter, StringComparison.Ordinal));
+        }
+
+        if (!string.IsNullOrWhiteSpace(mechanismFilter))
+        {
+            string mechanismTerm = mechanismFilter.Trim();
+            query = query.Where(item => MatchesNumericFilter(item.MechanismType, mechanismTerm));
+        }
+
+        query = statusFilter.ToLowerInvariant() switch
+        {
+            "success" => query.Where(IsSuccess),
+            "non-success" => query.Where(item => !IsSuccess(item)),
+            "returned-false" => query.Where(item => string.Equals(item.Status, "ReturnedFalse", StringComparison.Ordinal)),
+            "failed" => query.Where(item => string.Equals(item.Status, "Failed", StringComparison.Ordinal)),
+            _ => query
+        };
+
+        DateTimeOffset? threshold = timeRangeFilter.ToLowerInvariant() switch
+        {
+            "1h" => nowUtc.AddHours(-1),
+            "6h" => nowUtc.AddHours(-6),
+            "24h" => nowUtc.AddHours(-24),
+            "7d" => nowUtc.AddDays(-7),
+            _ => null
+        };
+
+        if (threshold.HasValue)
+        {
+            query = query.Where(item => item.TimestampUtc >= threshold.Value);
+        }
+
+        return query
+            .OrderByDescending(item => item.TimestampUtc)
+            .ThenBy(item => item.DeviceName, StringComparer.Ordinal)
+            .ThenBy(item => item.OperationName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public static bool IsSuccess(AdminPkcs11TelemetryEntry item)
+        => string.Equals(item.Status, "Succeeded", StringComparison.Ordinal);
+
+    public static string GetStatusBadgeClass(AdminPkcs11TelemetryEntry item)
+        => item.Status switch
+        {
+            "Succeeded" => "text-bg-success",
+            "ReturnedFalse" => "text-bg-warning",
+            _ => "text-bg-danger"
+        };
+
+    public static string FormatMechanism(ulong? value)
+        => value.HasValue ? $"0x{value.Value:X}" : "—";
+
+    public static string FormatDecimal(ulong? value)
+        => value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "—";
+
+    private static bool MatchesNumericFilter(ulong? value, string filter)
+    {
+        if (!value.HasValue)
+        {
+            return false;
+        }
+
+        if (TryParseNumericFilter(filter, out ulong parsed))
+        {
+            return value.Value == parsed;
+        }
+
+        string decimalText = value.Value.ToString(CultureInfo.InvariantCulture);
+        string hexText = FormatMechanism(value);
+        return decimalText.Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || hexText.Contains(filter, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryParseNumericFilter(string filter, out ulong value)
+    {
+        if (filter.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return ulong.TryParse(filter.AsSpan(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+        }
+
+        return ulong.TryParse(filter, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool Contains(string? value, string term)
+        => value?.Contains(term, StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
@@ -1,0 +1,342 @@
+@page "/telemetry"
+@attribute [Authorize(Policy = AdminRoles.Viewer)]
+@using Pkcs11Wrapper.Admin.Application.Models
+@inject HsmAdminService Admin
+
+<PageTitle>PKCS#11 Telemetry</PageTitle>
+
+<section class="page-hero page-hero-audit">
+    <div class="page-hero-copy">
+        <div class="page-eyebrow">PKCS#11 visibility</div>
+        <h1>PKCS#11 Telemetry</h1>
+        <p class="page-lead">Admin host'un wrapper üzerinden yaptığı PKCS#11 çağrılarının redacted telemetry görünümü. Buradaki olaylar intentionally safe tutulur: PIN, payload, wrapped blobs ve secret-bearing attributes bu yüzeye yazılmaz.</p>
+        <div class="page-hero-tags">
+            <span class="page-tag">Redacted only</span>
+            <span class="page-tag">Device / slot filters</span>
+            <span class="page-tag">Mechanism correlation</span>
+            <span class="page-tag">Failure review</span>
+        </div>
+    </div>
+    <div class="page-hero-side">
+        <div class="hero-panel">
+            <div class="hero-panel-title">Capture scope</div>
+            <div class="hero-panel-value">Latest @_loadWindowSize events</div>
+            <div class="hero-panel-copy">The viewer reads the newest admin-hosted PKCS#11 telemetry window so operators can isolate a device, slot, mechanism, or failing operation quickly.</div>
+        </div>
+        <div class="hero-panel">
+            <div class="hero-panel-title">Safety posture</div>
+            <div class="hero-panel-value">Redaction enforced</div>
+            <div class="hero-panel-copy">Only the wrapper's already-redacted field stream is persisted here. Raw exception messages are intentionally not stored in this viewer.</div>
+        </div>
+    </div>
+</section>
+
+<div class="alert alert-info">
+    <div class="fw-semibold">Safe telemetry surface</div>
+    <div class="small">Search and filter the redacted PKCS#11 event stream by device, slot, operation, mechanism, status, and recent time window. Use <a href="audit">Audit Logs</a> when you need actor/action traceability; use this page when you need PKCS#11 call context.</div>
+</div>
+
+<div class="row g-3 mb-3">
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Loaded events</div>
+                <div class="display-6 metric-meta">@_entries.Count</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Filtered events</div>
+                <div class="display-6 metric-meta">@FilteredEntries.Count</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Non-success</div>
+                <div class="display-6 metric-meta">@FilteredEntries.Count(entry => !Pkcs11TelemetryView.IsSuccess(entry))</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Devices in window</div>
+                <div class="display-6 metric-meta">@AvailableDevices.Count</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
+    <div class="card-body row g-3 align-items-end">
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <button class="btn btn-primary" @onclick="LoadAsync">Refresh</button>
+        </div>
+        <div class="col-xl-4 col-lg-5 col-md-6">
+            <label class="form-label">Search</label>
+            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="device, native op, return value, field..." />
+        </div>
+        <div class="col-xl-2 col-lg-4 col-md-6">
+            <label class="form-label">Device</label>
+            <select class="form-select" @bind="_deviceFilter" @bind:after="OnFiltersChanged">
+                <option value="">All devices</option>
+                @foreach (string device in AvailableDevices)
+                {
+                    <option value="@device">@device</option>
+                }
+            </select>
+        </div>
+        <div class="col-xl-2 col-lg-4 col-md-6">
+            <label class="form-label">Operation</label>
+            <select class="form-select" @bind="_operationFilter" @bind:after="OnFiltersChanged">
+                <option value="">All operations</option>
+                @foreach (string operation in AvailableOperations)
+                {
+                    <option value="@operation">@operation</option>
+                }
+            </select>
+        </div>
+        <div class="col-xl-2 col-lg-4 col-md-6">
+            <label class="form-label">Status</label>
+            <select class="form-select" @bind="_statusFilter" @bind:after="OnFiltersChanged">
+                <option value="all">All statuses</option>
+                <option value="success">Success only</option>
+                <option value="non-success">Non-success</option>
+                <option value="returned-false">Returned false</option>
+                <option value="failed">Failed</option>
+            </select>
+        </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Slot</label>
+            <input class="form-control" @bind="_slotFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="decimal or hex" />
+        </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Mechanism</label>
+            <input class="form-control" @bind="_mechanismFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="0x1082 or 4226" />
+        </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Time range</label>
+            <select class="form-select" @bind="_timeRangeFilter" @bind:after="OnFiltersChanged">
+                <option value="all">All loaded</option>
+                <option value="1h">Last hour</option>
+                <option value="6h">Last 6 hours</option>
+                <option value="24h">Last 24 hours</option>
+                <option value="7d">Last 7 days</option>
+            </select>
+        </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Page size</label>
+            <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChanged">
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+                <option value="200">200</option>
+            </select>
+        </div>
+    </div>
+</div>
+
+@if (_entries.Count == 0)
+{
+    <div class="empty-state">No PKCS#11 telemetry has been captured yet.</div>
+}
+else if (FilteredEntries.Count == 0)
+{
+    <div class="empty-state">No PKCS#11 telemetry matched the current filters.</div>
+}
+else
+{
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+        <div class="small text-muted">
+            Showing @CurrentRangeStart-@CurrentRangeEnd of @FilteredEntries.Count filtered event(s) from the latest @_entries.Count loaded item(s).
+        </div>
+        <div class="small text-muted">Page @CurrentPageIndex of @TotalPages</div>
+    </div>
+
+    <div class="table-responsive table-shell">
+        <table class="table table-striped align-middle">
+            <thead>
+                <tr>
+                    <th>When</th>
+                    <th>Device</th>
+                    <th>Operation</th>
+                    <th>Slot</th>
+                    <th>Mechanism</th>
+                    <th>Status</th>
+                    <th>Duration</th>
+                    <th>Details</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (AdminPkcs11TelemetryEntry entry in CurrentPageEntries)
+                {
+                    <tr>
+                        <td><span class="table-pill table-pill-code">@entry.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span></td>
+                        <td>
+                            <div class="fw-semibold">@entry.DeviceName</div>
+                            <div class="small text-muted">@entry.DeviceId</div>
+                        </td>
+                        <td>
+                            <div class="fw-semibold">@entry.OperationName</div>
+                            <div class="small text-muted">@(string.IsNullOrWhiteSpace(entry.NativeOperationName) ? "managed wrapper" : entry.NativeOperationName)</div>
+                        </td>
+                        <td>
+                            <div>@Pkcs11TelemetryView.FormatDecimal(entry.SlotId)</div>
+                            <div class="small text-muted">session @Pkcs11TelemetryView.FormatDecimal(entry.SessionHandle)</div>
+                        </td>
+                        <td><span class="table-pill table-pill-code">@Pkcs11TelemetryView.FormatMechanism(entry.MechanismType)</span></td>
+                        <td>
+                            <span class="badge @Pkcs11TelemetryView.GetStatusBadgeClass(entry)">@entry.Status</span>
+                        </td>
+                        <td><span class="table-pill table-pill-code">@entry.DurationMilliseconds.ToString("F2") ms</span></td>
+                        <td>
+                            <div class="d-flex flex-wrap gap-1 mb-1">
+                                @if (!string.IsNullOrWhiteSpace(entry.ReturnValue))
+                                {
+                                    <span class="table-pill table-pill-code">rv=@entry.ReturnValue</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(entry.ExceptionType))
+                                {
+                                    <span class="table-pill">exception=@entry.ExceptionType</span>
+                                }
+                            </div>
+
+                            @if (entry.Fields.Length == 0)
+                            {
+                                <div class="small text-muted">No extra redacted fields.</div>
+                            }
+                            else
+                            {
+                                <div class="d-flex flex-wrap gap-1 small">
+                                    @foreach (AdminPkcs11TelemetryField field in entry.Fields)
+                                    {
+                                        <span class="table-pill">@field.Name</span>
+                                        <span class="table-pill table-pill-code">@field.Classification</span>
+                                        <span class="text-muted me-2">@(string.IsNullOrWhiteSpace(field.Value) ? "[suppressed]" : field.Value)</span>
+                                    }
+                                </div>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3">
+        <button class="btn btn-outline-secondary" @onclick="PreviousPage" disabled="@(CurrentPageIndex <= 1)">Previous</button>
+        <div class="small text-muted">Page @CurrentPageIndex / @TotalPages</div>
+        <button class="btn btn-outline-secondary" @onclick="NextPage" disabled="@(CurrentPageIndex >= TotalPages)">Next</button>
+    </div>
+}
+
+@code {
+    private const int _loadWindowSize = 500;
+
+    private IReadOnlyList<AdminPkcs11TelemetryEntry> _entries = [];
+    private string _searchText = string.Empty;
+    private string _deviceFilter = string.Empty;
+    private string _slotFilter = string.Empty;
+    private string _operationFilter = string.Empty;
+    private string _mechanismFilter = string.Empty;
+    private string _statusFilter = "all";
+    private string _timeRangeFilter = "24h";
+    private int _pageSize = 25;
+    private int _pageIndex = 1;
+
+    private IReadOnlyList<string> AvailableDevices => _entries
+        .Select(entry => entry.DeviceName)
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(device => device, StringComparer.Ordinal)
+        .ToArray();
+
+    private IReadOnlyList<string> AvailableOperations => _entries
+        .Select(entry => entry.OperationName)
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(operation => operation, StringComparer.Ordinal)
+        .ToArray();
+
+    private IReadOnlyList<AdminPkcs11TelemetryEntry> FilteredEntries => Pkcs11TelemetryView.Apply(
+        _entries,
+        _searchText,
+        _deviceFilter,
+        _slotFilter,
+        _operationFilter,
+        _mechanismFilter,
+        _statusFilter,
+        _timeRangeFilter,
+        DateTimeOffset.UtcNow);
+
+    private IReadOnlyList<AdminPkcs11TelemetryEntry> CurrentPageEntries
+    {
+        get
+        {
+            IReadOnlyList<AdminPkcs11TelemetryEntry> filtered = FilteredEntries;
+            int pageIndex = GetSafePageIndex(filtered.Count);
+            return filtered.Skip((pageIndex - 1) * _pageSize).Take(_pageSize).ToArray();
+        }
+    }
+
+    private int CurrentPageIndex => GetSafePageIndex(FilteredEntries.Count);
+
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling(FilteredEntries.Count / (double)_pageSize));
+
+    private int CurrentRangeStart => FilteredEntries.Count == 0 ? 0 : ((CurrentPageIndex - 1) * _pageSize) + 1;
+
+    private int CurrentRangeEnd => Math.Min(CurrentPageIndex * _pageSize, FilteredEntries.Count);
+
+    protected override Task OnInitializedAsync() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _entries = await Admin.GetPkcs11TelemetryAsync(_loadWindowSize);
+        _pageIndex = 1;
+    }
+
+    private Task OnFiltersChanged()
+    {
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task OnPageSizeChanged()
+    {
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private void PreviousPage()
+    {
+        if (_pageIndex > 1)
+        {
+            _pageIndex--;
+        }
+    }
+
+    private void NextPage()
+    {
+        if (_pageIndex < TotalPages)
+        {
+            _pageIndex++;
+        }
+    }
+
+    private int GetSafePageIndex(int filteredCount)
+    {
+        int totalPages = Math.Max(1, (int)Math.Ceiling(filteredCount / (double)_pageSize));
+        if (_pageIndex < 1)
+        {
+            _pageIndex = 1;
+        }
+        else if (_pageIndex > totalPages)
+        {
+            _pageIndex = totalPages;
+        }
+
+        return _pageIndex;
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddDataProtection()
     .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(adminStorage.DataRoot, "keys")));
 builder.Services.AddSingleton<IDeviceProfileStore, JsonDeviceProfileStore>();
 builder.Services.AddSingleton<IAuditLogStore, JsonLineAuditLogStore>();
+builder.Services.AddSingleton<IPkcs11TelemetryStore, JsonLinePkcs11TelemetryStore>();
 builder.Services.AddSingleton<ProtectedPinStore>();
 builder.Services.AddSingleton<Pkcs11LabTemplateStore>();
 builder.Services.AddSingleton<IDeviceDependencyCleanupService, DeviceDependencyCleanupService>();
@@ -57,6 +58,7 @@ builder.Services.AddSingleton(sp => new LocalAdminLoginThrottleService(sp.GetReq
 builder.Services.AddScoped<IAdminActorContext, HttpContextAdminActorContext>();
 builder.Services.AddScoped<IAdminAuthorizationService, HttpContextAdminAuthorizationService>();
 builder.Services.AddScoped<AuditLogService>();
+builder.Services.AddScoped<Pkcs11TelemetryService>();
 builder.Services.AddScoped<LocalAdminSecurityService>();
 builder.Services.AddScoped<LocalAdminLoginService>();
 builder.Services.AddScoped<HsmAdminService>();

--- a/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
@@ -142,11 +142,53 @@ public sealed class JsonStoresTests
         }
     }
 
+    [Fact]
+    public async Task JsonPkcs11TelemetryStoreReturnsNewestWindow()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            JsonLinePkcs11TelemetryStore store = new(new AdminStorageOptions { DataRoot = root });
+            for (int i = 0; i < 20; i++)
+            {
+                await store.AppendAsync(CreateTelemetry($"Operation-{i}", DateTimeOffset.UtcNow.AddSeconds(i)));
+            }
+
+            IReadOnlyList<AdminPkcs11TelemetryEntry> logs = await store.ReadRecentAsync(3);
+
+            Assert.Equal(3, logs.Count);
+            Assert.Equal("Operation-19", logs[0].OperationName);
+            Assert.Equal("Operation-17", logs[^1].OperationName);
+            Assert.Equal("Masked", Assert.Single(logs[0].Fields).Classification);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static HsmDeviceProfile CreateProfile(string name)
         => new(Guid.NewGuid(), name, "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
 
     private static AdminAuditLogEntry CreateAudit(string target, string details, DateTimeOffset timestamp)
         => new(Guid.NewGuid(), timestamp, "tester", ["admin"], "cookie", "Device", "Add", target, "Success", details, 0, null, string.Empty, "127.0.0.1", "trace-1", "test-agent", Environment.MachineName);
+
+    private static AdminPkcs11TelemetryEntry CreateTelemetry(string operationName, DateTimeOffset timestamp)
+        => new(
+            Guid.NewGuid(),
+            timestamp,
+            Guid.NewGuid(),
+            "Primary",
+            operationName,
+            $"C_{operationName}",
+            "Succeeded",
+            1.23,
+            "CKR_OK",
+            1,
+            2,
+            0x1082,
+            null,
+            [new AdminPkcs11TelemetryField("credential.pin", "Masked", "set(len=8)")]);
 
     private static string CreateTempDirectory()
     {

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryServiceTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryServiceTests.cs
@@ -1,0 +1,98 @@
+using Pkcs11Wrapper.Admin.Application.Abstractions;
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Application.Services;
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class Pkcs11TelemetryServiceTests
+{
+    [Fact]
+    public void ListenerMapsOperationEventsIntoTelemetryEntries()
+    {
+        RecordingStore store = new();
+        Pkcs11TelemetryService service = new(store);
+        HsmDeviceProfile device = new(Guid.NewGuid(), "Primary", "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+        IPkcs11OperationTelemetryListener listener = service.CreateListener(device);
+        Pkcs11OperationTelemetryEvent operationEvent = new(
+            "SignData",
+            "C_Sign",
+            Pkcs11OperationTelemetryStatus.Failed,
+            TimeSpan.FromMilliseconds(12.5),
+            null,
+            7,
+            19,
+            0x00000040,
+            new InvalidOperationException("should not be persisted"))
+        {
+            Fields =
+            [
+                new Pkcs11OperationTelemetryField("input", Pkcs11TelemetryFieldClassification.LengthOnly, "len=32"),
+                new Pkcs11OperationTelemetryField("credential.pin", Pkcs11TelemetryFieldClassification.Masked, "set(len=8)")
+            ]
+        };
+
+        listener.OnOperationCompleted(in operationEvent);
+
+        AdminPkcs11TelemetryEntry entry = Assert.Single(store.Entries);
+        Assert.Equal(device.Id, entry.DeviceId);
+        Assert.Equal("Primary", entry.DeviceName);
+        Assert.Equal("SignData", entry.OperationName);
+        Assert.Equal("C_Sign", entry.NativeOperationName);
+        Assert.Equal("Failed", entry.Status);
+        Assert.Equal((ulong)7, entry.SlotId);
+        Assert.Equal((ulong)19, entry.SessionHandle);
+        Assert.Equal((ulong)0x00000040, entry.MechanismType);
+        Assert.Equal("InvalidOperationException", entry.ExceptionType);
+        Assert.DoesNotContain(entry.Fields, field => field.Value?.Contains("should not be persisted", StringComparison.Ordinal) == true);
+        Assert.Contains(entry.Fields, field => field.Name == "input" && field.Classification == "LengthOnly" && field.Value == "len=32");
+        Assert.Contains(entry.Fields, field => field.Name == "credential.pin" && field.Classification == "Masked" && field.Value == "set(len=8)");
+    }
+
+    [Fact]
+    public void ListenerSwallowsStoreFailures()
+    {
+        Pkcs11TelemetryService service = new(new ThrowingStore());
+        HsmDeviceProfile device = new(Guid.NewGuid(), "Primary", "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+        IPkcs11OperationTelemetryListener listener = service.CreateListener(device);
+        Pkcs11OperationTelemetryEvent operationEvent = new(
+            "OpenSession",
+            "C_OpenSession",
+            Pkcs11OperationTelemetryStatus.Succeeded,
+            TimeSpan.FromMilliseconds(1),
+            null,
+            1,
+            2,
+            null,
+            null);
+
+        listener.OnOperationCompleted(in operationEvent);
+    }
+
+    private sealed class RecordingStore : IPkcs11TelemetryStore
+    {
+        private readonly List<AdminPkcs11TelemetryEntry> _entries = [];
+
+        public IReadOnlyList<AdminPkcs11TelemetryEntry> Entries => _entries;
+
+        public Task AppendAsync(AdminPkcs11TelemetryEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([.. _entries.TakeLast(take).Reverse()]);
+    }
+
+    private sealed class ThrowingStore : IPkcs11TelemetryStore
+    {
+        public Task AppendAsync(AdminPkcs11TelemetryEntry entry, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("boom");
+
+        public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([]);
+    }
+}

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryViewTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryViewTests.cs
@@ -1,0 +1,107 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Web.Components.Pages;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class Pkcs11TelemetryViewTests
+{
+    [Fact]
+    public void ApplyFiltersByDeviceSlotOperationMechanismStatusAndTimeRange()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        AdminPkcs11TelemetryEntry[] items =
+        [
+            CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-40), slotId: 1, mechanismType: null),
+            CreateEntry("Primary", "SignData", "Failed", now.AddMinutes(-10), slotId: 2, mechanismType: 0x00000040, returnValue: "CKR_GENERAL_ERROR"),
+            CreateEntry("Backup", "SignData", "ReturnedFalse", now.AddDays(-2), slotId: 2, mechanismType: 0x00000040)
+        ];
+
+        IReadOnlyList<AdminPkcs11TelemetryEntry> filtered = Pkcs11TelemetryView.Apply(
+            items,
+            searchText: null,
+            deviceFilter: "Primary",
+            slotFilter: "2",
+            operationFilter: "SignData",
+            mechanismFilter: "0x40",
+            statusFilter: "failed",
+            timeRangeFilter: "24h",
+            nowUtc: now);
+
+        AdminPkcs11TelemetryEntry match = Assert.Single(filtered);
+        Assert.Equal("Primary", match.DeviceName);
+        Assert.Equal("SignData", match.OperationName);
+        Assert.Equal("Failed", match.Status);
+    }
+
+    [Fact]
+    public void ApplySearchesReturnValuesAndRedactedFields()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        AdminPkcs11TelemetryEntry[] items =
+        [
+            CreateEntry(
+                "Primary",
+                "Login",
+                "Failed",
+                now.AddMinutes(-2),
+                slotId: 3,
+                mechanismType: null,
+                returnValue: "CKR_PIN_INCORRECT",
+                fields:
+                [
+                    new AdminPkcs11TelemetryField("credential.pin", "Masked", "set(len=8)")
+                ]),
+            CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-1), slotId: 3, mechanismType: null)
+        ];
+
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byReturnValue = Pkcs11TelemetryView.Apply(items, "pin_incorrect", null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byFieldName = Pkcs11TelemetryView.Apply(items, "credential.pin", null, null, null, null, "all", "all", now);
+
+        Assert.Single(byReturnValue);
+        Assert.Single(byFieldName);
+        Assert.Equal("Login", byReturnValue[0].OperationName);
+        Assert.Equal("Login", byFieldName[0].OperationName);
+    }
+
+    [Fact]
+    public void NonSuccessFilterIncludesReturnedFalseAndFailed()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        AdminPkcs11TelemetryEntry[] items =
+        [
+            CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-3), slotId: 1, mechanismType: null),
+            CreateEntry("Primary", "FindObjects", "ReturnedFalse", now.AddMinutes(-2), slotId: 1, mechanismType: null),
+            CreateEntry("Primary", "SignData", "Failed", now.AddMinutes(-1), slotId: 1, mechanismType: 0x40)
+        ];
+
+        IReadOnlyList<AdminPkcs11TelemetryEntry> filtered = Pkcs11TelemetryView.Apply(items, null, null, null, null, null, "non-success", "all", now);
+
+        Assert.Equal(2, filtered.Count);
+        Assert.DoesNotContain(filtered, item => item.Status == "Succeeded");
+    }
+
+    private static AdminPkcs11TelemetryEntry CreateEntry(
+        string deviceName,
+        string operationName,
+        string status,
+        DateTimeOffset timestampUtc,
+        ulong? slotId,
+        ulong? mechanismType,
+        string? returnValue = null,
+        AdminPkcs11TelemetryField[]? fields = null)
+        => new(
+            Guid.NewGuid(),
+            timestampUtc,
+            Guid.NewGuid(),
+            deviceName,
+            operationName,
+            $"C_{operationName}",
+            status,
+            4.2,
+            returnValue,
+            slotId,
+            99,
+            mechanismType,
+            status == "Failed" ? "Pkcs11Exception" : null,
+            fields ?? []);
+}


### PR DESCRIPTION
## Summary
Add a PKCS#11 telemetry viewer to the admin panel.

## Included work
- dedicated PKCS#11 telemetry store/pipeline for the admin app
- `/telemetry` viewer page with filtering, paging, and safe redacted field rendering
- nav/dashboard integration
- docs/status updates and test coverage

## Notes
- keeps PKCS#11 telemetry separate from actor/action audit logs
- persists only redacted wrapper telemetry fields plus safe context

## Closes
Closes #40
