### PR TITLE
Add telemetry retention, export, and correlation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 - key/object browsing, detail, edit, copy, generate, import, and destroy flows
 - tracked session visibility and control (`login` / `logout` / `cancel` / `close-all` + invalidation visibility)
 - PKCS#11 Lab diagnostics, crypto experiments, object workflows, and scenario replay helpers
-- PKCS#11 telemetry viewer with redacted device / slot / mechanism / status filtering
+- PKCS#11 telemetry viewer with redacted device / slot / mechanism / status filtering, bounded retention/rotation, safe export, and audit correlation links
 - protected PIN cache + append-only chained audit log integrity
 
 ## Platform & validation status
@@ -256,7 +256,7 @@ Current capabilities include:
 - protected PIN caching for repeat operations
 - device-profile configuration export/import
 - PKCS#11 Lab for diagnostics, crypto operations, object inspection, wrap/unwrap, raw attribute reads, and scenario replay
-- PKCS#11 telemetry viewer for redacted wrapper-level operation traces and failure correlation
+- PKCS#11 telemetry viewer for redacted wrapper-level operation traces, bounded retention/export control, and audit correlation
 - append-only chained audit entries with integrity verification
 
 ## Documentation map
@@ -275,6 +275,7 @@ Current capabilities include:
 - [docs/smoke.md](docs/smoke.md) - smoke sample behavior and troubleshooting
 - [docs/telemetry-redaction.md](docs/telemetry-redaction.md) - PKCS#11 telemetry redaction policy
 - [docs/telemetry-integrations.md](docs/telemetry-integrations.md) - `ILogger` and `ActivitySource` / OpenTelemetry integration guidance
+- [docs/admin-telemetry-operations.md](docs/admin-telemetry-operations.md) - admin telemetry retention, rotation, export, and audit-correlation operations
 - [docs/release.md](docs/release.md) - release checklist and packaging discipline
 - [docs/versioning.md](docs/versioning.md) - centralized versioning model and tag strategy
 - [docs/admin-panel-roadmap.md](docs/admin-panel-roadmap.md) - admin panel roadmap

--- a/docs/admin-telemetry-operations.md
+++ b/docs/admin-telemetry-operations.md
@@ -1,0 +1,111 @@
+# Admin telemetry operations
+
+The admin panel persists **only the wrapper's already-redacted PKCS#11 telemetry stream**. This document covers the operational lifecycle controls added around that data so telemetry remains useful without becoming an unbounded storage sink.
+
+## What is stored
+
+The admin telemetry store keeps redacted PKCS#11 operation entries under the admin data root:
+
+- active file: `pkcs11-telemetry.jsonl`
+- rotated archives: `pkcs11-telemetry-YYYYMMDD-HHMMSSfff.jsonl`
+
+Each entry includes the existing PKCS#11 context (operation, native call, slot, session handle, mechanism, duration, return value, exception type, redacted fields) plus admin-side correlation hints when available:
+
+- admin actor name
+- authentication type
+- request/session trace identifier
+- correlation id / activity trace id
+
+The viewer uses those fields to link back into matching audit trails.
+
+## Retention and rotation
+
+Telemetry rotation is **size-based** and retention is **age/count-based**.
+
+### Rotation behavior
+
+Before appending a new event, the store checks whether the active JSONL file would exceed the configured `ActiveFileMaxBytes` threshold.
+
+If it would:
+
+1. the current active file is renamed to a timestamped archive
+2. a fresh active `pkcs11-telemetry.jsonl` file is created
+3. the new event is appended to the fresh active file
+
+This keeps the hottest file small and keeps the newest event in the active file instead of immediately pushing it into an archive.
+
+### Retention behavior
+
+Retention is enforced during read/write lifecycle operations:
+
+- archives older than `RetentionDays` are deleted
+- only the newest `MaxArchivedFiles` archives are kept
+- empty active files left behind after rotation cleanup are removed
+
+Because rotation + pruning happen inside the telemetry store, storage growth stays bounded even if the viewer/export surface is never opened manually.
+
+## Configuration
+
+Configure the lifecycle policy under `AdminTelemetry`:
+
+```json
+{
+  "AdminTelemetry": {
+    "ActiveFileMaxBytes": 1048576,
+    "RetentionDays": 14,
+    "MaxArchivedFiles": 8,
+    "ExportMaxEntries": 5000
+  }
+}
+```
+
+Meaning:
+
+- `ActiveFileMaxBytes`: max size of the hot JSONL file before rotation
+- `RetentionDays`: delete retained telemetry older than this many days (`0` disables age pruning)
+- `MaxArchivedFiles`: keep at most this many rotated archives (`0` means only the active file remains)
+- `ExportMaxEntries`: hard cap for download/export responses
+
+## Safe export/download
+
+The admin app exposes a first-class redacted telemetry export endpoint:
+
+- `GET /telemetry/export`
+
+Supported query parameters mirror the viewer filters:
+
+- `take`
+- `search`
+- `device`
+- `slot`
+- `operation`
+- `mechanism`
+- `status`
+- `timeRange`
+
+Export characteristics:
+
+- JSON payload with metadata + filtered entries
+- server-side cap via `ExportMaxEntries`
+- `MayBeTruncated=true` when more retained matches existed than were emitted
+- no raw PINs, payload bytes, wrapped blobs, or secret-bearing attributes are introduced by export
+
+Exports are also audited through the admin audit log.
+
+## Correlation with audit review
+
+The telemetry viewer now surfaces request/audit correlation when the admin action ran inside an authenticated request context:
+
+- actor badge
+- auth type badge
+- request/session trace text
+- direct link into `/audit?q=...`
+
+The audit page search now matches session trace ids, remote IP, and user agent text so a telemetry row can pivot into a narrower operational review trail quickly.
+
+## Operational guidance
+
+- Use the viewer for **wrapper-side PKCS#11 call context**.
+- Use the audit log for **who/when/action** traceability.
+- Use export when you need to hand a redacted retained window to another operator or attach it to an investigation artifact.
+- Do not treat wrapper telemetry as a substitute for vendor-native HSM audit facilities.

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,7 @@ The wrapper surface implemented through the current phase set includes:
 - multipart operations and operation-state APIs
 - optional PKCS#11 v3 interface discovery and message-based API surface
 - optional `C_LoginUser` / `C_SessionCancel` through the discovered v3 interface
-- opt-in structured operation telemetry with duration, result/exception, slot/session/mechanism context, and redacted field summaries for sensitive PKCS#11 inputs
+- opt-in structured operation telemetry with duration, result/exception, slot/session/mechanism context, redacted field summaries for sensitive PKCS#11 inputs, and admin-side retention/export/correlation controls in the admin panel
 - administrative operations for session invalidation and token/PIN provisioning
 - NativeAOT smoke validation through the sample app on Linux and Windows
 
@@ -106,6 +106,7 @@ Notable current assumptions:
 - Fixture contract: `docs/softhsm-fixture.md`
 - CI behavior: `docs/ci.md`
 - Telemetry redaction policy: `docs/telemetry-redaction.md`
+- Admin telemetry operations: `docs/admin-telemetry-operations.md`
 - Smoke sample usage: `docs/smoke.md`
 - Compatibility matrix: `docs/compatibility-matrix.md`
 - Thales Luna integration guide: `docs/luna-integration.md`

