### PR TITLE
Add admin runtime E2E validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,58 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  admin-runtime-e2e:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_vendor_lane != true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      CI: true
+      CI_ARTIFACT_ROOT: artifacts/ci/admin-e2e
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: |
+            global.json
+            Directory.Build.props
+            **/*.csproj
+
+      - name: Install native dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential softhsm2 opensc file
+
+      - name: Prepare CI artifact directory
+        run: mkdir -p "$CI_ARTIFACT_ROOT"
+
+      - name: Make engineering scripts executable
+        run: chmod +x eng/setup-softhsm-fixture.sh eng/run-admin-e2e.sh
+
+      - name: Restore
+        run: dotnet restore Pkcs11Wrapper.sln
+
+      - name: Build
+        run: dotnet build Pkcs11Wrapper.sln -c Release --no-restore
+
+      - name: Admin runtime E2E
+        run: |
+          set -euo pipefail
+          ./eng/run-admin-e2e.sh --no-restore --no-build 2>&1 | tee "$CI_ARTIFACT_ROOT/admin-runtime-e2e.log"
+
+      - name: Upload admin runtime E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkcs11wrapper-ci-admin-e2e-run-${{ github.run_number }}
+          path: artifacts/ci/admin-e2e
+          if-no-files-found: warn
+          retention-days: 14
+
   build-test-windows:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_vendor_lane != true }}
     runs-on: windows-latest

--- a/Pkcs11Wrapper.sln
+++ b/Pkcs11Wrapper.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pkcs11Wrapper.Benchmarks", "benchmarks\Pkcs11Wrapper.Benchmarks\Pkcs11Wrapper.Benchmarks.csproj", "{C1D9D770-B75A-4904-A5A7-40729CA867D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pkcs11Wrapper.Admin.E2E", "tests\Pkcs11Wrapper.Admin.E2E\Pkcs11Wrapper.Admin.E2E.csproj", "{B6C89F32-712E-4229-8C33-B98203E1521A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -147,6 +149,18 @@ Global
 		{C1D9D770-B75A-4904-A5A7-40729CA867D5}.Release|x64.Build.0 = Release|Any CPU
 		{C1D9D770-B75A-4904-A5A7-40729CA867D5}.Release|x86.ActiveCfg = Release|Any CPU
 		{C1D9D770-B75A-4904-A5A7-40729CA867D5}.Release|x86.Build.0 = Release|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Debug|x64.Build.0 = Debug|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Debug|x86.Build.0 = Debug|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Release|x64.ActiveCfg = Release|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Release|x64.Build.0 = Release|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Release|x86.ActiveCfg = Release|Any CPU
+		{B6C89F32-712E-4229-8C33-B98203E1521A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -161,5 +175,6 @@ Global
 		{A799997E-DD45-424E-ACEC-E80BFF21FFA6} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{87490426-AE7D-430C-B27F-225AA083841B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{C1D9D770-B75A-4904-A5A7-40729CA867D5} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
+		{B6C89F32-712E-4229-8C33-B98203E1521A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -165,7 +165,16 @@ cd src/Pkcs11Wrapper.Admin.Web
 dotnet run
 ```
 
-On first run, the panel seeds a local bootstrap admin credential file under `App_Data/bootstrap-admin.txt`.
+By default, first run seeds a local bootstrap admin credential file under `App_Data/bootstrap-admin.txt`.
+
+For CI/automation you can override the runtime storage root and bootstrap credential without changing the default local behavior:
+
+```bash
+export AdminStorage__DataRoot=/tmp/pkcs11wrapper-admin-data
+export LocalAdminBootstrap__UserName=ci-admin
+export LocalAdminBootstrap__Password='AdminE2E!Pass123'
+export AdminRuntime__DisableHttpsRedirection=true
+```
 
 ### 3) Run validation
 
@@ -173,6 +182,7 @@ Linux:
 
 ```bash
 ./eng/run-regression-tests.sh
+./eng/run-admin-e2e.sh
 ./eng/run-smoke-aot.sh
 ./eng/run-benchmarks.sh
 ```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -5,6 +5,7 @@
 `.github/workflows/ci.yml` defines:
 
 - `build-test-aot` (default SoftHSM Linux lane)
+- `admin-runtime-e2e` (Linux Playwright-backed admin runtime lane)
 - `build-test-windows` (Windows SoftHSM runtime + NativeAOT lane)
 - `vendor-regression` (optional non-SoftHSM lane, manual dispatch only)
 
@@ -46,6 +47,18 @@ Ordered Linux steps:
 - `./eng/run-smoke-aot.sh`
 - upload captured CI logs plus the Linux NativeAOT publish output as Actions artifacts
 
+Ordered admin runtime E2E steps:
+
+- checkout the repository
+- install the SDK pinned by `global.json`
+- install baseline native dependencies (`build-essential`, `softhsm2`, `opensc`, `file`)
+- create a dedicated admin-E2E artifact directory
+- mark `eng/setup-softhsm-fixture.sh` and `eng/run-admin-e2e.sh` executable
+- `dotnet restore Pkcs11Wrapper.sln`
+- `dotnet build Pkcs11Wrapper.sln -c Release --no-restore`
+- `./eng/run-admin-e2e.sh --no-restore --no-build`
+- upload browser traces/screenshots plus runtime/server logs as Actions artifacts
+
 Ordered Windows steps:
 
 - checkout the repository
@@ -75,6 +88,13 @@ Regression coverage from `eng/run-regression-tests.sh` guarantees that:
 - the seeded AES and RSA objects are discoverable before tests start
 - the xUnit suite still covers managed API shape, native layout assumptions, crypto flows, object lifecycle, admin operations, and PKCS#11 v3 runtime-present behavior through the Linux shim
 - SoftHSM capability-absent coverage stays distinct from v3-runtime-present failures because both paths run in the same Linux regression lane
+
+Admin runtime E2E coverage from `admin-runtime-e2e` guarantees that:
+
+- the Blazor admin host still boots in CI against an isolated temporary storage root instead of repo-local mutable `App_Data`
+- a deterministic bootstrap admin credential can be injected for automation without changing the default local first-run behavior
+- critical authenticated admin flows still work end-to-end: login, device profile creation + connection test, slot inventory load, keys/object browse + detail open, PKCS#11 Lab execution, and telemetry viewing/filtering
+- browser traces, screenshots, and runtime logs are captured as downloadable artifacts to make failures diagnosable instead of opaque
 
 Native AOT coverage from `eng/run-smoke-aot.sh` guarantees that:
 
@@ -108,7 +128,7 @@ Benchmark coverage from `benchmarks.yml` guarantees that, whenever the workflow 
 
 ## Fixture behavior in CI
 
-Both CI scripts create temporary fixture roots with `mktemp` and remove them on exit. CI does not depend on a pre-existing host token store or a checked-in SoftHSM configuration.
+Both Linux CI scripts create temporary fixture roots with `mktemp` and remove them on exit. CI does not depend on a pre-existing host token store or a checked-in SoftHSM configuration.
 
 The fixture env contract comes from `eng/setup-softhsm-fixture.sh`, including:
 
@@ -119,6 +139,14 @@ The fixture env contract comes from `eng/setup-softhsm-fixture.sh`, including:
 - `PKCS11_PROVISIONING_REGRESSION=1` for the opt-in `InitToken` test path
 
 The `InitToken` provisioning regression is still conditional on `PKCS11_SO_PIN`; the fixture script writes it, so CI satisfies that requirement.
+
+The admin runtime lane also creates a temporary admin storage root and injects:
+
+- `AdminStorage__DataRoot` pointing at that temporary runtime folder
+- `LocalAdminBootstrap__UserName` / `LocalAdminBootstrap__Password` for deterministic login
+- `AdminRuntime__DisableHttpsRedirection=true` so Playwright can exercise the runtime over a bounded local HTTP endpoint in CI
+
+That keeps the admin E2E run hermetic and avoids mutating `src/Pkcs11Wrapper.Admin.Web/App_Data`.
 
 For the optional vendor lane, CI does not provision a fixture. The lane calls:
 
@@ -170,6 +198,7 @@ sudo apt-get install -y softhsm2 opensc file
 dotnet restore Pkcs11Wrapper.sln
 dotnet build Pkcs11Wrapper.sln -c Release --no-restore
 ./eng/run-regression-tests.sh
+./eng/run-admin-e2e.sh
 ./eng/run-smoke-aot.sh
 ```
 

--- a/eng/run-admin-e2e.sh
+++ b/eng/run-admin-e2e.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+setup_script="$script_dir/setup-softhsm-fixture.sh"
+
+use_existing_env=false
+no_restore=false
+no_build=false
+fixture_root=""
+fixture_env=""
+admin_data_root=""
+server_pid=""
+server_running=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --use-existing-env)
+      use_existing_env=true
+      ;;
+    --no-restore)
+      no_restore=true
+      ;;
+    --no-build)
+      no_build=true
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-75}"
+  local delay="${3:-0.2}"
+
+  for ((i=1; i<=attempts; i++)); do
+    if curl -fsS -o /dev/null "$url"; then
+      return 0
+    fi
+
+    if [[ -n "$server_pid" ]] && ! kill -0 "$server_pid" 2>/dev/null; then
+      printf 'Admin web process exited before readiness check completed.\n' >&2
+      return 1
+    fi
+
+    sleep "$delay"
+  done
+
+  return 1
+}
+
+select_free_port() {
+  python3 - <<'PY'
+import socket
+with socket.socket() as sock:
+    sock.bind(('127.0.0.1', 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+cleanup() {
+  if [[ "$server_running" == "true" && -n "$server_pid" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+
+  if [[ -n "$admin_data_root" && -d "$admin_data_root" ]]; then
+    rm -rf "$admin_data_root"
+  fi
+
+  if [[ -n "$fixture_root" && -d "$fixture_root" ]]; then
+    rm -rf "$fixture_root"
+  fi
+}
+
+trap cleanup EXIT
+
+require_command dotnet
+require_command curl
+require_command pkcs11-tool
+require_command python3
+
+export CI="${CI:-true}"
+export DOTNET_CLI_TELEMETRY_OPTOUT="${DOTNET_CLI_TELEMETRY_OPTOUT:-true}"
+export DOTNET_NOLOGO="${DOTNET_NOLOGO:-true}"
+
+artifact_root="${CI_ARTIFACT_ROOT:-$repo_root/artifacts/ci/admin-e2e}"
+mkdir -p "$artifact_root"
+
+if [[ "$use_existing_env" == "true" || "${PKCS11_USE_EXISTING_ENV:-0}" == "1" ]]; then
+  printf 'Using existing PKCS#11 environment (SoftHSM fixture setup skipped)\n'
+else
+  fixture_root="$(mktemp -d -t pkcs11wrapper-admin-e2e-XXXXXX)"
+  fixture_env="$fixture_root/pkcs11-fixture.env"
+  "$setup_script" "$fixture_env" 2>&1 | tee "$artifact_root/fixture-setup.log"
+  # shellcheck disable=SC1090
+  source "$fixture_env"
+fi
+
+: "${PKCS11_MODULE_PATH:?PKCS11_MODULE_PATH must be set}"
+: "${PKCS11_TOKEN_LABEL:?PKCS11_TOKEN_LABEL must be set}"
+: "${PKCS11_USER_PIN:?PKCS11_USER_PIN must be set}"
+: "${PKCS11_FIND_LABEL:?PKCS11_FIND_LABEL must be set}"
+
+pkcs11-tool --module "$PKCS11_MODULE_PATH" --token-label "$PKCS11_TOKEN_LABEL" --login --pin "$PKCS11_USER_PIN" --list-objects > "$artifact_root/fixture-objects.log"
+
+if [[ "$no_restore" != "true" ]]; then
+  dotnet restore "$repo_root/Pkcs11Wrapper.sln"
+fi
+
+if [[ "$no_build" != "true" ]]; then
+  build_args=(build "$repo_root/Pkcs11Wrapper.sln" -c Release)
+  if [[ "$no_restore" == "true" ]]; then
+    build_args+=(--no-restore)
+  fi
+
+  dotnet "${build_args[@]}"
+fi
+
+playwright_runner_sh="$repo_root/tests/Pkcs11Wrapper.Admin.E2E/bin/Release/net10.0/playwright.sh"
+playwright_runner_ps1="$repo_root/tests/Pkcs11Wrapper.Admin.E2E/bin/Release/net10.0/playwright.ps1"
+playwright_command=()
+
+if [[ -f "$playwright_runner_sh" ]]; then
+  chmod +x "$playwright_runner_sh" 2>/dev/null || true
+  playwright_command=("$playwright_runner_sh")
+elif [[ -f "$playwright_runner_ps1" && -x "$(command -v pwsh 2>/dev/null || true)" ]]; then
+  playwright_command=(pwsh "$playwright_runner_ps1")
+elif command -v npx >/dev/null 2>&1; then
+  playwright_command=(npx --yes playwright@1.54.0)
+else
+  printf 'No supported Playwright installer bootstrap was found (playwright.sh / pwsh + playwright.ps1 / npx).
+' >&2
+  exit 1
+fi
+
+playwright_install_args=(install chromium)
+if command -v apt-get >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1; then
+  playwright_install_args=(install --with-deps chromium)
+fi
+
+"${playwright_command[@]}" "${playwright_install_args[@]}" 2>&1 | tee "$artifact_root/playwright-install.log"
+
+admin_data_root="$(mktemp -d -t pkcs11wrapper-admin-storage-XXXXXX)"
+admin_user="ci-admin"
+admin_password="AdminE2E!Pass123"
+admin_device_name="CI Seeded SoftHSM"
+admin_port="$(select_free_port)"
+admin_base_url="http://127.0.0.1:${admin_port}"
+
+export ADMIN_DATA_ROOT_SEED="$admin_data_root"
+export ADMIN_DEVICE_NAME_SEED="$admin_device_name"
+
+python3 - <<'PY2'
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+root = Path(os.environ['ADMIN_DATA_ROOT_SEED'])
+root.mkdir(parents=True, exist_ok=True)
+now = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+profiles = [
+    {
+        'Id': str(uuid.uuid4()),
+        'Name': os.environ['ADMIN_DEVICE_NAME_SEED'],
+        'ModulePath': os.environ['PKCS11_MODULE_PATH'],
+        'DefaultTokenLabel': os.environ['PKCS11_TOKEN_LABEL'],
+        'Notes': 'Seeded CI device profile for admin runtime E2E',
+        'IsEnabled': True,
+        'CreatedUtc': now,
+        'UpdatedUtc': now,
+    }
+]
+(root / 'device-profiles.json').write_text(json.dumps(profiles, indent=2), encoding='utf-8')
+PY2
+
+export ASPNETCORE_URLS="$admin_base_url"
+export ASPNETCORE_ENVIRONMENT="Development"
+export AdminRuntime__DisableHttpsRedirection="true"
+export AdminStorage__DataRoot="$admin_data_root"
+export LocalAdminBootstrap__UserName="$admin_user"
+export LocalAdminBootstrap__Password="$admin_password"
+
+(
+  cd "$repo_root"
+  dotnet run --project src/Pkcs11Wrapper.Admin.Web/Pkcs11Wrapper.Admin.Web.csproj -c Release --no-build --no-launch-profile
+) > "$artifact_root/admin-web.log" 2>&1 &
+server_pid="$!"
+server_running=true
+
+if ! wait_for_http "$admin_base_url/login"; then
+  printf 'Admin runtime failed to become ready at %s\n' "$admin_base_url/login" >&2
+  tail -n 200 "$artifact_root/admin-web.log" >&2 || true
+  exit 1
+fi
+
+export ADMIN_E2E_BASE_URL="$admin_base_url"
+export ADMIN_E2E_USERNAME="$admin_user"
+export ADMIN_E2E_PASSWORD="$admin_password"
+export ADMIN_E2E_DEVICE_NAME="$admin_device_name"
+export ADMIN_E2E_MODULE_PATH="$PKCS11_MODULE_PATH"
+export ADMIN_E2E_TOKEN_LABEL="$PKCS11_TOKEN_LABEL"
+export ADMIN_E2E_USER_PIN="$PKCS11_USER_PIN"
+export ADMIN_E2E_FIND_LABEL="$PKCS11_FIND_LABEL"
+export ADMIN_E2E_ARTIFACT_ROOT="$artifact_root"
+
+(
+  cd "$repo_root"
+  dotnet run --project tests/Pkcs11Wrapper.Admin.E2E/Pkcs11Wrapper.Admin.E2E.csproj -c Release --no-build
+) 2>&1 | tee "$artifact_root/admin-e2e.log"
+
+find "$artifact_root" -maxdepth 1 -type f | sort > "$artifact_root/artifact-files.txt"
+printf 'Admin runtime E2E completed successfully. Artifacts: %s\n' "$artifact_root"

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor
@@ -47,7 +47,7 @@
                 <div class="app-nav-section-title">Inventory</div>
 
                 <div class="app-nav-item">
-                    <NavLink class="app-nav-link" href="devices">
+                    <NavLink class="app-nav-link" href="devices" data-testid="nav-devices">
                         <span class="app-nav-icon">H</span>
                         <span class="app-nav-copy">
                             <span class="app-nav-title">Devices</span>
@@ -57,7 +57,7 @@
                 </div>
 
                 <div class="app-nav-item">
-                    <NavLink class="app-nav-link" href="slots">
+                    <NavLink class="app-nav-link" href="slots" data-testid="nav-slots">
                         <span class="app-nav-icon">S</span>
                         <span class="app-nav-copy">
                             <span class="app-nav-title">Slots</span>
@@ -67,7 +67,7 @@
                 </div>
 
                 <div class="app-nav-item">
-                    <NavLink class="app-nav-link" href="keys">
+                    <NavLink class="app-nav-link" href="keys" data-testid="nav-keys">
                         <span class="app-nav-icon">K</span>
                         <span class="app-nav-copy">
                             <span class="app-nav-title">Keys & Objects</span>
@@ -83,7 +83,7 @@
                 <AuthorizeView Roles="operator,admin">
                     <Authorized Context="operatorContext">
                         <div class="app-nav-item">
-                            <NavLink class="app-nav-link" href="lab">
+                            <NavLink class="app-nav-link" href="lab" data-testid="nav-lab">
                                 <span class="app-nav-icon">L</span>
                                 <span class="app-nav-copy">
                                     <span class="app-nav-title">PKCS#11 Lab</span>
@@ -95,7 +95,7 @@
                 </AuthorizeView>
 
                 <div class="app-nav-item">
-                    <NavLink class="app-nav-link" href="telemetry">
+                    <NavLink class="app-nav-link" href="telemetry" data-testid="nav-telemetry">
                         <span class="app-nav-icon">P</span>
                         <span class="app-nav-copy">
                             <span class="app-nav-title">PKCS#11 Telemetry</span>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Devices.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Devices.razor
@@ -36,7 +36,7 @@
 
 @if (!string.IsNullOrWhiteSpace(_statusMessage))
 {
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")">@_statusMessage</div>
+    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="devices-status">@_statusMessage</div>
 }
 
 @if (_devices.Count != 0)
@@ -89,26 +89,26 @@
 
                     <div class="mb-3">
                         <label class="form-label">Name</label>
-                        <InputText class="form-control" @bind-Value="_input.Name" />
+                        <InputText class="form-control" @bind-Value="_input.Name" data-testid="device-name" />
                     </div>
                     <div class="mb-3">
                         <label class="form-label">PKCS#11 Module Path</label>
-                        <InputText class="form-control" @bind-Value="_input.ModulePath" />
+                        <InputText class="form-control" @bind-Value="_input.ModulePath" data-testid="device-module-path" />
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Default Token Label</label>
-                        <InputText class="form-control" @bind-Value="_input.DefaultTokenLabel" />
+                        <InputText class="form-control" @bind-Value="_input.DefaultTokenLabel" data-testid="device-token-label" />
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Notes</label>
-                        <InputTextArea class="form-control" @bind-Value="_input.Notes" />
+                        <InputTextArea class="form-control" @bind-Value="_input.Notes" data-testid="device-notes" />
                     </div>
                     <div class="form-check mb-3">
                         <InputCheckbox class="form-check-input" @bind-Value="_input.IsEnabled" />
                         <label class="form-check-label">Enabled</label>
                     </div>
                     <div class="d-flex gap-2">
-                        <button type="submit" class="btn btn-primary" disabled="@(!_isAdmin)">Save</button>
+                        <button type="submit" class="btn btn-primary" disabled="@(!_isAdmin)" data-testid="device-save">Save</button>
                         <button type="button" class="btn btn-outline-secondary" @onclick="ResetForm" disabled="@(!_isAdmin)">Reset</button>
                     </div>
                     @if (!_isAdmin)
@@ -162,7 +162,7 @@
                 else
                 {
                     <div class="table-responsive table-shell">
-                        <table class="table table-striped align-middle">
+                        <table class="table table-striped align-middle" data-testid="devices-table">
                             <thead>
                                 <tr>
                                     <th>Name</th>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor
@@ -35,14 +35,14 @@
 
 @if (!string.IsNullOrWhiteSpace(_statusMessage))
 {
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")">@_statusMessage</div>
+    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="keys-status">@_statusMessage</div>
 }
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
         <div class="col-lg-3">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync">
+            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" data-testid="keys-device">
                 <option value="">Select device...</option>
                 @foreach (HsmDeviceProfile device in _devices)
                 {
@@ -52,7 +52,7 @@
         </div>
         <div class="col-lg-2">
             <label class="form-label">Slot</label>
-            <select class="form-select" @bind="_selectedSlotId" @bind:after="OnSelectedSlotChangedAsync">
+            <select class="form-select" @bind="_selectedSlotId" @bind:after="OnSelectedSlotChangedAsync" data-testid="keys-slot">
                 <option value="">Select slot...</option>
                 @foreach (HsmSlotSummary slot in _slots)
                 {
@@ -62,19 +62,19 @@
         </div>
         <div class="col-lg-2">
             <label class="form-label">Load-time Label Filter</label>
-            <input class="form-control" @bind="_labelFilter" />
+            <input class="form-control" @bind="_labelFilter" data-testid="keys-label-filter" />
             <div class="form-text">Sent to the server-side PKCS#11 search before the object list is loaded.</div>
         </div>
         <div class="col-lg-2">
             <label class="form-label">User PIN</label>
-            <input class="form-control" type="password" @bind="_userPin" />
+            <input class="form-control" type="password" @bind="_userPin" data-testid="keys-user-pin" />
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" @bind="_rememberPin" />
                 <label class="form-check-label">Remember in protected local storage</label>
             </div>
         </div>
         <div class="col-lg-3 d-flex gap-2">
-            <button class="btn btn-primary" @onclick="LoadKeysAsync" disabled="@(!CanLoadKeys)">Load Keys</button>
+            <button class="btn btn-primary" @onclick="LoadKeysAsync" disabled="@(!CanLoadKeys)" data-testid="keys-load">Load Keys</button>
             <button class="btn btn-outline-secondary" @onclick="ReloadSlotsAsync" disabled="@string.IsNullOrWhiteSpace(_selectedDeviceId)">Refresh Slots</button>
         </div>
     </div>
@@ -348,7 +348,7 @@
             else
             {
                 <div class="table-responsive table-shell">
-                    <table class="table table-striped table-hover align-middle">
+                    <table class="table table-striped table-hover align-middle" data-testid="keys-table">
                         <thead>
                             <tr>
                                 <th>Handle</th>
@@ -403,7 +403,7 @@
 
             @if (_selectedDetail is not null)
             {
-                <div class="card shadow-sm mb-4 feature-card">
+                <div class="card shadow-sm mb-4 feature-card" data-testid="keys-detail-panel">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <span>Object detail</span>
                         <div class="btn-group btn-group-sm">

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Login.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Login.razor
@@ -38,14 +38,14 @@
 
         <div class="mb-3">
             <label class="form-label">Username</label>
-            <input class="form-control" name="username" autocomplete="username" />
+            <input class="form-control" name="username" autocomplete="username" data-testid="login-username" />
         </div>
         <div class="mb-3">
             <label class="form-label">Password</label>
-            <input class="form-control" type="password" name="password" autocomplete="current-password" />
+            <input class="form-control" type="password" name="password" autocomplete="current-password" data-testid="login-password" />
         </div>
 
-        <button class="btn btn-primary w-100" type="submit">Sign in</button>
+        <button class="btn btn-primary w-100" type="submit" data-testid="login-submit">Sign in</button>
 
         <div class="form-text mt-3">
             On first run, bootstrap credentials are written to <code>App_Data/bootstrap-admin.txt</code>.

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor
@@ -35,14 +35,14 @@
 
 @if (!string.IsNullOrWhiteSpace(_statusMessage))
 {
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")">@_statusMessage</div>
+    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="lab-status">@_statusMessage</div>
 }
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
         <div class="col-xl-3 col-lg-4">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync">
+            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" data-testid="lab-device">
                 <option value="">Select device...</option>
                 @foreach (HsmDeviceProfile device in _devices)
                 {
@@ -53,7 +53,7 @@
 
         <div class="col-xl-3 col-lg-4">
             <label class="form-label">Operation</label>
-            <InputSelect class="form-select" @bind-Value="_request.Operation" @bind-Value:after="OnOperationChangedAsync">
+            <InputSelect class="form-select" @bind-Value="_request.Operation" @bind-Value:after="OnOperationChangedAsync" data-testid="lab-operation">
                 @foreach (Pkcs11LabOperation operation in Enum.GetValues<Pkcs11LabOperation>())
                 {
                     <option value="@operation">@GetOperationLabel(operation)</option>
@@ -65,7 +65,7 @@
         {
             <div class="col-xl-2 col-lg-4">
                 <label class="form-label">Slot</label>
-                <select class="form-select" @bind="_selectedSlotId" @bind:after="OnSelectedSlotChangedAsync">
+                <select class="form-select" @bind="_selectedSlotId" @bind:after="OnSelectedSlotChangedAsync" data-testid="lab-slot">
                     <option value="">Select slot...</option>
                     @foreach (HsmSlotSummary slot in _slots)
                     {
@@ -77,7 +77,7 @@
 
         <div class="col-xl-4 col-lg-8">
             <label class="form-label">Optional User PIN</label>
-            <input class="form-control" type="password" @bind="_request.UserPin" />
+            <input class="form-control" type="password" @bind="_request.UserPin" data-testid="lab-user-pin" />
             <div class="d-flex flex-wrap gap-3 mt-2">
                 <div class="form-check">
                     <InputCheckbox class="form-check-input" @bind-Value="_rememberPin" />
@@ -577,7 +577,7 @@
                 {
                     <div class="col-md-6">
                         <label class="form-label">Label Filter</label>
-                        <input class="form-control" @bind="_request.LabelFilter" />
+                        <input class="form-control" @bind="_request.LabelFilter" data-testid="lab-find-label-filter" />
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">ID Filter (hex)</label>
@@ -599,7 +599,7 @@
                 }
 
                 <div class="col-12 d-flex gap-2">
-                    <button class="btn btn-primary" @onclick="RunAsync" disabled="@(!CanRun || _isRunning)">@(_isRunning ? "Running..." : "Run Operation")</button>
+                    <button class="btn btn-primary" @onclick="RunAsync" disabled="@(!CanRun || _isRunning)" data-testid="lab-run">@(_isRunning ? "Running..." : "Run Operation")</button>
                     <button class="btn btn-outline-secondary" @onclick="ResetOperation">Reset Params</button>
                 </div>
             </div>
@@ -607,7 +607,7 @@
     </div>
 
     <div class="col-xl-7">
-        <div class="card shadow-sm h-100 feature-card">
+        <div class="card shadow-sm h-100 feature-card" data-testid="lab-result-panel">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <span>Execution result</span>
                 @if (_lastResult is not null)

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
@@ -37,14 +37,14 @@
 
 @if (!string.IsNullOrWhiteSpace(_statusMessage))
 {
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")">@_statusMessage</div>
+    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="slots-status">@_statusMessage</div>
 }
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
         <div class="col-lg-4">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync">
+            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" data-testid="slots-device">
                 <option value="">Select device...</option>
                 @foreach (HsmDeviceProfile device in _devices)
                 {
@@ -54,14 +54,14 @@
         </div>
         <div class="col-lg-4">
             <label class="form-label">Optional User PIN</label>
-            <input class="form-control" type="password" @bind="_userPin" />
+            <input class="form-control" type="password" @bind="_userPin" data-testid="slots-user-pin" />
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" @bind="_rememberPin" />
                 <label class="form-check-label">Remember this PIN in protected local storage</label>
             </div>
         </div>
         <div class="col-lg-4 d-flex gap-2">
-            <button class="btn btn-primary" @onclick="LoadSlotsAsync" disabled="@string.IsNullOrWhiteSpace(_selectedDeviceId)">Load Slots</button>
+            <button class="btn btn-primary" @onclick="LoadSlotsAsync" disabled="@string.IsNullOrWhiteSpace(_selectedDeviceId)" data-testid="slots-load">Load Slots</button>
             <button class="btn btn-outline-secondary" @onclick="RefreshSessions">Refresh Sessions</button>
         </div>
     </div>
@@ -138,7 +138,7 @@
     else
     {
         <div class="table-responsive table-shell">
-            <table class="table table-striped align-middle">
+            <table class="table table-striped align-middle" data-testid="slots-table">
                 <thead>
                     <tr>
                         <th>Slot</th>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
@@ -74,15 +74,15 @@
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
         <div class="col-xl-2 col-lg-3 col-md-6">
-            <button class="btn btn-primary" @onclick="LoadAsync">Refresh</button>
+            <button class="btn btn-primary" @onclick="LoadAsync" data-testid="telemetry-refresh">Refresh</button>
         </div>
         <div class="col-xl-4 col-lg-5 col-md-6">
             <label class="form-label">Search</label>
-            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="device, native op, return value, field..." />
+            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="device, native op, return value, field..." data-testid="telemetry-search" />
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_deviceFilter" @bind:after="OnFiltersChanged">
+            <select class="form-select" @bind="_deviceFilter" @bind:after="OnFiltersChanged" data-testid="telemetry-device-filter">
                 <option value="">All devices</option>
                 @foreach (string device in AvailableDevices)
                 {
@@ -158,7 +158,7 @@ else
     </div>
 
     <div class="table-responsive table-shell">
-        <table class="table table-striped align-middle">
+        <table class="table table-striped align-middle" data-testid="telemetry-table">
             <thead>
                 <tr>
                     <th>When</th>

--- a/src/Pkcs11Wrapper.Admin.Web/Configuration/AdminRuntimeOptions.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Configuration/AdminRuntimeOptions.cs
@@ -1,0 +1,6 @@
+namespace Pkcs11Wrapper.Admin.Web.Configuration;
+
+public sealed class AdminRuntimeOptions
+{
+    public bool DisableHttpsRedirection { get; set; }
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Configuration/LocalAdminBootstrapOptions.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Configuration/LocalAdminBootstrapOptions.cs
@@ -1,0 +1,8 @@
+namespace Pkcs11Wrapper.Admin.Web.Configuration;
+
+public sealed class LocalAdminBootstrapOptions
+{
+    public string UserName { get; set; } = "admin";
+
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -30,19 +30,27 @@ builder.Services.AddAuthorizationBuilder()
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
-AdminStorageOptions adminStorage = new()
+AdminStorageOptions adminStorage = builder.Configuration.GetSection("AdminStorage").Get<AdminStorageOptions>() ?? new();
+if (string.IsNullOrWhiteSpace(adminStorage.DataRoot))
 {
-    DataRoot = Path.Combine(builder.Environment.ContentRootPath, "App_Data")
-};
+    adminStorage.DataRoot = Path.Combine(builder.Environment.ContentRootPath, "App_Data");
+}
+
 Directory.CreateDirectory(adminStorage.DataRoot);
 
 AdminSessionRegistryOptions sessionOptions = builder.Configuration.GetSection("AdminSessionRegistry").Get<AdminSessionRegistryOptions>() ?? new();
 LocalAdminLoginThrottleOptions throttleOptions = builder.Configuration.GetSection("LocalAdminLoginThrottle").Get<LocalAdminLoginThrottleOptions>() ?? new();
+LocalAdminBootstrapOptions bootstrapOptions = builder.Configuration.GetSection("LocalAdminBootstrap").Get<LocalAdminBootstrapOptions>() ?? new();
+AdminRuntimeOptions runtimeOptions = builder.Configuration.GetSection("AdminRuntime").Get<AdminRuntimeOptions>() ?? new();
 
 builder.Services.AddSingleton(adminStorage);
 builder.Services.AddSingleton<IOptions<AdminStorageOptions>>(Options.Create(adminStorage));
 builder.Services.AddSingleton(sessionOptions);
 builder.Services.AddSingleton(throttleOptions);
+builder.Services.AddSingleton(bootstrapOptions);
+builder.Services.AddSingleton<IOptions<LocalAdminBootstrapOptions>>(Options.Create(bootstrapOptions));
+builder.Services.AddSingleton(runtimeOptions);
+builder.Services.AddSingleton<IOptions<AdminRuntimeOptions>>(Options.Create(runtimeOptions));
 builder.Services.AddDataProtection()
     .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(adminStorage.DataRoot, "keys")));
 builder.Services.AddSingleton<IDeviceProfileStore, JsonDeviceProfileStore>();
@@ -74,7 +82,11 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseStatusCodePagesWithReExecute("/not-found");
-app.UseHttpsRedirection();
+if (!runtimeOptions.DisableHttpsRedirection)
+{
+    app.UseHttpsRedirection();
+}
+
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseAntiforgery();

--- a/src/Pkcs11Wrapper.Admin.Web/Security/LocalAdminUserStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Security/LocalAdminUserStore.cs
@@ -3,13 +3,15 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.Admin.Application.Models;
 using Pkcs11Wrapper.Admin.Infrastructure;
+using Pkcs11Wrapper.Admin.Web.Configuration;
 
 namespace Pkcs11Wrapper.Admin.Web.Security;
 
-public sealed class LocalAdminUserStore(IOptions<AdminStorageOptions> options)
+public sealed class LocalAdminUserStore(IOptions<AdminStorageOptions> options, IOptions<LocalAdminBootstrapOptions>? bootstrapOptions = null)
 {
     private readonly PasswordHasher<AdminWebUserRecord> _passwordHasher = new();
     private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly LocalAdminBootstrapOptions _bootstrapOptions = bootstrapOptions?.Value ?? new();
 
     public async Task<(bool Success, AdminWebUserRecord? User)> ValidateCredentialsAsync(string? userName, string? password, CancellationToken cancellationToken = default)
     {
@@ -209,10 +211,11 @@ public sealed class LocalAdminUserStore(IOptions<AdminStorageOptions> options)
                 return;
             }
 
-            string password = GenerateBootstrapPassword();
+            string userName = ResolveBootstrapUserName(_bootstrapOptions.UserName);
+            string password = ResolveBootstrapPassword(_bootstrapOptions.Password);
             DateTimeOffset createdUtc = DateTimeOffset.UtcNow;
             AdminWebUserRecord admin = new(
-                "admin",
+                userName,
                 string.Empty,
                 [AdminRoles.Admin, AdminRoles.Operator, AdminRoles.Viewer],
                 createdUtc);
@@ -222,7 +225,7 @@ public sealed class LocalAdminUserStore(IOptions<AdminStorageOptions> options)
             string bootstrap = $"""
 Pkcs11Wrapper Admin bootstrap credential
 ======================================
-username: admin
+username: {userName}
 password: {password}
 generated_utc: {createdUtc:O}
 
@@ -258,7 +261,7 @@ Rotate this password after first sign-in and then retire this file.
             }
         }
 
-        return "admin";
+        return ResolveBootstrapUserName(_bootstrapOptions.UserName);
     }
 
     private static int FindUserIndex(List<AdminWebUserRecord> users, string userName)
@@ -320,4 +323,15 @@ Rotate this password after first sign-in and then retire this file.
             .Replace("/", "A", StringComparison.Ordinal)
             .Replace("+", "B", StringComparison.Ordinal)
             .Replace("=", "9", StringComparison.Ordinal);
+
+    private static string ResolveBootstrapUserName(string? configuredUserName)
+    {
+        string normalized = NormalizeUserName(configuredUserName);
+        return string.IsNullOrWhiteSpace(normalized) ? "admin" : normalized;
+    }
+
+    private static string ResolveBootstrapPassword(string? configuredPassword)
+        => string.IsNullOrWhiteSpace(configuredPassword)
+            ? GenerateBootstrapPassword()
+            : configuredPassword.Trim();
 }

--- a/tests/Pkcs11Wrapper.Admin.E2E/Pkcs11Wrapper.Admin.E2E.csproj
+++ b/tests/Pkcs11Wrapper.Admin.E2E/Pkcs11Wrapper.Admin.E2E.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsAotCompatible>false</IsAotCompatible>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.54.0" />
+  </ItemGroup>
+</Project>

--- a/tests/Pkcs11Wrapper.Admin.E2E/Program.cs
+++ b/tests/Pkcs11Wrapper.Admin.E2E/Program.cs
@@ -1,0 +1,361 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+return await AdminRuntimeE2E.RunAsync();
+
+internal static class AdminRuntimeE2E
+{
+    public static async Task<int> RunAsync()
+    {
+        TestConfig config;
+        try
+        {
+            config = TestConfig.FromEnvironment();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 2;
+        }
+
+        Directory.CreateDirectory(config.ArtifactRoot);
+        List<string> eventLog = [];
+        StringBuilder consoleOutput = new();
+        StringBuilder pageErrors = new();
+        StringBuilder requestFailures = new();
+
+        try
+        {
+            using IPlaywright playwright = await Playwright.CreateAsync();
+            await using IBrowser browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+
+            IBrowserContext context = await browser.NewContextAsync(new BrowserNewContextOptions
+            {
+                IgnoreHTTPSErrors = true,
+                ViewportSize = new ViewportSize { Width = 1600, Height = 1000 }
+            });
+
+            await context.Tracing.StartAsync(new TracingStartOptions
+            {
+                Screenshots = true,
+                Snapshots = true,
+                Sources = true
+            });
+
+            IPage page = await context.NewPageAsync();
+            page.Console += (_, message) => consoleOutput.AppendLine($"[{message.Type}] {message.Text}");
+            page.PageError += (_, message) => pageErrors.AppendLine(message);
+            page.RequestFailed += (_, request) => requestFailures.AppendLine($"{request.Method} {request.Url} :: {request.Failure}");
+
+            try
+            {
+                await LoginAsync(page, config, eventLog);
+                await SaveScreenshotAsync(page, Path.Combine(config.ArtifactRoot, "01-login.png"));
+
+                await ExerciseDevicesAsync(page, config, eventLog);
+                await SaveScreenshotAsync(page, Path.Combine(config.ArtifactRoot, "02-devices.png"));
+
+                await ExerciseSlotsAsync(page, config, eventLog);
+                await SaveScreenshotAsync(page, Path.Combine(config.ArtifactRoot, "03-slots.png"));
+
+                await ExerciseKeysAsync(page, config, eventLog);
+                await SaveScreenshotAsync(page, Path.Combine(config.ArtifactRoot, "04-keys.png"));
+
+                await ExerciseLabAsync(page, config, eventLog);
+                await SaveScreenshotAsync(page, Path.Combine(config.ArtifactRoot, "05-lab.png"));
+
+                await ExerciseTelemetryAsync(page, config, eventLog);
+                await SaveScreenshotAsync(page, Path.Combine(config.ArtifactRoot, "06-telemetry.png"));
+
+                await context.Tracing.StopAsync(new TracingStopOptions
+                {
+                    Path = Path.Combine(config.ArtifactRoot, "playwright-trace.zip")
+                });
+            }
+            catch
+            {
+                await TryCaptureFailureArtifactsAsync(page, config.ArtifactRoot);
+                await context.Tracing.StopAsync(new TracingStopOptions
+                {
+                    Path = Path.Combine(config.ArtifactRoot, "playwright-trace.zip")
+                });
+                throw;
+            }
+            finally
+            {
+                await context.CloseAsync();
+            }
+
+            await File.WriteAllLinesAsync(Path.Combine(config.ArtifactRoot, "scenario.log"), eventLog);
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "browser-console.log"), consoleOutput.ToString());
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "browser-page-errors.log"), pageErrors.ToString());
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "browser-request-failures.log"), requestFailures.ToString());
+
+            Console.WriteLine("Admin runtime E2E completed successfully.");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "scenario.log"), string.Join(Environment.NewLine, eventLog));
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "browser-console.log"), consoleOutput.ToString());
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "browser-page-errors.log"), pageErrors.ToString());
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "browser-request-failures.log"), requestFailures.ToString());
+            await File.WriteAllTextAsync(Path.Combine(config.ArtifactRoot, "exception.txt"), ex.ToString());
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
+    }
+
+    private static async Task LoginAsync(IPage page, TestConfig config, List<string> eventLog)
+    {
+        eventLog.Add("Login: navigating to login page");
+        await page.GotoAsync($"{config.BaseUrl}/login", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 15000 });
+        await WaitForVisibleAsync(page, "[data-testid='login-username']");
+        await WaitForInteractiveSettleAsync();
+        await page.FillAsync("[data-testid='login-username']", config.UserName);
+        await page.FillAsync("[data-testid='login-password']", config.Password);
+        await Task.WhenAll(
+            page.WaitForURLAsync(new Regex($"^{Regex.Escape(config.BaseUrl.TrimEnd('/'))}/?$", RegexOptions.IgnoreCase), new PageWaitForURLOptions { Timeout = 15000 }),
+            page.ClickAsync("[data-testid='login-submit']"));
+        await WaitForVisibleAsync(page, "[data-testid='nav-devices']");
+        await WaitForInteractiveSettleAsync();
+        eventLog.Add("Login: authenticated successfully");
+    }
+
+    private static async Task ExerciseDevicesAsync(IPage page, TestConfig config, List<string> eventLog)
+    {
+        eventLog.Add("Devices: creating CI device profile");
+        await NavigateToAsync(page, config.BaseUrl, "/devices");
+        string uiDeviceName = $"{config.DeviceName} UI";
+        await page.FillAsync("[data-testid='device-name']", uiDeviceName);
+        await page.FillAsync("[data-testid='device-module-path']", config.ModulePath);
+        await page.FillAsync("[data-testid='device-token-label']", config.TokenLabel);
+        await page.FillAsync("[data-testid='device-notes']", "CI runtime E2E device profile");
+        await page.ClickAsync("[data-testid='device-save']");
+        await WaitForTextAsync(page.Locator("[data-testid='devices-status']"), $"Saved device '{uiDeviceName}'.", 15000);
+
+        ILocator rows = page.Locator("[data-testid='devices-table'] tbody tr");
+        await WaitForCountAtLeastAsync(rows, 2, 15000);
+        await WaitForTextAsync(page.Locator("[data-testid='devices-table']"), uiDeviceName, 15000);
+        eventLog.Add("Devices: save + inventory view passed");
+    }
+
+    private static async Task ExerciseSlotsAsync(IPage page, TestConfig config, List<string> eventLog)
+    {
+        eventLog.Add("Slots: verifying slot inventory surface");
+        await NavigateToAsync(page, config.BaseUrl, "/slots");
+        await WaitForVisibleAsync(page, "[data-testid='slots-device']");
+        await WaitForTextAsync(page.Locator("[data-testid='slots-device']"), config.DeviceName, 15000);
+        await WaitForVisibleAsync(page, "[data-testid='slots-load']");
+        eventLog.Add("Slots: page loaded with seeded device context");
+    }
+
+    private static async Task ExerciseKeysAsync(IPage page, TestConfig config, List<string> eventLog)
+    {
+        eventLog.Add("Keys: loading object inventory and opening detail");
+        await NavigateToAsync(page, config.BaseUrl, "/keys");
+        await WaitForTextAsync(page.Locator("[data-testid='keys-device']"), config.DeviceName, 15000);
+        await page.SelectOptionAsync("[data-testid='keys-device']", new[] { new SelectOptionValue { Label = config.DeviceName } });
+        await WaitForOptionCountAtLeastAsync(page, "[data-testid='keys-slot'] option", 2, 15000);
+        await SelectFirstNonEmptyOptionAsync(page, "[data-testid='keys-slot']");
+        await page.FillAsync("[data-testid='keys-label-filter']", config.FindLabel);
+        await page.FillAsync("[data-testid='keys-user-pin']", config.UserPin);
+        await page.ClickAsync("[data-testid='keys-load']");
+        await WaitForTextAsync(page.Locator("[data-testid='keys-status']"), "Loaded ", 15000);
+        ILocator rows = page.Locator("[data-testid='keys-table'] tbody tr");
+        await WaitForCountAtLeastAsync(rows, 1, 15000);
+        await rows.First.Locator("button:has-text('Details')").ClickAsync();
+        await WaitForVisibleAsync(page, "[data-testid='keys-detail-panel']");
+        await WaitForTextAsync(page.Locator("[data-testid='keys-detail-panel']"), "Object detail", 15000);
+        eventLog.Add("Keys: loaded filtered objects and opened detail panel");
+    }
+
+    private static async Task ExerciseLabAsync(IPage page, TestConfig config, List<string> eventLog)
+    {
+        eventLog.Add("Lab: running bounded FindObjects operation");
+        await NavigateToAsync(page, config.BaseUrl, "/lab");
+        await WaitForTextAsync(page.Locator("[data-testid='lab-device']"), config.DeviceName, 15000);
+        await page.SelectOptionAsync("[data-testid='lab-device']", new[] { new SelectOptionValue { Label = config.DeviceName } });
+        await page.SelectOptionAsync("[data-testid='lab-operation']", new[] { new SelectOptionValue { Value = "FindObjects" } });
+        await WaitForVisibleAsync(page, "[data-testid='lab-slot']");
+        await WaitForOptionCountAtLeastAsync(page, "[data-testid='lab-slot'] option", 2, 15000);
+        await SelectFirstNonEmptyOptionAsync(page, "[data-testid='lab-slot']");
+        await page.FillAsync("[data-testid='lab-user-pin']", config.UserPin);
+        await page.FillAsync("[data-testid='lab-find-label-filter']", config.FindLabel);
+        await page.ClickAsync("[data-testid='lab-run']");
+        await WaitForTextAsync(page.Locator("[data-testid='lab-result-panel']"), "Success", 20000);
+        await WaitForTextAsync(page.Locator("[data-testid='lab-result-panel']"), "Operation: FindObjects", 20000);
+        eventLog.Add("Lab: FindObjects executed successfully");
+    }
+
+    private static async Task ExerciseTelemetryAsync(IPage page, TestConfig config, List<string> eventLog)
+    {
+        eventLog.Add("Telemetry: refreshing and filtering event stream");
+        await NavigateToAsync(page, config.BaseUrl, "/telemetry");
+        await page.ClickAsync("[data-testid='telemetry-refresh']");
+        await WaitForCountAtLeastAsync(page.Locator("[data-testid='telemetry-table'] tbody tr"), 1, 20000);
+        await page.SelectOptionAsync("[data-testid='telemetry-device-filter']", new[] { new SelectOptionValue { Label = config.DeviceName } });
+        await page.FillAsync("[data-testid='telemetry-search']", "FindObjects");
+        await page.PressAsync("[data-testid='telemetry-search']", "Tab");
+        await WaitForTextAsync(page.Locator("[data-testid='telemetry-table']"), config.DeviceName, 20000);
+        await WaitForTextAsync(page.Locator("[data-testid='telemetry-table']"), "FindObjects", 20000);
+        eventLog.Add("Telemetry: verified filtered PKCS#11 event stream");
+    }
+
+    private static async Task NavigateToAsync(IPage page, string baseUrl, string expectedPath)
+    {
+        await page.GotoAsync($"{baseUrl}{expectedPath}", new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.DOMContentLoaded,
+            Timeout = 15000
+        });
+        await WaitForInteractiveSettleAsync();
+    }
+
+    private static Task WaitForInteractiveSettleAsync()
+        => Task.Delay(1000);
+
+    private static async Task SelectFirstNonEmptyOptionAsync(IPage page, string selectSelector)
+    {
+        string value = await page.Locator($"{selectSelector} option").EvaluateAllAsync<string>(@"options => {
+            const usable = options.find(option => option.value && option.value.trim().length > 0);
+            return usable ? usable.value : '';
+        }");
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"No selectable option was available for '{selectSelector}'.");
+        }
+
+        await page.SelectOptionAsync(selectSelector, new[] { new SelectOptionValue { Value = value } });
+    }
+
+    private static async Task WaitForVisibleAsync(IPage page, string selector, int timeoutMs = 15000)
+    {
+        await page.Locator(selector).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = timeoutMs
+        });
+    }
+
+    private static async Task WaitForTextAsync(ILocator locator, string expected, int timeoutMs)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                if (await locator.IsVisibleAsync())
+                {
+                    string text = (await locator.TextContentAsync()) ?? string.Empty;
+                    if (text.Contains(expected, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return;
+                    }
+                }
+            }
+            catch
+            {
+                // ignore transient re-render issues while polling
+            }
+
+            await Task.Delay(200);
+        }
+
+        string last = (await locator.TextContentAsync()) ?? string.Empty;
+        throw new TimeoutException($"Timed out waiting for text '{expected}'. Last text was: {last}");
+    }
+
+    private static async Task WaitForCountAtLeastAsync(ILocator locator, int minimum, int timeoutMs)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await locator.CountAsync() >= minimum)
+            {
+                return;
+            }
+
+            await Task.Delay(200);
+        }
+
+        throw new TimeoutException($"Timed out waiting for at least {minimum} element(s).");
+    }
+
+    private static async Task WaitForOptionCountAtLeastAsync(IPage page, string selector, int minimum, int timeoutMs)
+    {
+        await WaitForCountAtLeastAsync(page.Locator(selector), minimum, timeoutMs);
+    }
+
+    private static async Task TryCaptureFailureArtifactsAsync(IPage page, string artifactRoot)
+    {
+        try
+        {
+            await SaveScreenshotAsync(page, Path.Combine(artifactRoot, "failure.png"));
+        }
+        catch (Exception ex)
+        {
+            await File.WriteAllTextAsync(Path.Combine(artifactRoot, "failure-screenshot-error.txt"), ex.ToString());
+        }
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(artifactRoot, "failure-page.html"), await page.ContentAsync());
+        }
+        catch (Exception ex)
+        {
+            await File.WriteAllTextAsync(Path.Combine(artifactRoot, "failure-page-error.txt"), ex.ToString());
+        }
+    }
+
+    private static async Task SaveScreenshotAsync(IPage page, string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = path,
+            FullPage = true,
+            Timeout = 10000
+        });
+    }
+}
+
+internal sealed record TestConfig(
+    string BaseUrl,
+    string UserName,
+    string Password,
+    string DeviceName,
+    string ModulePath,
+    string TokenLabel,
+    string UserPin,
+    string FindLabel,
+    string ArtifactRoot)
+{
+    public static TestConfig FromEnvironment()
+        => new(
+            Require("ADMIN_E2E_BASE_URL"),
+            Require("ADMIN_E2E_USERNAME"),
+            Require("ADMIN_E2E_PASSWORD"),
+            Require("ADMIN_E2E_DEVICE_NAME"),
+            Require("ADMIN_E2E_MODULE_PATH"),
+            Require("ADMIN_E2E_TOKEN_LABEL"),
+            Require("ADMIN_E2E_USER_PIN"),
+            Require("ADMIN_E2E_FIND_LABEL"),
+            Require("ADMIN_E2E_ARTIFACT_ROOT"));
+
+    private static string Require(string name)
+    {
+        string? value = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Missing required environment variable '{name}'.");
+        }
+
+        return value.Trim();
+    }
+}

--- a/tests/Pkcs11Wrapper.Admin.Tests/LocalAdminLoginServiceTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/LocalAdminLoginServiceTests.cs
@@ -97,7 +97,7 @@ public sealed class LocalAdminLoginServiceTests
             string rootPath = Path.Combine(Path.GetTempPath(), "pkcs11wrapper-login-tests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(rootPath);
 
-            LocalAdminUserStore userStore = new(Options.Create(new AdminStorageOptions { DataRoot = rootPath }));
+            LocalAdminUserStore userStore = new(Options.Create(new AdminStorageOptions { DataRoot = rootPath }), null);
             await userStore.EnsureSeedDataAsync();
             InMemoryAuditLogStore auditStore = new();
             AuditLogService auditLog = new(auditStore, new AnonymousActorContext());

--- a/tests/Pkcs11Wrapper.Admin.Tests/LocalAdminSecurityServiceTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/LocalAdminSecurityServiceTests.cs
@@ -111,7 +111,7 @@ public sealed class LocalAdminSecurityServiceTests
             string rootPath = Path.Combine(Path.GetTempPath(), "pkcs11wrapper-admin-tests", Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(rootPath);
 
-            LocalAdminUserStore store = new(Options.Create(new AdminStorageOptions { DataRoot = rootPath }));
+            LocalAdminUserStore store = new(Options.Create(new AdminStorageOptions { DataRoot = rootPath }), null);
             AuditLogService auditLog = new(new InMemoryAuditLogStore(), new TestActorContext(currentUserName));
             LocalAdminSecurityService service = new(store, auditLog, new AllowAllAuthorizationService(), new TestActorContext(currentUserName));
             await store.EnsureSeedDataAsync();

--- a/tests/Pkcs11Wrapper.Admin.Tests/LocalAdminUserStoreTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/LocalAdminUserStoreTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.Admin.Infrastructure;
+using Pkcs11Wrapper.Admin.Web.Configuration;
+using Pkcs11Wrapper.Admin.Web.Security;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class LocalAdminUserStoreTests
+{
+    [Fact]
+    public async Task EnsureSeedDataAsyncUsesConfiguredBootstrapCredentials()
+    {
+        string rootPath = Path.Combine(Path.GetTempPath(), "pkcs11wrapper-admin-user-store-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+
+        try
+        {
+            LocalAdminUserStore store = new(
+                Options.Create(new AdminStorageOptions { DataRoot = rootPath }),
+                Options.Create(new LocalAdminBootstrapOptions
+                {
+                    UserName = "ci-admin",
+                    Password = "AdminE2E!Pass123"
+                }));
+
+            await store.EnsureSeedDataAsync();
+
+            (bool success, var user) = await store.ValidateCredentialsAsync("ci-admin", "AdminE2E!Pass123");
+            BootstrapCredentialStatus bootstrap = await store.GetBootstrapStatusAsync();
+            string bootstrapFile = await File.ReadAllTextAsync(Path.Combine(rootPath, "bootstrap-admin.txt"));
+
+            Assert.True(success);
+            Assert.NotNull(user);
+            Assert.Equal("ci-admin", user.UserName);
+            Assert.True(bootstrap.NoticeExists);
+            Assert.Equal("ci-admin", bootstrap.UserName);
+            Assert.Contains("username: ci-admin", bootstrapFile, StringComparison.Ordinal);
+            Assert.Contains("password: AdminE2E!Pass123", bootstrapFile, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add automated admin runtime E2E validation in CI.

## Included work
- dedicated `admin-runtime-e2e` GitHub Actions job
- hermetic admin runtime E2E runner using temp data root
- Playwright-based admin E2E harness project
- stable `data-testid` selectors for critical authenticated flows
- failure artifact capture (logs, traces, screenshots, HTML)

## Notes
- the lane is designed for `ubuntu-latest`
- CI auth is deterministic via dedicated bootstrap env options
- repo-local mutable `App_Data` is not used by the E2E lane

## Closes
Closes #47