--- a/src/Pkcs11Wrapper.Admin.Application/Abstractions/IPkcs11TelemetryStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Abstractions/IPkcs11TelemetryStore.cs
@@ -7,4 +7,8 @@ public interface IPkcs11TelemetryStore
     Task AppendAsync(AdminPkcs11TelemetryEntry entry, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadAllAsync(CancellationToken cancellationToken = default);
+
+    Task<AdminPkcs11TelemetryStorageStatus> GetStorageStatusAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Pkcs11Wrapper.Admin.Application/AdminApplicationJsonContext.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/AdminApplicationJsonContext.cs
@@ -5,6 +5,7 @@ namespace Pkcs11Wrapper.Admin.Application;
 
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(AdminConfigurationExportBundle))]
+[JsonSerializable(typeof(AdminPkcs11TelemetryExportBundle))]
 public sealed partial class AdminApplicationJsonContext : JsonSerializerContext
 {
 }

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryEntry.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryEntry.cs
@@ -19,4 +19,8 @@ public sealed record AdminPkcs11TelemetryEntry(
     ulong? SessionHandle,
     ulong? MechanismType,
     string? ExceptionType,
+    string? Actor,
+    string? AuthenticationType,
+    string? SessionId,
+    string? CorrelationId,
     AdminPkcs11TelemetryField[] Fields);

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryExportBundle.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryExportBundle.cs
@@ -1,0 +1,12 @@
+namespace Pkcs11Wrapper.Admin.Application.Models;
+
+public sealed record AdminPkcs11TelemetryExportBundle(
+    string Format,
+    int SchemaVersion,
+    DateTimeOffset ExportedUtc,
+    bool RedactedOnly,
+    bool MayBeTruncated,
+    int EntryCount,
+    AdminPkcs11TelemetryQuery Filters,
+    AdminPkcs11TelemetryStorageStatus StorageStatus,
+    AdminPkcs11TelemetryEntry[] Entries);

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryOptions.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryOptions.cs
@@ -1,0 +1,12 @@
+namespace Pkcs11Wrapper.Admin.Application.Models;
+
+public sealed class AdminPkcs11TelemetryOptions
+{
+    public long ActiveFileMaxBytes { get; set; } = 1 * 1024 * 1024;
+
+    public int RetentionDays { get; set; } = 14;
+
+    public int MaxArchivedFiles { get; set; } = 8;
+
+    public int ExportMaxEntries { get; set; } = 5000;
+}

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryQuery.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryQuery.cs
@@ -1,0 +1,11 @@
+namespace Pkcs11Wrapper.Admin.Application.Models;
+
+public sealed record AdminPkcs11TelemetryQuery(
+    int Take = 500,
+    string? SearchText = null,
+    string? DeviceFilter = null,
+    string? SlotFilter = null,
+    string? OperationFilter = null,
+    string? MechanismFilter = null,
+    string StatusFilter = "all",
+    string TimeRangeFilter = "all");

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryStorageStatus.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryStorageStatus.cs
@@ -1,0 +1,11 @@
+namespace Pkcs11Wrapper.Admin.Application.Models;
+
+public sealed record AdminPkcs11TelemetryStorageStatus(
+    long ActiveFileBytes,
+    int ArchivedFileCount,
+    int RetainedFileCount,
+    long RetainedBytes,
+    long ActiveFileMaxBytes,
+    int RetentionDays,
+    int MaxArchivedFiles,
+    int ExportMaxEntries);

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -133,10 +133,53 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         return auditLog.VerifyIntegrityAsync(forceVerification, cancellationToken);
     }
 
-    public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> GetPkcs11TelemetryAsync(int take = 500, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> GetPkcs11TelemetryAsync(AdminPkcs11TelemetryQuery? query = null, CancellationToken cancellationToken = default)
     {
         authorization.DemandViewer();
-        return pkcs11Telemetry?.GetRecentAsync(take, cancellationToken) ?? Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([]);
+        return pkcs11Telemetry?.GetRecentAsync(query, cancellationToken) ?? Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([]);
+    }
+
+    public Task<AdminPkcs11TelemetryStorageStatus> GetPkcs11TelemetryStorageStatusAsync(CancellationToken cancellationToken = default)
+    {
+        authorization.DemandViewer();
+        return pkcs11Telemetry?.GetStorageStatusAsync(cancellationToken)
+            ?? Task.FromResult(new AdminPkcs11TelemetryStorageStatus(0, 0, 0, 0, 0, 0, 0, 0));
+    }
+
+    public async Task<AdminPkcs11TelemetryExportBundle> ExportPkcs11TelemetryAsync(AdminPkcs11TelemetryQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        authorization.DemandViewer();
+
+        try
+        {
+            AdminPkcs11TelemetryExportBundle bundle = pkcs11Telemetry is null
+                ? new AdminPkcs11TelemetryExportBundle(
+                    "Pkcs11Wrapper.Admin.Pkcs11Telemetry",
+                    1,
+                    DateTimeOffset.UtcNow,
+                    RedactedOnly: true,
+                    MayBeTruncated: false,
+                    EntryCount: 0,
+                    Filters: query ?? new(),
+                    StorageStatus: new AdminPkcs11TelemetryStorageStatus(0, 0, 0, 0, 0, 0, 0, 0),
+                    Entries: [])
+                : await pkcs11Telemetry.ExportAsync(query, cancellationToken);
+
+            await auditLog.WriteAsync(
+                "Telemetry",
+                "Export",
+                query?.DeviceFilter ?? "retained-window",
+                "Success",
+                $"Exported {bundle.EntryCount} redacted PKCS#11 telemetry event(s). Search='{query?.SearchText ?? string.Empty}', operation='{query?.OperationFilter ?? string.Empty}', status='{query?.StatusFilter ?? "all"}', timeRange='{query?.TimeRangeFilter ?? "all"}'.",
+                cancellationToken: cancellationToken);
+
+            return bundle;
+        }
+        catch (Exception ex)
+        {
+            await auditLog.WriteAsync("Telemetry", "Export", query?.DeviceFilter ?? "retained-window", "Failure", ex.Message, cancellationToken: cancellationToken);
+            throw;
+        }
     }
 
     public async Task<DashboardSummary> GetDashboardAsync(CancellationToken cancellationToken = default)

--- a/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryQueryEvaluator.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryQueryEvaluator.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Application.Services;
+
+public static class Pkcs11TelemetryQueryEvaluator
+{
+    public static IReadOnlyList<AdminPkcs11TelemetryEntry> Apply(
+        IReadOnlyList<AdminPkcs11TelemetryEntry> items,
+        AdminPkcs11TelemetryQuery query,
+        DateTimeOffset nowUtc)
+    {
+        IEnumerable<AdminPkcs11TelemetryEntry> filtered = items;
+
+        if (!string.IsNullOrWhiteSpace(query.SearchText))
+        {
+            string term = query.SearchText.Trim();
+            filtered = filtered.Where(item =>
+                Contains(item.DeviceName, term)
+                || Contains(item.DeviceId.ToString("D"), term)
+                || Contains(item.OperationName, term)
+                || Contains(item.NativeOperationName, term)
+                || Contains(item.Status, term)
+                || Contains(item.ReturnValue, term)
+                || Contains(item.ExceptionType, term)
+                || Contains(item.Actor, term)
+                || Contains(item.AuthenticationType, term)
+                || Contains(item.SessionId, term)
+                || Contains(item.CorrelationId, term)
+                || Contains(FormatDecimal(item.SlotId), term)
+                || Contains(FormatDecimal(item.SessionHandle), term)
+                || Contains(FormatMechanism(item.MechanismType), term)
+                || item.Fields.Any(field =>
+                    Contains(field.Name, term)
+                    || Contains(field.Classification, term)
+                    || Contains(field.Value, term)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.DeviceFilter))
+        {
+            filtered = filtered.Where(item => string.Equals(item.DeviceName, query.DeviceFilter, StringComparison.Ordinal));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.SlotFilter))
+        {
+            string slotTerm = query.SlotFilter.Trim();
+            filtered = filtered.Where(item => MatchesNumericFilter(item.SlotId, slotTerm));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.OperationFilter))
+        {
+            filtered = filtered.Where(item => string.Equals(item.OperationName, query.OperationFilter, StringComparison.Ordinal));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.MechanismFilter))
+        {
+            string mechanismTerm = query.MechanismFilter.Trim();
+            filtered = filtered.Where(item => MatchesNumericFilter(item.MechanismType, mechanismTerm));
+        }
+
+        filtered = (query.StatusFilter ?? "all").ToLowerInvariant() switch
+        {
+            "success" => filtered.Where(IsSuccess),
+            "non-success" => filtered.Where(item => !IsSuccess(item)),
+            "returned-false" => filtered.Where(item => string.Equals(item.Status, "ReturnedFalse", StringComparison.Ordinal)),
+            "failed" => filtered.Where(item => string.Equals(item.Status, "Failed", StringComparison.Ordinal)),
+            _ => filtered
+        };
+
+        DateTimeOffset? threshold = (query.TimeRangeFilter ?? "all").ToLowerInvariant() switch
+        {
+            "1h" => nowUtc.AddHours(-1),
+            "6h" => nowUtc.AddHours(-6),
+            "24h" => nowUtc.AddHours(-24),
+            "7d" => nowUtc.AddDays(-7),
+            _ => null
+        };
+
+        if (threshold.HasValue)
+        {
+            filtered = filtered.Where(item => item.TimestampUtc >= threshold.Value);
+        }
+
+        return filtered
+            .OrderByDescending(item => item.TimestampUtc)
+            .ThenBy(item => item.DeviceName, StringComparer.Ordinal)
+            .ThenBy(item => item.OperationName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public static bool IsSuccess(AdminPkcs11TelemetryEntry item)
+        => string.Equals(item.Status, "Succeeded", StringComparison.Ordinal);
+
+    public static string FormatMechanism(ulong? value)
+        => value.HasValue ? $"0x{value.Value:X}" : "—";
+
+    public static string FormatDecimal(ulong? value)
+        => value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "—";
+
+    private static bool MatchesNumericFilter(ulong? value, string filter)
+    {
+        if (!value.HasValue)
+        {
+            return false;
+        }
+
+        if (TryParseNumericFilter(filter, out ulong parsed))
+        {
+            return value.Value == parsed;
+        }
+
+        string decimalText = value.Value.ToString(CultureInfo.InvariantCulture);
+        string hexText = FormatMechanism(value);
+        return decimalText.Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || hexText.Contains(filter, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryParseNumericFilter(string filter, out ulong value)
+    {
+        if (filter.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return ulong.TryParse(filter.AsSpan(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+        }
+
+        return ulong.TryParse(filter, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool Contains(string? value, string term)
+        => value?.Contains(term, StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryService.cs
@@ -1,18 +1,69 @@
+using System.Diagnostics;
 using Pkcs11Wrapper.Admin.Application.Abstractions;
 using Pkcs11Wrapper.Admin.Application.Models;
 using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.Admin.Application.Services;
 
-public sealed class Pkcs11TelemetryService(IPkcs11TelemetryStore store)
+public sealed class Pkcs11TelemetryService(IPkcs11TelemetryStore store, IAdminActorContext actorContext, AdminPkcs11TelemetryOptions options)
 {
-    public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> GetRecentAsync(int take = 500, CancellationToken cancellationToken = default)
-        => store.ReadRecentAsync(take, cancellationToken);
+    private const string ExportFormat = "Pkcs11Wrapper.Admin.Pkcs11Telemetry";
+    private const int ExportSchemaVersion = 1;
+
+    public async Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> GetRecentAsync(AdminPkcs11TelemetryQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        AdminPkcs11TelemetryQuery effectiveQuery = NormalizeQuery(query ?? new());
+        IReadOnlyList<AdminPkcs11TelemetryEntry> entries = await store.ReadRecentAsync(effectiveQuery.Take, cancellationToken);
+        return Pkcs11TelemetryQueryEvaluator.Apply(entries, effectiveQuery, DateTimeOffset.UtcNow);
+    }
+
+    public Task<AdminPkcs11TelemetryStorageStatus> GetStorageStatusAsync(CancellationToken cancellationToken = default)
+        => store.GetStorageStatusAsync(cancellationToken);
+
+    public async Task<AdminPkcs11TelemetryExportBundle> ExportAsync(AdminPkcs11TelemetryQuery? query = null, CancellationToken cancellationToken = default)
+    {
+        AdminPkcs11TelemetryQuery effectiveQuery = NormalizeExportQuery(query ?? new(Take: GetNormalizedExportMaxEntries()));
+        IReadOnlyList<AdminPkcs11TelemetryEntry> retainedEntries = await store.ReadAllAsync(cancellationToken);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> fullyFiltered = Pkcs11TelemetryQueryEvaluator.Apply(retainedEntries, effectiveQuery with { Take = int.MaxValue }, DateTimeOffset.UtcNow);
+        AdminPkcs11TelemetryEntry[] entries = [.. fullyFiltered.Take(effectiveQuery.Take)];
+        AdminPkcs11TelemetryStorageStatus storageStatus = await store.GetStorageStatusAsync(cancellationToken);
+
+        return new(
+            ExportFormat,
+            ExportSchemaVersion,
+            DateTimeOffset.UtcNow,
+            RedactedOnly: true,
+            MayBeTruncated: fullyFiltered.Count > entries.Length,
+            EntryCount: entries.Length,
+            Filters: effectiveQuery,
+            StorageStatus: storageStatus,
+            Entries: entries);
+    }
 
     public IPkcs11OperationTelemetryListener CreateListener(HsmDeviceProfile device)
-        => new AdminPkcs11TelemetryListener(store, device);
+        => new AdminPkcs11TelemetryListener(store, device, actorContext.GetCurrent(), Activity.Current?.TraceId.ToString());
 
-    private sealed class AdminPkcs11TelemetryListener(IPkcs11TelemetryStore store, HsmDeviceProfile device) : IPkcs11OperationTelemetryListener
+    private AdminPkcs11TelemetryQuery NormalizeQuery(AdminPkcs11TelemetryQuery query)
+        => query with { Take = NormalizeTake(query.Take, defaultTake: 500) };
+
+    private AdminPkcs11TelemetryQuery NormalizeExportQuery(AdminPkcs11TelemetryQuery query)
+        => query with { Take = NormalizeTake(query.Take, defaultTake: GetNormalizedExportMaxEntries()) };
+
+    private int NormalizeTake(int take, int defaultTake)
+    {
+        int exportMaxEntries = GetNormalizedExportMaxEntries();
+        if (take <= 0)
+        {
+            return Math.Min(defaultTake, exportMaxEntries);
+        }
+
+        return Math.Min(take, exportMaxEntries);
+    }
+
+    private int GetNormalizedExportMaxEntries()
+        => options.ExportMaxEntries <= 0 ? 5000 : options.ExportMaxEntries;
+
+    private sealed class AdminPkcs11TelemetryListener(IPkcs11TelemetryStore store, HsmDeviceProfile device, AdminActorInfo actor, string? activityTraceId) : IPkcs11OperationTelemetryListener
     {
         public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
         {
@@ -30,6 +81,10 @@ public sealed class Pkcs11TelemetryService(IPkcs11TelemetryStore store)
                 operationEvent.SessionHandle.HasValue ? (ulong)operationEvent.SessionHandle.Value : null,
                 operationEvent.MechanismType.HasValue ? (ulong)operationEvent.MechanismType.Value : null,
                 operationEvent.Exception?.GetType().Name,
+                string.IsNullOrWhiteSpace(actor.Name) ? null : actor.Name,
+                string.IsNullOrWhiteSpace(actor.AuthenticationType) ? null : actor.AuthenticationType,
+                string.IsNullOrWhiteSpace(actor.SessionId) ? null : actor.SessionId,
+                string.IsNullOrWhiteSpace(activityTraceId) ? actor.SessionId : activityTraceId,
                 [.. operationEvent.Fields.Select(field => new AdminPkcs11TelemetryField(field.Name, field.Classification.ToString(), field.Value))]);
 
             try

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLinePkcs11TelemetryStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLinePkcs11TelemetryStore.cs
@@ -5,24 +5,30 @@ using Pkcs11Wrapper.Admin.Application.Models;
 
 namespace Pkcs11Wrapper.Admin.Infrastructure;
 
-public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions options) : IPkcs11TelemetryStore
+public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions storageOptions, AdminPkcs11TelemetryOptions? telemetryOptions = null) : IPkcs11TelemetryStore
 {
     private readonly SemaphoreSlim _mutex = new(1, 1);
+    private readonly AdminPkcs11TelemetryOptions _telemetryOptions = telemetryOptions ?? new();
 
     public async Task AppendAsync(AdminPkcs11TelemetryEntry entry, CancellationToken cancellationToken = default)
     {
         await _mutex.WaitAsync(cancellationToken);
         try
         {
-            string path = GetPath();
+            string path = GetActivePath();
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await EnforceRetentionAsync(cancellationToken);
 
             string line = JsonSerializer.Serialize(entry, AdminJsonContext.Default.AdminPkcs11TelemetryEntry) + Environment.NewLine;
+            int lineBytes = Encoding.UTF8.GetByteCount(line);
+            await RotateIfNeededForAppendAsync(lineBytes, cancellationToken);
 
             await using FileStream stream = new(path, FileMode.Append, FileAccess.Write, FileShare.Read, 64 * 1024, FileOptions.Asynchronous);
             await using StreamWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
             await writer.WriteAsync(line.AsMemory(), cancellationToken);
             await writer.FlushAsync(cancellationToken);
+
+            await EnforceRetentionAsync(cancellationToken);
         }
         finally
         {
@@ -35,15 +41,8 @@ public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions options) : 
         await _mutex.WaitAsync(cancellationToken);
         try
         {
-            string path = GetPath();
-            if (!File.Exists(path))
-            {
-                return [];
-            }
-
-            return (await ReadTailLinesAsync(path, Math.Max(1, take), cancellationToken))
-                .Select(line => DeserializeEntry(line, path))
-                .ToArray();
+            await EnforceRetentionAsync(cancellationToken);
+            return await ReadEntriesAsync(Math.Max(1, take), cancellationToken);
         }
         finally
         {
@@ -51,7 +50,216 @@ public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions options) : 
         }
     }
 
-    private string GetPath() => Path.Combine(options.DataRoot, options.TelemetryLogFileName);
+    public async Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadAllAsync(CancellationToken cancellationToken = default)
+    {
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            await EnforceRetentionAsync(cancellationToken);
+            return await ReadEntriesAsync(null, cancellationToken);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    public async Task<AdminPkcs11TelemetryStorageStatus> GetStorageStatusAsync(CancellationToken cancellationToken = default)
+    {
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            await EnforceRetentionAsync(cancellationToken);
+            string activePath = GetActivePath();
+            FileInfo[] retainedFiles = GetRetainedFilesNewestFirst().Select(path => new FileInfo(path)).ToArray();
+            FileInfo? activeFile = retainedFiles.FirstOrDefault(file => string.Equals(file.FullName, activePath, StringComparison.Ordinal));
+
+            return new(
+                ActiveFileBytes: activeFile?.Exists == true ? activeFile.Length : 0,
+                ArchivedFileCount: retainedFiles.Count(file => !string.Equals(file.FullName, activePath, StringComparison.Ordinal)),
+                RetainedFileCount: retainedFiles.Length,
+                RetainedBytes: retainedFiles.Where(file => file.Exists).Sum(file => file.Length),
+                ActiveFileMaxBytes: GetNormalizedActiveFileMaxBytes(),
+                RetentionDays: GetNormalizedRetentionDays(),
+                MaxArchivedFiles: GetNormalizedMaxArchivedFiles(),
+                ExportMaxEntries: GetNormalizedExportMaxEntries());
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private async Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadEntriesAsync(int? take, CancellationToken cancellationToken)
+    {
+        List<AdminPkcs11TelemetryEntry> entries = [];
+        foreach (string path in GetRetainedFilesNewestFirst())
+        {
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            string[] lines = await File.ReadAllLinesAsync(path, cancellationToken);
+            for (int index = lines.Length - 1; index >= 0; index--)
+            {
+                string line = lines[index].Trim();
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                entries.Add(DeserializeEntry(line, path));
+                if (take.HasValue && entries.Count >= take.Value)
+                {
+                    return SortEntries(entries);
+                }
+            }
+        }
+
+        return SortEntries(entries);
+    }
+
+    private async Task RotateIfNeededForAppendAsync(int incomingLineBytes, CancellationToken cancellationToken)
+    {
+        string activePath = GetActivePath();
+        if (!File.Exists(activePath))
+        {
+            return;
+        }
+
+        FileInfo activeInfo = new(activePath);
+        if (activeInfo.Length == 0)
+        {
+            return;
+        }
+
+        if (activeInfo.Length + incomingLineBytes <= GetNormalizedActiveFileMaxBytes())
+        {
+            return;
+        }
+
+        string archivePath = CreateArchivePath();
+        await Task.Run(() => File.Move(activePath, archivePath), cancellationToken);
+    }
+
+    private async Task EnforceRetentionAsync(CancellationToken cancellationToken)
+    {
+        string directory = GetDirectoryPath();
+        if (!Directory.Exists(directory))
+        {
+            return;
+        }
+
+        DateTimeOffset nowUtc = DateTimeOffset.UtcNow;
+        int retentionDays = GetNormalizedRetentionDays();
+        if (retentionDays > 0)
+        {
+            DateTimeOffset cutoff = nowUtc.AddDays(-retentionDays);
+            foreach (string path in GetRetainedFilesNewestFirst())
+            {
+                FileInfo info = new(path);
+                if (info.Exists && info.LastWriteTimeUtc < cutoff.UtcDateTime)
+                {
+                    await Task.Run(() => info.Delete(), cancellationToken);
+                }
+            }
+        }
+
+        string activePath = GetActivePath();
+        string[] archives = GetArchivePathsNewestFirst();
+        int maxArchivedFiles = GetNormalizedMaxArchivedFiles();
+        if (archives.Length > maxArchivedFiles)
+        {
+            foreach (string path in archives.Skip(maxArchivedFiles))
+            {
+                if (File.Exists(path))
+                {
+                    await Task.Run(() => File.Delete(path), cancellationToken);
+                }
+            }
+        }
+
+        if (File.Exists(activePath))
+        {
+            FileInfo active = new(activePath);
+            if (active.Length == 0 && GetArchivePathsNewestFirst().Length > 0)
+            {
+                await Task.Run(() => active.Delete(), cancellationToken);
+            }
+        }
+    }
+
+    private string[] GetRetainedFilesNewestFirst()
+    {
+        string activePath = GetActivePath();
+        List<string> files = [];
+        if (File.Exists(activePath))
+        {
+            files.Add(activePath);
+        }
+
+        files.AddRange(GetArchivePathsNewestFirst());
+        return [.. files];
+    }
+
+    private string[] GetArchivePathsNewestFirst()
+    {
+        string directory = GetDirectoryPath();
+        if (!Directory.Exists(directory))
+        {
+            return [];
+        }
+
+        return Directory.EnumerateFiles(directory, GetArchiveSearchPattern(), SearchOption.TopDirectoryOnly)
+            .OrderByDescending(path => Path.GetFileName(path), StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private string CreateArchivePath()
+    {
+        string directory = GetDirectoryPath();
+        string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(storageOptions.TelemetryLogFileName);
+        string extension = Path.GetExtension(storageOptions.TelemetryLogFileName);
+        string timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMdd-HHmmssfff");
+        string candidate = Path.Combine(directory, $"{fileNameWithoutExtension}-{timestamp}{extension}");
+        int suffix = 1;
+        while (File.Exists(candidate))
+        {
+            candidate = Path.Combine(directory, $"{fileNameWithoutExtension}-{timestamp}-{suffix:D2}{extension}");
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private string GetArchiveSearchPattern()
+        => $"{Path.GetFileNameWithoutExtension(storageOptions.TelemetryLogFileName)}-*{Path.GetExtension(storageOptions.TelemetryLogFileName)}";
+
+    private string GetActivePath()
+        => Path.Combine(storageOptions.DataRoot, storageOptions.TelemetryLogFileName);
+
+    private string GetDirectoryPath()
+        => Path.GetDirectoryName(GetActivePath())!;
+
+    private long GetNormalizedActiveFileMaxBytes()
+        => _telemetryOptions.ActiveFileMaxBytes <= 0 ? 1 * 1024 * 1024 : _telemetryOptions.ActiveFileMaxBytes;
+
+    private int GetNormalizedRetentionDays()
+        => _telemetryOptions.RetentionDays < 0 ? 0 : _telemetryOptions.RetentionDays;
+
+    private int GetNormalizedMaxArchivedFiles()
+        => _telemetryOptions.MaxArchivedFiles < 0 ? 0 : _telemetryOptions.MaxArchivedFiles;
+
+    private int GetNormalizedExportMaxEntries()
+        => _telemetryOptions.ExportMaxEntries <= 0 ? 5000 : _telemetryOptions.ExportMaxEntries;
+
+    private static IReadOnlyList<AdminPkcs11TelemetryEntry> SortEntries(IEnumerable<AdminPkcs11TelemetryEntry> entries)
+        => entries
+            .OrderByDescending(entry => entry.TimestampUtc)
+            .ThenBy(entry => entry.DeviceName, StringComparer.Ordinal)
+            .ThenBy(entry => entry.OperationName, StringComparer.Ordinal)
+            .ToArray();
 
     private static AdminPkcs11TelemetryEntry DeserializeEntry(string line, string path)
     {
@@ -63,82 +271,6 @@ public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions options) : 
         catch (JsonException ex)
         {
             throw new InvalidOperationException($"Telemetry log '{path}' contains an unreadable JSON line.", ex);
-        }
-    }
-
-    private static async Task<IReadOnlyList<string>> ReadTailLinesAsync(string path, int take, CancellationToken cancellationToken)
-    {
-        List<string> lines = [];
-        await using FileStream stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        if (stream.Length == 0)
-        {
-            return lines;
-        }
-
-        long position = stream.Length;
-        byte[] buffer = new byte[4096];
-        StringBuilder reversed = new();
-        bool skippedTrailingNewline = false;
-
-        while (position > 0 && lines.Count < take)
-        {
-            int bytesToRead = (int)Math.Min(buffer.Length, position);
-            position -= bytesToRead;
-            stream.Position = position;
-            int read = await stream.ReadAsync(buffer.AsMemory(0, bytesToRead), cancellationToken);
-
-            for (int index = read - 1; index >= 0; index--)
-            {
-                char current = (char)buffer[index];
-                if (current == '\n')
-                {
-                    if (!skippedTrailingNewline && reversed.Length == 0)
-                    {
-                        skippedTrailingNewline = true;
-                        continue;
-                    }
-
-                    AddCompletedLine(lines, reversed);
-                    if (lines.Count >= take)
-                    {
-                        break;
-                    }
-
-                    skippedTrailingNewline = true;
-                }
-                else
-                {
-                    reversed.Append(current);
-                }
-            }
-        }
-
-        if (lines.Count < take && reversed.Length > 0)
-        {
-            AddCompletedLine(lines, reversed);
-        }
-
-        return lines;
-    }
-
-    private static void AddCompletedLine(List<string> lines, StringBuilder reversed)
-    {
-        if (reversed.Length == 0)
-        {
-            return;
-        }
-
-        char[] chars = new char[reversed.Length];
-        for (int i = 0; i < reversed.Length; i++)
-        {
-            chars[i] = reversed[reversed.Length - 1 - i];
-        }
-
-        string line = new string(chars).TrimEnd('\r');
-        reversed.Clear();
-        if (!string.IsNullOrWhiteSpace(line))
-        {
-            lines.Add(line);
         }
     }
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Audit.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Audit.razor
@@ -152,7 +152,13 @@ else
                 {
                     <tr>
                         <td><span class="table-pill table-pill-code">@log.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span></td>
-                        <td>@log.Actor</td>
+                        <td>
+                            <div>@log.Actor</div>
+                            @if (!string.IsNullOrWhiteSpace(log.SessionId))
+                            {
+                                <div class="small text-muted">trace @log.SessionId</div>
+                            }
+                        </td>
                         <td>@string.Join(", ", log.ActorRoles)</td>
                         <td><span class="table-pill">@log.Category</span></td>
                         <td>@log.Action</td>
@@ -175,8 +181,12 @@ else
 }
 
 @code {
+    [SupplyParameterFromQuery(Name = "q")]
+    public string? QueryText { get; set; }
+
     private IReadOnlyList<AdminAuditLogEntry> _logs = [];
     private AuditIntegrityStatus? _integrity;
+    private string _appliedQueryText = string.Empty;
     private string _searchText = string.Empty;
     private string _categoryFilter = string.Empty;
     private string _outcomeFilter = "all";
@@ -209,10 +219,14 @@ else
 
     protected override Task OnInitializedAsync() => LoadAsync();
 
+    protected override void OnParametersSet()
+        => ApplyQueryText();
+
     private async Task LoadAsync(bool forceVerify = false)
     {
         _logs = await Admin.GetAuditLogsAsync();
         _integrity = await Admin.GetAuditIntegrityAsync(forceVerify);
+        ApplyQueryText();
         _pageIndex = 1;
     }
 
@@ -257,7 +271,10 @@ else
                 || Contains(log.Action, term)
                 || Contains(log.Target, term)
                 || Contains(log.Outcome, term)
-                || Contains(log.Details, term));
+                || Contains(log.Details, term)
+                || Contains(log.SessionId, term)
+                || Contains(log.RemoteIp, term)
+                || Contains(log.UserAgent, term));
         }
 
         if (!string.IsNullOrWhiteSpace(_categoryFilter))
@@ -273,6 +290,19 @@ else
         };
 
         return query.ToArray();
+    }
+
+    private void ApplyQueryText()
+    {
+        string queryText = QueryText?.Trim() ?? string.Empty;
+        if (string.Equals(_appliedQueryText, queryText, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _appliedQueryText = queryText;
+        _searchText = queryText;
+        _pageIndex = 1;
     }
 
     private int GetSafePageIndex(int filteredCount)

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryView.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryView.cs
@@ -1,5 +1,6 @@
-using System.Globalization;
+using Microsoft.AspNetCore.WebUtilities;
 using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Application.Services;
 
 namespace Pkcs11Wrapper.Admin.Web.Components.Pages;
 
@@ -15,82 +16,20 @@ public static class Pkcs11TelemetryView
         string statusFilter,
         string timeRangeFilter,
         DateTimeOffset nowUtc)
-    {
-        IEnumerable<AdminPkcs11TelemetryEntry> query = items;
-
-        if (!string.IsNullOrWhiteSpace(searchText))
-        {
-            string term = searchText.Trim();
-            query = query.Where(item =>
-                Contains(item.DeviceName, term)
-                || Contains(item.OperationName, term)
-                || Contains(item.NativeOperationName, term)
-                || Contains(item.Status, term)
-                || Contains(item.ReturnValue, term)
-                || Contains(item.ExceptionType, term)
-                || Contains(FormatDecimal(item.SlotId), term)
-                || Contains(FormatDecimal(item.SessionHandle), term)
-                || Contains(FormatMechanism(item.MechanismType), term)
-                || item.Fields.Any(field =>
-                    Contains(field.Name, term)
-                    || Contains(field.Classification, term)
-                    || Contains(field.Value, term)));
-        }
-
-        if (!string.IsNullOrWhiteSpace(deviceFilter))
-        {
-            query = query.Where(item => string.Equals(item.DeviceName, deviceFilter, StringComparison.Ordinal));
-        }
-
-        if (!string.IsNullOrWhiteSpace(slotFilter))
-        {
-            string slotTerm = slotFilter.Trim();
-            query = query.Where(item => MatchesNumericFilter(item.SlotId, slotTerm));
-        }
-
-        if (!string.IsNullOrWhiteSpace(operationFilter))
-        {
-            query = query.Where(item => string.Equals(item.OperationName, operationFilter, StringComparison.Ordinal));
-        }
-
-        if (!string.IsNullOrWhiteSpace(mechanismFilter))
-        {
-            string mechanismTerm = mechanismFilter.Trim();
-            query = query.Where(item => MatchesNumericFilter(item.MechanismType, mechanismTerm));
-        }
-
-        query = statusFilter.ToLowerInvariant() switch
-        {
-            "success" => query.Where(IsSuccess),
-            "non-success" => query.Where(item => !IsSuccess(item)),
-            "returned-false" => query.Where(item => string.Equals(item.Status, "ReturnedFalse", StringComparison.Ordinal)),
-            "failed" => query.Where(item => string.Equals(item.Status, "Failed", StringComparison.Ordinal)),
-            _ => query
-        };
-
-        DateTimeOffset? threshold = timeRangeFilter.ToLowerInvariant() switch
-        {
-            "1h" => nowUtc.AddHours(-1),
-            "6h" => nowUtc.AddHours(-6),
-            "24h" => nowUtc.AddHours(-24),
-            "7d" => nowUtc.AddDays(-7),
-            _ => null
-        };
-
-        if (threshold.HasValue)
-        {
-            query = query.Where(item => item.TimestampUtc >= threshold.Value);
-        }
-
-        return query
-            .OrderByDescending(item => item.TimestampUtc)
-            .ThenBy(item => item.DeviceName, StringComparer.Ordinal)
-            .ThenBy(item => item.OperationName, StringComparer.Ordinal)
-            .ToArray();
-    }
+        => Pkcs11TelemetryQueryEvaluator.Apply(
+            items,
+            new AdminPkcs11TelemetryQuery(
+                SearchText: searchText,
+                DeviceFilter: deviceFilter,
+                SlotFilter: slotFilter,
+                OperationFilter: operationFilter,
+                MechanismFilter: mechanismFilter,
+                StatusFilter: statusFilter,
+                TimeRangeFilter: timeRangeFilter),
+            nowUtc);
 
     public static bool IsSuccess(AdminPkcs11TelemetryEntry item)
-        => string.Equals(item.Status, "Succeeded", StringComparison.Ordinal);
+        => Pkcs11TelemetryQueryEvaluator.IsSuccess(item);
 
     public static string GetStatusBadgeClass(AdminPkcs11TelemetryEntry item)
         => item.Status switch
@@ -101,39 +40,21 @@ public static class Pkcs11TelemetryView
         };
 
     public static string FormatMechanism(ulong? value)
-        => value.HasValue ? $"0x{value.Value:X}" : "—";
+        => Pkcs11TelemetryQueryEvaluator.FormatMechanism(value);
 
     public static string FormatDecimal(ulong? value)
-        => value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : "—";
+        => Pkcs11TelemetryQueryEvaluator.FormatDecimal(value);
 
-    private static bool MatchesNumericFilter(ulong? value, string filter)
+    public static string BuildAuditHref(AdminPkcs11TelemetryEntry item)
     {
-        if (!value.HasValue)
-        {
-            return false;
-        }
+        string? search = !string.IsNullOrWhiteSpace(item.SessionId)
+            ? item.SessionId
+            : !string.IsNullOrWhiteSpace(item.CorrelationId)
+                ? item.CorrelationId
+                : item.Actor;
 
-        if (TryParseNumericFilter(filter, out ulong parsed))
-        {
-            return value.Value == parsed;
-        }
-
-        string decimalText = value.Value.ToString(CultureInfo.InvariantCulture);
-        string hexText = FormatMechanism(value);
-        return decimalText.Contains(filter, StringComparison.OrdinalIgnoreCase)
-            || hexText.Contains(filter, StringComparison.OrdinalIgnoreCase);
+        return string.IsNullOrWhiteSpace(search)
+            ? "/audit"
+            : QueryHelpers.AddQueryString("/audit", "q", search);
     }
-
-    private static bool TryParseNumericFilter(string filter, out ulong value)
-    {
-        if (filter.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-        {
-            return ulong.TryParse(filter.AsSpan(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
-        }
-
-        return ulong.TryParse(filter, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
-    }
-
-    private static bool Contains(string? value, string term)
-        => value?.Contains(term, StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
@@ -1,5 +1,6 @@
 @page "/telemetry"
 @attribute [Authorize(Policy = AdminRoles.Viewer)]
+@using System.Globalization
 @using Pkcs11Wrapper.Admin.Application.Models
 @inject HsmAdminService Admin
 
@@ -14,7 +15,8 @@
             <span class="page-tag">Redacted only</span>
             <span class="page-tag">Device / slot filters</span>
             <span class="page-tag">Mechanism correlation</span>
-            <span class="page-tag">Failure review</span>
+            <span class="page-tag">Retention aware</span>
+            <span class="page-tag">Audit trace links</span>
         </div>
     </div>
     <div class="page-hero-side">
@@ -24,17 +26,25 @@
             <div class="hero-panel-copy">The viewer reads the newest admin-hosted PKCS#11 telemetry window so operators can isolate a device, slot, mechanism, or failing operation quickly.</div>
         </div>
         <div class="hero-panel">
-            <div class="hero-panel-title">Safety posture</div>
-            <div class="hero-panel-value">Redaction enforced</div>
-            <div class="hero-panel-copy">Only the wrapper's already-redacted field stream is persisted here. Raw exception messages are intentionally not stored in this viewer.</div>
+            <div class="hero-panel-title">Lifecycle posture</div>
+            <div class="hero-panel-value">Rotated + bounded</div>
+            <div class="hero-panel-copy">The JSONL store auto-rotates and prunes retained telemetry so storage growth stays bounded while still allowing safe redacted exports.</div>
         </div>
     </div>
 </section>
 
 <div class="alert alert-info">
     <div class="fw-semibold">Safe telemetry surface</div>
-    <div class="small">Search and filter the redacted PKCS#11 event stream by device, slot, operation, mechanism, status, and recent time window. Use <a href="audit">Audit Logs</a> when you need actor/action traceability; use this page when you need PKCS#11 call context.</div>
+    <div class="small">Search and filter the redacted PKCS#11 event stream by device, slot, operation, mechanism, status, actor trace, and recent time window. Use <a href="audit">Audit Logs</a> when you need actor/action traceability; this page now links back into matching audit traces when request/session correlation is available.</div>
 </div>
+
+@if (_storageStatus is not null)
+{
+    <div class="alert alert-secondary">
+        <div class="fw-semibold">Retention policy</div>
+        <div class="small">Active log rotates at @FormatBytes(_storageStatus.ActiveFileMaxBytes), retains up to @_storageStatus.MaxArchivedFiles archive file(s) for @_storageStatus.RetentionDays day(s), and exports are capped at @_storageStatus.ExportMaxEntries retained event(s).</div>
+    </div>
+}
 
 <div class="row g-3 mb-3">
     <div class="col-xl-3 col-md-4 col-sm-6">
@@ -69,6 +79,38 @@
             </div>
         </div>
     </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Retained files</div>
+                <div class="display-6 metric-meta">@(_storageStatus?.RetainedFileCount ?? 0)</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Retained size</div>
+                <div class="display-6 metric-meta">@FormatBytes(_storageStatus?.RetainedBytes ?? 0)</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Archive files</div>
+                <div class="display-6 metric-meta">@(_storageStatus?.ArchivedFileCount ?? 0)</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-4 col-sm-6">
+        <div class="card shadow-sm h-100 metric-card">
+            <div class="card-body">
+                <div class="metric-label">Export cap</div>
+                <div class="display-6 metric-meta">@(_storageStatus?.ExportMaxEntries ?? 0)</div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
@@ -76,9 +118,13 @@
         <div class="col-xl-2 col-lg-3 col-md-6">
             <button class="btn btn-primary" @onclick="LoadAsync" data-testid="telemetry-refresh">Refresh</button>
         </div>
+        <div class="col-xl-3 col-lg-4 col-md-6">
+            <a class="btn btn-outline-secondary" href="@BuildExportHref()" data-testid="telemetry-export">Download filtered JSON</a>
+            <div class="form-text">Exports only the redacted retained stream and respects the server-side export cap.</div>
+        </div>
         <div class="col-xl-4 col-lg-5 col-md-6">
             <label class="form-label">Search</label>
-            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="device, native op, return value, field..." data-testid="telemetry-search" />
+            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="device, native op, return value, actor, trace, field..." data-testid="telemetry-search" />
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Device</label>
@@ -203,7 +249,33 @@ else
                                 {
                                     <span class="table-pill">exception=@entry.ExceptionType</span>
                                 }
+                                @if (!string.IsNullOrWhiteSpace(entry.Actor))
+                                {
+                                    <span class="table-pill">actor=@entry.Actor</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(entry.AuthenticationType))
+                                {
+                                    <span class="table-pill table-pill-code">auth=@entry.AuthenticationType</span>
+                                }
+                                @if (!string.IsNullOrWhiteSpace(entry.SessionId) || !string.IsNullOrWhiteSpace(entry.CorrelationId) || !string.IsNullOrWhiteSpace(entry.Actor))
+                                {
+                                    <a class="table-pill table-pill-code text-decoration-none" href="@Pkcs11TelemetryView.BuildAuditHref(entry)">audit trace</a>
+                                }
                             </div>
+
+                            @if (!string.IsNullOrWhiteSpace(entry.SessionId) || !string.IsNullOrWhiteSpace(entry.CorrelationId))
+                            {
+                                <div class="small text-muted mb-1">
+                                    @if (!string.IsNullOrWhiteSpace(entry.SessionId))
+                                    {
+                                        <span class="me-2">session=@entry.SessionId</span>
+                                    }
+                                    @if (!string.IsNullOrWhiteSpace(entry.CorrelationId) && !string.Equals(entry.CorrelationId, entry.SessionId, StringComparison.Ordinal))
+                                    {
+                                        <span>correlation=@entry.CorrelationId</span>
+                                    }
+                                </div>
+                            }
 
                             @if (entry.Fields.Length == 0)
                             {
@@ -238,6 +310,7 @@ else
     private const int _loadWindowSize = 500;
 
     private IReadOnlyList<AdminPkcs11TelemetryEntry> _entries = [];
+    private AdminPkcs11TelemetryStorageStatus? _storageStatus;
     private string _searchText = string.Empty;
     private string _deviceFilter = string.Empty;
     private string _slotFilter = string.Empty;
@@ -293,7 +366,11 @@ else
 
     private async Task LoadAsync()
     {
-        _entries = await Admin.GetPkcs11TelemetryAsync(_loadWindowSize);
+        Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> entriesTask = Admin.GetPkcs11TelemetryAsync(new AdminPkcs11TelemetryQuery(Take: _loadWindowSize));
+        Task<AdminPkcs11TelemetryStorageStatus> statusTask = Admin.GetPkcs11TelemetryStorageStatusAsync();
+        await Task.WhenAll(entriesTask, statusTask);
+        _entries = await entriesTask;
+        _storageStatus = await statusTask;
         _pageIndex = 1;
     }
 
@@ -338,5 +415,43 @@ else
         }
 
         return _pageIndex;
+    }
+
+    private string BuildExportHref()
+    {
+        Dictionary<string, string?> query = new()
+        {
+            ["take"] = _storageStatus?.ExportMaxEntries > 0 ? _storageStatus.ExportMaxEntries.ToString(CultureInfo.InvariantCulture) : null,
+            ["search"] = string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
+            ["device"] = string.IsNullOrWhiteSpace(_deviceFilter) ? null : _deviceFilter,
+            ["slot"] = string.IsNullOrWhiteSpace(_slotFilter) ? null : _slotFilter,
+            ["operation"] = string.IsNullOrWhiteSpace(_operationFilter) ? null : _operationFilter,
+            ["mechanism"] = string.IsNullOrWhiteSpace(_mechanismFilter) ? null : _mechanismFilter,
+            ["status"] = string.IsNullOrWhiteSpace(_statusFilter) ? null : _statusFilter,
+            ["timeRange"] = string.IsNullOrWhiteSpace(_timeRangeFilter) ? null : _timeRangeFilter
+        };
+
+        return Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
+            "/telemetry/export",
+            query.Where(pair => !string.IsNullOrWhiteSpace(pair.Value)).ToDictionary(pair => pair.Key, pair => pair.Value));
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes <= 0)
+        {
+            return "0 B";
+        }
+
+        string[] units = ["B", "KB", "MB", "GB"];
+        double value = bytes;
+        int unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex++;
+        }
+
+        return $"{value:0.#} {units[unitIndex]}";
     }
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Components/_Imports.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/_Imports.razor
@@ -1,6 +1,7 @@
 @using System.ComponentModel.DataAnnotations
 @using System.Net.Http
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Pkcs11Wrapper.Admin.Web/Configuration/TelemetryEndpoints.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Configuration/TelemetryEndpoints.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Pkcs11Wrapper.Admin.Application;
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Application.Services;
+
+namespace Pkcs11Wrapper.Admin.Web.Configuration;
+
+public static class TelemetryEndpoints
+{
+    public static async Task<IResult> ExportAsync(
+        HsmAdminService admin,
+        [FromQuery(Name = "take")] int? take,
+        [FromQuery(Name = "search")] string? searchText,
+        [FromQuery(Name = "device")] string? deviceFilter,
+        [FromQuery(Name = "slot")] string? slotFilter,
+        [FromQuery(Name = "operation")] string? operationFilter,
+        [FromQuery(Name = "mechanism")] string? mechanismFilter,
+        [FromQuery(Name = "status")] string? statusFilter,
+        [FromQuery(Name = "timeRange")] string? timeRangeFilter,
+        CancellationToken cancellationToken)
+    {
+        AdminPkcs11TelemetryExportBundle bundle = await admin.ExportPkcs11TelemetryAsync(
+            new AdminPkcs11TelemetryQuery(
+                Take: take ?? 0,
+                SearchText: searchText,
+                DeviceFilter: deviceFilter,
+                SlotFilter: slotFilter,
+                OperationFilter: operationFilter,
+                MechanismFilter: mechanismFilter,
+                StatusFilter: statusFilter ?? "all",
+                TimeRangeFilter: timeRangeFilter ?? "all"),
+            cancellationToken);
+
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(bundle, AdminApplicationJsonContext.Default.AdminPkcs11TelemetryExportBundle);
+        string fileName = $"pkcs11wrapper-admin-telemetry-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json";
+        return Results.File(payload, "application/json; charset=utf-8", fileName);
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -42,6 +42,7 @@ AdminSessionRegistryOptions sessionOptions = builder.Configuration.GetSection("A
 LocalAdminLoginThrottleOptions throttleOptions = builder.Configuration.GetSection("LocalAdminLoginThrottle").Get<LocalAdminLoginThrottleOptions>() ?? new();
 LocalAdminBootstrapOptions bootstrapOptions = builder.Configuration.GetSection("LocalAdminBootstrap").Get<LocalAdminBootstrapOptions>() ?? new();
 AdminRuntimeOptions runtimeOptions = builder.Configuration.GetSection("AdminRuntime").Get<AdminRuntimeOptions>() ?? new();
+AdminPkcs11TelemetryOptions telemetryOptions = builder.Configuration.GetSection("AdminTelemetry").Get<AdminPkcs11TelemetryOptions>() ?? new();
 
 builder.Services.AddSingleton(adminStorage);
 builder.Services.AddSingleton<IOptions<AdminStorageOptions>>(Options.Create(adminStorage));
@@ -51,6 +52,8 @@ builder.Services.AddSingleton(bootstrapOptions);
 builder.Services.AddSingleton<IOptions<LocalAdminBootstrapOptions>>(Options.Create(bootstrapOptions));
 builder.Services.AddSingleton(runtimeOptions);
 builder.Services.AddSingleton<IOptions<AdminRuntimeOptions>>(Options.Create(runtimeOptions));
+builder.Services.AddSingleton(telemetryOptions);
+builder.Services.AddSingleton<IOptions<AdminPkcs11TelemetryOptions>>(Options.Create(telemetryOptions));
 builder.Services.AddDataProtection()
     .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(adminStorage.DataRoot, "keys")));
 builder.Services.AddSingleton<IDeviceProfileStore, JsonDeviceProfileStore>();
@@ -95,6 +98,8 @@ app.MapPost("/account/login", (Delegate)AccountEndpoints.LoginAsync);
 app.MapPost("/account/logout", (Delegate)AccountEndpoints.LogoutAsync);
 app.MapGet("/configuration/export", (Delegate)ConfigurationEndpoints.ExportAsync)
     .RequireAuthorization(AdminRoles.Admin);
+app.MapGet("/telemetry/export", (Delegate)TelemetryEndpoints.ExportAsync)
+    .RequireAuthorization(AdminRoles.Viewer);
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 

--- a/src/Pkcs11Wrapper.Admin.Web/appsettings.json
+++ b/src/Pkcs11Wrapper.Admin.Web/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AdminTelemetry": {
+    "ActiveFileMaxBytes": 1048576,
+    "RetentionDays": 14,
+    "MaxArchivedFiles": 8,
+    "ExportMaxEntries": 5000
+  }
 }

--- a/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
@@ -167,13 +167,49 @@ public sealed class JsonStoresTests
         }
     }
 
+    [Fact]
+    public async Task JsonPkcs11TelemetryStoreRotatesAndPrunesArchives()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            JsonLinePkcs11TelemetryStore store = new(
+                new AdminStorageOptions { DataRoot = root },
+                new AdminPkcs11TelemetryOptions
+                {
+                    ActiveFileMaxBytes = 350,
+                    MaxArchivedFiles = 2,
+                    RetentionDays = 14,
+                    ExportMaxEntries = 50
+                });
+
+            for (int i = 0; i < 12; i++)
+            {
+                await store.AppendAsync(CreateTelemetry($"Rotate-{i}", DateTimeOffset.UtcNow.AddSeconds(i), actor: "alice", sessionId: $"trace-{i}"));
+            }
+
+            AdminPkcs11TelemetryStorageStatus status = await store.GetStorageStatusAsync();
+            IReadOnlyList<AdminPkcs11TelemetryEntry> retained = await store.ReadAllAsync();
+
+            Assert.InRange(status.ArchivedFileCount, 1, 2);
+            Assert.InRange(status.RetainedFileCount, 1, 3);
+            Assert.True(status.RetainedBytes > 0);
+            Assert.Contains(retained, entry => entry.OperationName == "Rotate-11");
+            Assert.All(retained, entry => Assert.False(string.IsNullOrWhiteSpace(entry.Actor)));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static HsmDeviceProfile CreateProfile(string name)
         => new(Guid.NewGuid(), name, "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
 
     private static AdminAuditLogEntry CreateAudit(string target, string details, DateTimeOffset timestamp)
         => new(Guid.NewGuid(), timestamp, "tester", ["admin"], "cookie", "Device", "Add", target, "Success", details, 0, null, string.Empty, "127.0.0.1", "trace-1", "test-agent", Environment.MachineName);
 
-    private static AdminPkcs11TelemetryEntry CreateTelemetry(string operationName, DateTimeOffset timestamp)
+    private static AdminPkcs11TelemetryEntry CreateTelemetry(string operationName, DateTimeOffset timestamp, string? actor = null, string? sessionId = null)
         => new(
             Guid.NewGuid(),
             timestamp,
@@ -188,6 +224,10 @@ public sealed class JsonStoresTests
             2,
             0x1082,
             null,
+            actor,
+            actor is null ? null : "cookie",
+            sessionId,
+            sessionId,
             [new AdminPkcs11TelemetryField("credential.pin", "Masked", "set(len=8)")]);
 
     private static string CreateTempDirectory()

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryServiceTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryServiceTests.cs
@@ -11,7 +11,7 @@ public sealed class Pkcs11TelemetryServiceTests
     public void ListenerMapsOperationEventsIntoTelemetryEntries()
     {
         RecordingStore store = new();
-        Pkcs11TelemetryService service = new(store);
+        Pkcs11TelemetryService service = new(store, new StaticActorContext(new AdminActorInfo("alice", "cookie", true, ["admin"], "127.0.0.1", "trace-42", "tests")), new AdminPkcs11TelemetryOptions());
         HsmDeviceProfile device = new(Guid.NewGuid(), "Primary", "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
 
         IPkcs11OperationTelemetryListener listener = service.CreateListener(device);
@@ -45,6 +45,10 @@ public sealed class Pkcs11TelemetryServiceTests
         Assert.Equal((ulong)19, entry.SessionHandle);
         Assert.Equal((ulong)0x00000040, entry.MechanismType);
         Assert.Equal("InvalidOperationException", entry.ExceptionType);
+        Assert.Equal("alice", entry.Actor);
+        Assert.Equal("cookie", entry.AuthenticationType);
+        Assert.Equal("trace-42", entry.SessionId);
+        Assert.Equal("trace-42", entry.CorrelationId);
         Assert.DoesNotContain(entry.Fields, field => field.Value?.Contains("should not be persisted", StringComparison.Ordinal) == true);
         Assert.Contains(entry.Fields, field => field.Name == "input" && field.Classification == "LengthOnly" && field.Value == "len=32");
         Assert.Contains(entry.Fields, field => field.Name == "credential.pin" && field.Classification == "Masked" && field.Value == "set(len=8)");
@@ -53,7 +57,7 @@ public sealed class Pkcs11TelemetryServiceTests
     [Fact]
     public void ListenerSwallowsStoreFailures()
     {
-        Pkcs11TelemetryService service = new(new ThrowingStore());
+        Pkcs11TelemetryService service = new(new ThrowingStore(), new StaticActorContext(new AdminActorInfo("alice", "cookie", true, ["admin"], null, "trace-99", null)), new AdminPkcs11TelemetryOptions());
         HsmDeviceProfile device = new(Guid.NewGuid(), "Primary", "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
 
         IPkcs11OperationTelemetryListener listener = service.CreateListener(device);
@@ -71,6 +75,11 @@ public sealed class Pkcs11TelemetryServiceTests
         listener.OnOperationCompleted(in operationEvent);
     }
 
+    private sealed class StaticActorContext(AdminActorInfo actor) : IAdminActorContext
+    {
+        public AdminActorInfo GetCurrent() => actor;
+    }
+
     private sealed class RecordingStore : IPkcs11TelemetryStore
     {
         private readonly List<AdminPkcs11TelemetryEntry> _entries = [];
@@ -85,6 +94,12 @@ public sealed class Pkcs11TelemetryServiceTests
 
         public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([.. _entries.TakeLast(take).Reverse()]);
+
+        public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([.. _entries.OrderByDescending(entry => entry.TimestampUtc)]);
+
+        public Task<AdminPkcs11TelemetryStorageStatus> GetStorageStatusAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new AdminPkcs11TelemetryStorageStatus(0, 0, 0, 0, 1024, 14, 8, 5000));
     }
 
     private sealed class ThrowingStore : IPkcs11TelemetryStore
@@ -94,5 +109,11 @@ public sealed class Pkcs11TelemetryServiceTests
 
         public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([]);
+
+        public Task<IReadOnlyList<AdminPkcs11TelemetryEntry>> ReadAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AdminPkcs11TelemetryEntry>>([]);
+
+        public Task<AdminPkcs11TelemetryStorageStatus> GetStorageStatusAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new AdminPkcs11TelemetryStorageStatus(0, 0, 0, 0, 1024, 14, 8, 5000));
     }
 }

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryViewTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryViewTests.cs
@@ -34,7 +34,7 @@ public sealed class Pkcs11TelemetryViewTests
     }
 
     [Fact]
-    public void ApplySearchesReturnValuesAndRedactedFields()
+    public void ApplySearchesReturnValuesRedactedFieldsAndCorrelationFields()
     {
         DateTimeOffset now = DateTimeOffset.UtcNow;
         AdminPkcs11TelemetryEntry[] items =
@@ -47,6 +47,8 @@ public sealed class Pkcs11TelemetryViewTests
                 slotId: 3,
                 mechanismType: null,
                 returnValue: "CKR_PIN_INCORRECT",
+                actor: "alice",
+                sessionId: "trace-1",
                 fields:
                 [
                     new AdminPkcs11TelemetryField("credential.pin", "Masked", "set(len=8)")
@@ -56,11 +58,17 @@ public sealed class Pkcs11TelemetryViewTests
 
         IReadOnlyList<AdminPkcs11TelemetryEntry> byReturnValue = Pkcs11TelemetryView.Apply(items, "pin_incorrect", null, null, null, null, "all", "all", now);
         IReadOnlyList<AdminPkcs11TelemetryEntry> byFieldName = Pkcs11TelemetryView.Apply(items, "credential.pin", null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byActor = Pkcs11TelemetryView.Apply(items, "alice", null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byTrace = Pkcs11TelemetryView.Apply(items, "trace-1", null, null, null, null, "all", "all", now);
 
         Assert.Single(byReturnValue);
         Assert.Single(byFieldName);
+        Assert.Single(byActor);
+        Assert.Single(byTrace);
         Assert.Equal("Login", byReturnValue[0].OperationName);
         Assert.Equal("Login", byFieldName[0].OperationName);
+        Assert.Equal("Login", byActor[0].OperationName);
+        Assert.Equal("Login", byTrace[0].OperationName);
     }
 
     [Fact]
@@ -80,6 +88,15 @@ public sealed class Pkcs11TelemetryViewTests
         Assert.DoesNotContain(filtered, item => item.Status == "Succeeded");
     }
 
+    [Fact]
+    public void BuildAuditHrefUsesSessionIdWhenAvailable()
+    {
+        string href = Pkcs11TelemetryView.BuildAuditHref(CreateEntry("Primary", "OpenSession", "Succeeded", DateTimeOffset.UtcNow, 1, null, actor: "alice", sessionId: "trace-88", correlationId: "corr-1"));
+
+        Assert.Contains("/audit", href, StringComparison.Ordinal);
+        Assert.Contains("trace-88", href, StringComparison.Ordinal);
+    }
+
     private static AdminPkcs11TelemetryEntry CreateEntry(
         string deviceName,
         string operationName,
@@ -88,6 +105,9 @@ public sealed class Pkcs11TelemetryViewTests
         ulong? slotId,
         ulong? mechanismType,
         string? returnValue = null,
+        string? actor = null,
+        string? sessionId = null,
+        string? correlationId = null,
         AdminPkcs11TelemetryField[]? fields = null)
         => new(
             Guid.NewGuid(),
@@ -103,5 +123,9 @@ public sealed class Pkcs11TelemetryViewTests
             99,
             mechanismType,
             status == "Failed" ? "Pkcs11Exception" : null,
+            actor,
+            actor is null ? null : "cookie",
+            sessionId,
+            correlationId,
             fields ?? []);
 }


### PR DESCRIPTION
## Summary
Add telemetry retention, export, and correlation controls.

## Included work
- size-based rotation and bounded retention/pruning for PKCS#11 telemetry storage
- safe JSON export endpoint with metadata and truncation reporting
- correlation metadata linking telemetry back to admin context/audit review
- docs and admin test coverage

## Notes
- retention is enforced at the store layer so growth stays bounded even without UI usage
- exports only include redacted telemetry payloads

## Closes
Closes #48
