### PR TITLE
Add vendor-aware device profiles and admin UI hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 - Blazor Server admin UI
 - local auth with `viewer` / `operator` / `admin` roles
 - HSM device profile management + configuration export/import
+- vendor-aware device profiles with optional catalog metadata + setup hints
 - slot/token inspection
 - key/object browsing, detail, edit, copy, generate, import, and destroy flows
 - tracked session visibility and control (`login` / `logout` / `cancel` / `close-all` + invalidation visibility)
@@ -245,10 +246,11 @@ The admin panel is designed as an operational layer **on top of** the library in
 
 Current capabilities include:
 
-- device profile CRUD
+- device profile CRUD with optional vendor metadata/profile selection
 - local cookie auth with `viewer` / `operator` / `admin` roles
 - local user management, password rotation, and bootstrap credential lifecycle controls
 - PKCS#11 module connection testing
+- vendor-aware setup hints/caveats on Devices, Slots, Keys, and PKCS#11 Lab when a vendor-tagged profile is selected
 - slot and token browsing
 - key/object listing, detail, edit, copy, generate, import, destroy workflows
 - tracked session login/logout/cancel controls + slot-level close-all

--- a/docs/luna-integration.md
+++ b/docs/luna-integration.md
@@ -138,8 +138,10 @@ The admin panel already supports Luna in the current repo shape, but only throug
    - **Name**: your operational label for the HSM/partition
    - **PKCS#11 Module Path**: the exact Luna library path on that host
    - **Default Token Label**: the Luna partition/keyring label you expect operators to use most often
+   - **Vendor profile**: **Thales Luna / standard PKCS#11** to attach Luna-specific setup reminders without changing the standard PKCS#11 execution model
    - **Notes**: optional client/version/host reminders
 4. use the built-in **Test** action before relying on the profile operationally
+5. once selected, the Devices / Slots / Keys / PKCS#11 Lab pages will surface Luna-aware setup hints and scope boundaries, but they still intentionally stop short of Luna-only operational APIs
 
 ### What to use in the UI
 

--- a/src/Pkcs11Wrapper.Admin.Application/Models/HsmDeviceProfile.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/HsmDeviceProfile.cs
@@ -2,6 +2,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Pkcs11Wrapper.Admin.Application.Models;
 
+public sealed record HsmDeviceVendorMetadata(
+    string VendorId,
+    string VendorName,
+    string? ProfileId,
+    string? ProfileName);
+
 public sealed record HsmDeviceProfile(
     Guid Id,
     string Name,
@@ -10,7 +16,8 @@ public sealed record HsmDeviceProfile(
     string? Notes,
     bool IsEnabled,
     DateTimeOffset CreatedUtc,
-    DateTimeOffset UpdatedUtc);
+    DateTimeOffset UpdatedUtc,
+    HsmDeviceVendorMetadata? Vendor = null);
 
 public sealed class HsmDeviceProfileInput
 {
@@ -27,6 +34,18 @@ public sealed class HsmDeviceProfileInput
 
     [StringLength(2048)]
     public string? Notes { get; set; }
+
+    [StringLength(64)]
+    public string? VendorId { get; set; }
+
+    [StringLength(128)]
+    public string? VendorName { get; set; }
+
+    [StringLength(64)]
+    public string? VendorProfileId { get; set; }
+
+    [StringLength(128)]
+    public string? VendorProfileName { get; set; }
 
     public bool IsEnabled { get; set; } = true;
 }

--- a/src/Pkcs11Wrapper.Admin.Application/Services/DeviceProfileService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/DeviceProfileService.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Pkcs11Wrapper.Admin.Application.Abstractions;
 using Pkcs11Wrapper.Admin.Application.Models;
 
@@ -20,6 +21,7 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
         string normalizedModulePath = ValidateModulePath(input.ModulePath);
         string? normalizedTokenLabel = Normalize(input.DefaultTokenLabel);
         string? normalizedNotes = Normalize(input.Notes);
+        HsmDeviceVendorMetadata? normalizedVendor = NormalizeVendorMetadata(input.VendorId, input.VendorName, input.VendorProfileId, input.VendorProfileName);
         DateTimeOffset now = DateTimeOffset.UtcNow;
 
         EnsureUniqueName(devices, normalizedName, id);
@@ -40,7 +42,8 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
                 DefaultTokenLabel = normalizedTokenLabel,
                 Notes = normalizedNotes,
                 IsEnabled = input.IsEnabled,
-                UpdatedUtc = now
+                UpdatedUtc = now,
+                Vendor = normalizedVendor
             };
 
             devices[index] = updated;
@@ -56,7 +59,8 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
             normalizedNotes,
             input.IsEnabled,
             now,
-            now);
+            now,
+            normalizedVendor);
 
         devices.Add(created);
         await store.SaveAllAsync(devices, cancellationToken);
@@ -203,7 +207,8 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
             DefaultTokenLabel = Normalize(profile.DefaultTokenLabel),
             Notes = Normalize(profile.Notes),
             CreatedUtc = createdUtc,
-            UpdatedUtc = updatedUtc
+            UpdatedUtc = updatedUtc,
+            Vendor = NormalizeVendorMetadata(profile.Vendor)
         };
     }
 
@@ -223,6 +228,74 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
             {
                 throw new InvalidOperationException($"Imported configuration contains duplicate device name '{profile.Name}'.");
             }
+        }
+    }
+
+    private static HsmDeviceVendorMetadata? NormalizeVendorMetadata(HsmDeviceVendorMetadata? vendor)
+        => vendor is null ? null : NormalizeVendorMetadata(vendor.VendorId, vendor.VendorName, vendor.ProfileId, vendor.ProfileName);
+
+    private static HsmDeviceVendorMetadata? NormalizeVendorMetadata(string? vendorId, string? vendorName, string? profileId, string? profileName)
+    {
+        string? normalizedVendorId = NormalizeIdentifier(vendorId);
+        string? normalizedVendorName = Normalize(vendorName);
+        string? normalizedProfileId = NormalizeIdentifier(profileId);
+        string? normalizedProfileName = Normalize(profileName);
+
+        if (normalizedVendorId is null && normalizedVendorName is null && normalizedProfileId is null && normalizedProfileName is null)
+        {
+            return null;
+        }
+
+        normalizedVendorId ??= NormalizeIdentifier(normalizedVendorName)
+            ?? throw new ArgumentException("Vendor metadata requires a vendor id or vendor name.", nameof(vendorId));
+        normalizedVendorName ??= normalizedVendorId;
+        normalizedProfileId ??= NormalizeIdentifier(normalizedProfileName);
+        normalizedProfileName ??= normalizedProfileId;
+
+        ValidateOptionalLength(normalizedVendorId, 64, "Vendor id");
+        ValidateOptionalLength(normalizedVendorName, 128, "Vendor name");
+        ValidateOptionalLength(normalizedProfileId, 64, "Vendor profile id");
+        ValidateOptionalLength(normalizedProfileName, 128, "Vendor profile name");
+
+        return new(normalizedVendorId, normalizedVendorName, normalizedProfileId, normalizedProfileName);
+    }
+
+    private static string? NormalizeIdentifier(string? value)
+    {
+        string? normalized = Normalize(value);
+        if (normalized is null)
+        {
+            return null;
+        }
+
+        StringBuilder builder = new(normalized.Length);
+        bool pendingSeparator = false;
+        foreach (char character in normalized)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                if (pendingSeparator && builder.Length > 0)
+                {
+                    builder.Append('-');
+                }
+
+                builder.Append(char.ToLowerInvariant(character));
+                pendingSeparator = false;
+            }
+            else
+            {
+                pendingSeparator = builder.Length > 0;
+            }
+        }
+
+        return builder.Length == 0 ? null : builder.ToString();
+    }
+
+    private static void ValidateOptionalLength(string? value, int maxLength, string description)
+    {
+        if (value is not null && value.Length > maxLength)
+        {
+            throw new ArgumentException($"{description} must be {maxLength} characters or fewer.", description);
         }
     }
 

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Devices.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Devices.razor
@@ -9,11 +9,12 @@
     <div class="page-hero-copy">
         <div class="page-eyebrow">Device inventory</div>
         <h1>HSM Devices</h1>
-        <p class="page-lead">PKCS#11 module path'lerini tanımla, bağlantı testi yap ve admin panelinin hangi cihazlara erişeceğini yönet. Hedef burada sadece CRUD değil; cihaz envanterini okunaklı, güven veren ve operatörün hızlı karar verebileceği bir yüzeyde sunmak.</p>
+        <p class="page-lead">PKCS#11 module path'lerini tanımla, bağlantı testi yap ve admin panelinin hangi cihazlara erişeceğini yönet. Bu yüzey artık vendor metadata/profile seçimini de taşıyor; böylece operatör, standart PKCS#11 sınırını korurken cihazın vendor'a özgü kurulum caveat'larını da aynı yerden görebiliyor.</p>
         <div class="page-hero-tags">
             <span class="page-tag">Profile catalog</span>
             <span class="page-tag">Connection testing</span>
             <span class="page-tag">Operational filtering</span>
+            <span class="page-tag">Vendor-aware hints</span>
             @if (_isAdmin)
             {
                 <span class="page-tag">Admin-managed changes</span>
@@ -24,7 +25,7 @@
         <div class="hero-panel">
             <div class="hero-panel-title">Change authority</div>
             <div class="hero-panel-value">@(_isAdmin ? "Admin write access" : "Read / test only")</div>
-            <div class="hero-panel-copy">Only admin accounts can create, edit, or delete profiles; operators focus on inspection and connection verification.</div>
+            <div class="hero-panel-copy">Only admin accounts can create, edit, or delete profiles; operators focus on inspection, connection verification, and reading the attached vendor guidance.</div>
         </div>
         <div class="hero-panel">
             <div class="hero-panel-title">Primary outcome</div>
@@ -61,8 +62,9 @@
         <div class="col-xl-3 col-md-6">
             <div class="card shadow-sm h-100 metric-card">
                 <div class="card-body">
-                    <div class="metric-label">Disabled devices</div>
-                    <div class="display-6 metric-meta">@_devices.Count(device => !device.IsEnabled)</div>
+                    <div class="metric-label">Vendor-tagged profiles</div>
+                    <div class="display-6 metric-meta">@_devices.Count(device => device.Vendor is not null)</div>
+                    <div class="small metric-note">Generic profiles still work without vendor selection.</div>
                 </div>
             </div>
         </div>
@@ -80,7 +82,7 @@
 
 <div class="row g-4">
     <div class="col-lg-4">
-        <div class="card shadow-sm feature-card">
+        <div class="card shadow-sm feature-card mb-4">
             <div class="card-header">@(_editingId is null ? "Add Device" : "Edit Device")</div>
             <div class="card-body">
                 <EditForm Model="_input" OnValidSubmit="SaveAsync">
@@ -100,6 +102,41 @@
                         <InputText class="form-control" @bind-Value="_input.DefaultTokenLabel" data-testid="device-token-label" />
                     </div>
                     <div class="mb-3">
+                        <label class="form-label">Vendor profile</label>
+                        <select class="form-select" @bind="_vendorSelection" @bind:after="OnVendorSelectionChanged" data-testid="device-vendor-profile">
+                            <option value="@DeviceVendorProfileCatalog.VendorNeutralSelectionId">Vendor-neutral / generic</option>
+                            @foreach (DeviceVendorProfileDefinition profile in DeviceVendorProfileCatalog.Profiles)
+                            {
+                                <option value="@profile.SelectionId">@profile.DisplayName</option>
+                            }
+                            <option value="@DeviceVendorProfileCatalog.CustomSelectionId">Custom vendor metadata</option>
+                        </select>
+                        <div class="form-text">Optional. Use a built-in profile for reusable hints, or keep the profile generic when you only want standard PKCS#11 behavior.</div>
+                    </div>
+
+                    @if (SelectedCatalogProfile is not null)
+                    {
+                        <div class="surface-item mb-3">
+                            <div class="fw-semibold">@SelectedCatalogProfile.DisplayName</div>
+                            <div class="small text-muted mt-1">@SelectedCatalogProfile.Summary</div>
+                        </div>
+                    }
+                    else if (_vendorSelection == DeviceVendorProfileCatalog.CustomSelectionId)
+                    {
+                        <div class="row g-3 mb-3">
+                            <div class="col-12">
+                                <label class="form-label">Vendor name</label>
+                                <InputText class="form-control" @bind-Value="_input.VendorName" data-testid="device-vendor-name" />
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">Vendor profile label</label>
+                                <InputText class="form-control" @bind-Value="_input.VendorProfileName" data-testid="device-vendor-profile-name" />
+                                <div class="form-text">Optional label such as client family, module wrapper, or standard PKCS#11 track for this vendor.</div>
+                            </div>
+                        </div>
+                    }
+
+                    <div class="mb-3">
                         <label class="form-label">Notes</label>
                         <InputTextArea class="form-control" @bind-Value="_input.Notes" data-testid="device-notes" />
                     </div>
@@ -118,6 +155,8 @@
                 </EditForm>
             </div>
         </div>
+
+        <DeviceVendorHintsPanel Vendor="VendorPreview" Heading="Selected profile guidance" ShowWhenVendorNeutral="true" />
     </div>
 
     <div class="col-lg-8">
@@ -129,7 +168,7 @@
             <div class="card-body border-bottom row g-3 align-items-end">
                 <div class="col-lg-5">
                     <label class="form-label">Search</label>
-                    <input class="form-control" @bind="_searchText" @bind:event="oninput" placeholder="name, path, token, notes..." />
+                    <input class="form-control" @bind="_searchText" @bind:event="oninput" placeholder="name, path, token, vendor, notes..." />
                 </div>
                 <div class="col-lg-3 col-md-6">
                     <label class="form-label">Status</label>
@@ -168,6 +207,7 @@
                                     <th>Name</th>
                                     <th>Module Path</th>
                                     <th>Token</th>
+                                    <th>Vendor</th>
                                     <th>Status</th>
                                     <th>Updated</th>
                                     <th class="text-end">Actions</th>
@@ -179,10 +219,29 @@
                                     <tr class="@(_editingId == device.Id ? "table-active" : null)">
                                         <td>
                                             <div class="fw-semibold">@device.Name</div>
-                                            <div class="small text-muted">@device.Notes</div>
+                                            @if (!string.IsNullOrWhiteSpace(device.Notes))
+                                            {
+                                                <div class="small text-muted">@device.Notes</div>
+                                            }
                                         </td>
                                         <td><code>@device.ModulePath</code></td>
                                         <td>@(string.IsNullOrWhiteSpace(device.DefaultTokenLabel) ? "—" : device.DefaultTokenLabel)</td>
+                                        <td>
+                                            @if (device.Vendor is null)
+                                            {
+                                                <span class="small text-muted">Generic</span>
+                                            }
+                                            else
+                                            {
+                                                <div class="d-flex flex-wrap gap-2">
+                                                    <span class="table-pill">@device.Vendor.VendorName</span>
+                                                    @if (!string.IsNullOrWhiteSpace(device.Vendor.ProfileName))
+                                                    {
+                                                        <span class="table-pill">@device.Vendor.ProfileName</span>
+                                                    }
+                                                </div>
+                                            }
+                                        </td>
                                         <td>
                                             @if (device.IsEnabled)
                                             {
@@ -223,8 +282,11 @@
     private string _searchText = string.Empty;
     private string _statusFilter = "all";
     private string _sortMode = "name";
+    private string _vendorSelection = DeviceVendorProfileCatalog.VendorNeutralSelectionId;
 
     private IReadOnlyList<HsmDeviceProfile> FilteredDevices => ApplyOrdering(_devices.Where(MatchesFilters)).ToArray();
+    private DeviceVendorProfileDefinition? SelectedCatalogProfile => DeviceVendorProfileCatalog.FindBySelectionId(_vendorSelection);
+    private HsmDeviceVendorMetadata? VendorPreview => BuildVendorPreview();
 
     protected override async Task OnInitializedAsync()
     {
@@ -273,6 +335,11 @@
         _input.DefaultTokenLabel = device.DefaultTokenLabel;
         _input.Notes = device.Notes;
         _input.IsEnabled = device.IsEnabled;
+        _input.VendorId = device.Vendor?.VendorId;
+        _input.VendorName = device.Vendor?.VendorName;
+        _input.VendorProfileId = device.Vendor?.ProfileId;
+        _input.VendorProfileName = device.Vendor?.ProfileName;
+        _vendorSelection = DeviceVendorProfileCatalog.GetSelectionId(device.Vendor);
     }
 
     private void ResetForm()
@@ -283,28 +350,75 @@
         _input.DefaultTokenLabel = string.Empty;
         _input.Notes = string.Empty;
         _input.IsEnabled = true;
+        ClearVendorMetadata();
+        _vendorSelection = DeviceVendorProfileCatalog.VendorNeutralSelectionId;
+    }
+
+    private void OnVendorSelectionChanged()
+    {
+        if (_vendorSelection == DeviceVendorProfileCatalog.VendorNeutralSelectionId)
+        {
+            ClearVendorMetadata();
+            return;
+        }
+
+        if (_vendorSelection == DeviceVendorProfileCatalog.CustomSelectionId)
+        {
+            _input.VendorName ??= string.Empty;
+            _input.VendorProfileName ??= string.Empty;
+            _input.VendorId ??= string.Empty;
+            _input.VendorProfileId ??= string.Empty;
+            return;
+        }
+
+        DeviceVendorProfileDefinition? profile = SelectedCatalogProfile;
+        if (profile is null)
+        {
+            return;
+        }
+
+        _input.VendorId = profile.VendorId;
+        _input.VendorName = profile.VendorName;
+        _input.VendorProfileId = profile.ProfileId;
+        _input.VendorProfileName = profile.ProfileName;
     }
 
     private async Task TestAsync(Guid id)
     {
-        HsmConnectionTestResult result = await Admin.TestConnectionAsync(id);
-        _statusMessage = result.Success
-            ? $"{result.Message} Manufacturer={result.ManufacturerId}, Library={result.LibraryDescription}, InterfaceDiscovery={result.SupportsInterfaceDiscovery}."
-            : $"Connection test failed: {result.Message}";
-        _statusIsError = !result.Success;
+        try
+        {
+            HsmConnectionTestResult result = await Admin.TestConnectionAsync(id);
+            _statusMessage = result.Success
+                ? $"{result.Message} Manufacturer={result.ManufacturerId}, Library={result.LibraryDescription}, InterfaceDiscovery={result.SupportsInterfaceDiscovery}."
+                : $"Connection test failed: {result.Message}";
+            _statusIsError = !result.Success;
+        }
+        catch (Exception ex)
+        {
+            _statusMessage = ex.Message;
+            _statusIsError = true;
+        }
     }
 
     private async Task DeleteAsync(Guid id)
     {
-        await Admin.DeleteDeviceAsync(id);
-        _statusMessage = "Device deleted.";
-        _statusIsError = false;
-        if (_editingId == id)
+        try
         {
-            ResetForm();
-        }
+            await Admin.DeleteDeviceAsync(id);
+            _statusMessage = "Device deleted.";
+            _statusIsError = false;
+            if (_editingId == id)
+            {
+                ResetForm();
+            }
 
-        await LoadAsync();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            _statusMessage = ex.Message;
+            _statusIsError = true;
+        }
     }
 
     private bool MatchesFilters(HsmDeviceProfile device)
@@ -315,7 +429,9 @@
             bool matchesSearch = Contains(device.Name, term)
                 || Contains(device.ModulePath, term)
                 || Contains(device.DefaultTokenLabel, term)
-                || Contains(device.Notes, term);
+                || Contains(device.Notes, term)
+                || Contains(device.Vendor?.VendorName, term)
+                || Contains(device.Vendor?.ProfileName, term);
             if (!matchesSearch)
             {
                 return false;
@@ -338,6 +454,71 @@
             "enabled" => devices.OrderByDescending(device => device.IsEnabled).ThenBy(device => device.Name, StringComparer.OrdinalIgnoreCase),
             _ => devices.OrderBy(device => device.Name, StringComparer.OrdinalIgnoreCase)
         };
+
+    private HsmDeviceVendorMetadata? BuildVendorPreview()
+    {
+        string? vendorId = NormalizePreviewPart(_input.VendorId) ?? ToPreviewIdentifier(_input.VendorName);
+        string? vendorName = NormalizePreviewPart(_input.VendorName);
+        string? profileId = NormalizePreviewPart(_input.VendorProfileId) ?? ToPreviewIdentifier(_input.VendorProfileName);
+        string? profileName = NormalizePreviewPart(_input.VendorProfileName);
+
+        if (vendorId is null && vendorName is null && profileId is null && profileName is null)
+        {
+            return null;
+        }
+
+        vendorId ??= ToPreviewIdentifier(vendorName);
+        if (vendorId is null)
+        {
+            return null;
+        }
+
+        vendorName ??= vendorId;
+        profileName ??= profileId;
+        return new(vendorId, vendorName, profileId, profileName);
+    }
+
+    private void ClearVendorMetadata()
+    {
+        _input.VendorId = string.Empty;
+        _input.VendorName = string.Empty;
+        _input.VendorProfileId = string.Empty;
+        _input.VendorProfileName = string.Empty;
+    }
+
+    private static string? NormalizePreviewPart(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? ToPreviewIdentifier(string? value)
+    {
+        string? normalized = NormalizePreviewPart(value);
+        if (normalized is null)
+        {
+            return null;
+        }
+
+        System.Text.StringBuilder builder = new(normalized.Length);
+        bool pendingSeparator = false;
+        foreach (char character in normalized)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                if (pendingSeparator && builder.Length > 0)
+                {
+                    builder.Append('-');
+                }
+
+                builder.Append(char.ToLowerInvariant(character));
+                pendingSeparator = false;
+            }
+            else
+            {
+                pendingSeparator = builder.Length > 0;
+            }
+        }
+
+        return builder.Length == 0 ? null : builder.ToString();
+    }
 
     private static bool Contains(string? value, string term)
         => value?.Contains(term, StringComparison.OrdinalIgnoreCase) == true;

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor
@@ -80,6 +80,8 @@
     </div>
 </div>
 
+<DeviceVendorHintsPanel Vendor="SelectedDevice?.Vendor" Heading="Selected device guidance" ShowWhenVendorNeutral="false" />
+
 @if (_slotCapabilities is not null)
 {
     <div class="card shadow-sm mb-4 feature-card">

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor.cs
@@ -41,6 +41,10 @@ public partial class Keys
     private bool _statusIsError;
     private bool _isOperator;
 
+    private HsmDeviceProfile? SelectedDevice
+        => Guid.TryParse(_selectedDeviceId, out Guid deviceId)
+            ? _devices.FirstOrDefault(device => device.Id == deviceId)
+            : null;
     private bool CanLoadKeys => Guid.TryParse(_selectedDeviceId, out _) && nuint.TryParse(_selectedSlotId, out _);
     private bool CanManageKeys => CanLoadKeys && !string.IsNullOrWhiteSpace(_userPin);
     private bool CanGenerateAes => CanManageKeys && _slotCapabilities?.SupportsAesKeyGeneration == true;

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor
@@ -92,6 +92,8 @@
     </div>
 </div>
 
+<DeviceVendorHintsPanel Vendor="SelectedDevice?.Vendor" Heading="Selected device guidance" ShowWhenVendorNeutral="false" />
+
 <div class="row g-3 mb-4">
     <div class="col-xl-3 col-md-6">
         <div class="card shadow-sm h-100 metric-card">

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor.cs
@@ -107,6 +107,11 @@ public partial class Pkcs11Lab
 
     private sealed record LabHistoryItem(DateTimeOffset RecordedAt, Pkcs11LabRequest Request, Pkcs11LabExecutionResult Result);
 
+    private HsmDeviceProfile? SelectedDevice
+        => Guid.TryParse(_selectedDeviceId, out Guid deviceId)
+            ? _devices.FirstOrDefault(device => device.Id == deviceId)
+            : null;
+
     private bool RequiresSlot => _request.Operation is Pkcs11LabOperation.MechanismList
         or Pkcs11LabOperation.MechanismInfo
         or Pkcs11LabOperation.SessionInfo

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
@@ -67,6 +67,8 @@
     </div>
 </div>
 
+<DeviceVendorHintsPanel Vendor="SelectedDevice?.Vendor" Heading="Selected device guidance" ShowWhenVendorNeutral="false" />
+
 @if (_slots.Count != 0)
 {
     <div class="row g-3 mb-4">
@@ -244,6 +246,10 @@
     private string _sortMode = "slot";
 
     private IReadOnlyList<HsmSlotSummary> FilteredSlots => ApplyOrdering(_slots.Where(MatchesFilters)).ToArray();
+    private HsmDeviceProfile? SelectedDevice
+        => Guid.TryParse(_selectedDeviceId, out Guid deviceId)
+            ? _devices.FirstOrDefault(device => device.Id == deviceId)
+            : null;
 
     private IReadOnlyList<AdminSessionSnapshot> CurrentDeviceSessions
         => Guid.TryParse(_selectedDeviceId, out Guid deviceId)

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorHintsPanel.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorHintsPanel.razor
@@ -1,0 +1,78 @@
+@using Pkcs11Wrapper.Admin.Application.Models
+
+@if (_guidance is not null)
+{
+    <div class="card shadow-sm feature-card accent-card-info vendor-guidance-card">
+        <div class="card-header d-flex justify-content-between align-items-center gap-3">
+            <span>@Heading</span>
+            <span class="small text-muted">@(_guidance.IsVendorNeutral ? "Generic guidance" : (_guidance.IsKnownProfile ? "Catalog profile" : "Custom metadata"))</span>
+        </div>
+        <div class="card-body d-flex flex-column gap-3">
+            <div class="d-flex flex-wrap gap-2 align-items-center">
+                <span class="table-pill">@_guidance.Title</span>
+                @if (!string.IsNullOrWhiteSpace(_guidance.ProfileName))
+                {
+                    <span class="table-pill">@_guidance.ProfileName</span>
+                }
+            </div>
+
+            <div class="small text-muted">@_guidance.Summary</div>
+
+            <div class="surface-stack">
+                @foreach (DeviceVendorHint hint in VisibleHints)
+                {
+                    <div class="surface-item vendor-hint-item">
+                        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+                            <div class="fw-semibold">@hint.Title</div>
+                            <span class="badge @GetBadgeClass(hint.Tone)">@GetToneLabel(hint.Tone)</span>
+                        </div>
+                        <div class="small text-muted">@hint.Body</div>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public string Heading { get; set; } = "Vendor setup guidance";
+
+    [Parameter]
+    public HsmDeviceVendorMetadata? Vendor { get; set; }
+
+    [Parameter]
+    public bool ShowWhenVendorNeutral { get; set; } = true;
+
+    [Parameter]
+    public int MaxHints { get; set; } = 3;
+
+    private DeviceVendorGuidance? _guidance;
+
+    private IReadOnlyList<DeviceVendorHint> VisibleHints
+        => _guidance is null
+            ? []
+            : _guidance.Hints.Take(Math.Max(1, MaxHints)).ToArray();
+
+    protected override void OnParametersSet()
+    {
+        DeviceVendorGuidance guidance = DeviceVendorProfileCatalog.GetGuidance(Vendor);
+        _guidance = !ShowWhenVendorNeutral && guidance.IsVendorNeutral ? null : guidance;
+    }
+
+    private static string GetBadgeClass(DeviceVendorHintTone tone)
+        => tone switch
+        {
+            DeviceVendorHintTone.Warning => "text-bg-warning",
+            DeviceVendorHintTone.Boundary => "text-bg-secondary",
+            _ => "text-bg-primary"
+        };
+
+    private static string GetToneLabel(DeviceVendorHintTone tone)
+        => tone switch
+        {
+            DeviceVendorHintTone.Warning => "Caveat",
+            DeviceVendorHintTone.Boundary => "Boundary",
+            _ => "Hint"
+        };
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
@@ -1,0 +1,196 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Web.Components.Shared;
+
+internal static class DeviceVendorProfileCatalog
+{
+    public const string VendorNeutralSelectionId = "vendor-neutral";
+    public const string CustomSelectionId = "custom";
+
+    public static IReadOnlyList<DeviceVendorProfileDefinition> Profiles { get; } =
+    [
+        new(
+            "thales-luna-standard",
+            "Thales Luna / standard PKCS#11",
+            "thales",
+            "Thales",
+            "luna-standard",
+            "Luna / standard PKCS#11",
+            "Use this when the admin host already has the Luna client/runtime installed and you want vendor-aware reminders while staying inside the repo's current standard PKCS#11 scope.",
+            [
+                new DeviceVendorHint(
+                    "Client/runtime must already exist on this host",
+                    "Point the profile at the exact Luna PKCS#11 library path visible to the running admin host or container. If your environment intentionally uses cklog or ckshim wrappers, point at that wrapper explicitly and validate the underlying Luna client configuration outside the app first.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Treat Luna capability differences as runtime reality",
+                    "Use the built-in Test action plus Slots/Keys inspection before assuming every standard call, mechanism, or PKCS#11 v3 path is available. Some Luna behavior is token/policy dependent and some v3 paths remain capability-gated or unverified in current repo guidance.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Luna-only CA_* admin flows stay out of scope here",
+                    "The admin UI remains focused on standard PKCS#11 device, slot, object, and lab workflows. HA control, cloning, PED/MofN, policy-admin, and other Luna-only extension families are intentionally not implemented on this surface.",
+                    DeviceVendorHintTone.Boundary)
+            ]),
+        new(
+            "entrust-nshield-standard",
+            "Entrust nShield / standard PKCS#11",
+            "entrust",
+            "Entrust",
+            "nshield-standard",
+            "nShield / standard PKCS#11",
+            "Use this when a device profile targets the standard PKCS#11 face of an Entrust nShield environment and you want the UI to keep vendor setup caveats visible without introducing vendor-specific operations.",
+            [
+                new DeviceVendorHint(
+                    "Run the admin app where the vendor client/world is already configured",
+                    "This UI does not bootstrap Security World or client runtime prerequisites for you. Use the exact module path that the running host/container can resolve and verify vendor prerequisites before relying on the profile operationally.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Confirm policy and mechanism exposure with live slot inspection",
+                    "Mechanism availability, object policy, and slot behavior can vary with the prepared world/HSM configuration. Use Test, Slots, and Keys pages to confirm what the module actually exposes instead of assuming a generic baseline.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Keep vendor administration outside this UI",
+                    "This profile is for standard PKCS#11 interaction only. Vendor-native provisioning, operational control, or lifecycle tooling should remain in vendor-specific operational paths rather than being inferred from the generic admin panel.",
+                    DeviceVendorHintTone.Boundary)
+            ]),
+        new(
+            "utimaco-standard",
+            "Utimaco / standard PKCS#11",
+            "utimaco",
+            "Utimaco",
+            "standard",
+            "Standard PKCS#11",
+            "Use this when the profile points at a Utimaco PKCS#11 module and you want the admin UI to keep standard-vs-vendor boundaries explicit while still guiding operators toward the right validation steps.",
+            [
+                new DeviceVendorHint(
+                    "Module path + runtime prerequisites are explicit",
+                    "The admin panel only uses the module path you configure. Make sure the vendor runtime, libraries, and any required host/container configuration are already present on the same machine that runs this app.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Validate token behavior from the live module",
+                    "Use connection testing, slot inventory, and the PKCS#11 Lab to confirm token presence, mechanism exposure, and object behavior in the actual environment. Vendor policy differences should be discovered from the runtime rather than assumed from generic docs.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Stay on the vendor-neutral operational surface",
+                    "This UI intentionally covers standard PKCS#11 workflows. Vendor-specific appliance or security-administration tasks remain out of scope and should stay in dedicated vendor tooling/processes.",
+                    DeviceVendorHintTone.Boundary)
+            ])
+    ];
+
+    public static DeviceVendorGuidance GetGuidance(HsmDeviceVendorMetadata? vendor)
+    {
+        if (vendor is null)
+        {
+            return CreateGenericGuidance();
+        }
+
+        DeviceVendorProfileDefinition? knownProfile = Profiles.FirstOrDefault(profile => profile.Matches(vendor));
+        return knownProfile is not null
+            ? CreateKnownProfileGuidance(knownProfile)
+            : CreateCustomVendorGuidance(vendor);
+    }
+
+    public static string GetSelectionId(HsmDeviceVendorMetadata? vendor)
+    {
+        if (vendor is null)
+        {
+            return VendorNeutralSelectionId;
+        }
+
+        DeviceVendorProfileDefinition? knownProfile = Profiles.FirstOrDefault(profile => profile.Matches(vendor));
+        return knownProfile?.SelectionId ?? CustomSelectionId;
+    }
+
+    public static DeviceVendorProfileDefinition? FindBySelectionId(string? selectionId)
+        => Profiles.FirstOrDefault(profile => string.Equals(profile.SelectionId, selectionId, StringComparison.Ordinal));
+
+    private static DeviceVendorGuidance CreateGenericGuidance()
+        => new(
+            "Vendor-neutral profile",
+            null,
+            "Use the generic path when you only need an explicit module path plus the normal standard PKCS#11 inventory/test workflows. You can still attach a vendor profile later without changing the rest of the device shape.",
+            [
+                new DeviceVendorHint(
+                    "Treat the module path as host-specific runtime configuration",
+                    "The admin app loads exactly the library path you store here. Keep that path accurate for the host/container that runs the panel and use the built-in Test action after changes.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Use device notes for environment breadcrumbs",
+                    "Record token labels, host-specific wrapper choices, client versions, or operator caveats in the Notes field so the profile remains understandable when someone revisits it later.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Vendor-specific operations still belong elsewhere",
+                    "This UI focuses on standard PKCS#11 management and diagnostics. If a scenario needs vendor-native control planes or extension APIs, keep that work out of the generic device workflow and document the boundary clearly.",
+                    DeviceVendorHintTone.Boundary)
+            ],
+            IsKnownProfile: false,
+            IsVendorNeutral: true);
+
+    private static DeviceVendorGuidance CreateKnownProfileGuidance(DeviceVendorProfileDefinition profile)
+        => new(
+            profile.VendorName,
+            profile.ProfileName ?? profile.DisplayName,
+            profile.Summary,
+            profile.Hints,
+            IsKnownProfile: true,
+            IsVendorNeutral: false);
+
+    private static DeviceVendorGuidance CreateCustomVendorGuidance(HsmDeviceVendorMetadata vendor)
+    {
+        string title = string.IsNullOrWhiteSpace(vendor.VendorName) ? "Custom vendor profile" : vendor.VendorName;
+        string? profileName = string.IsNullOrWhiteSpace(vendor.ProfileName) ? null : vendor.ProfileName;
+
+        return new(
+            title,
+            profileName,
+            "This device carries explicit vendor metadata even though it does not match one of the built-in profiles. The admin UI keeps the identity visible and falls back to generic vendor-aware guidance.",
+            [
+                new DeviceVendorHint(
+                    "Keep runtime prerequisites explicit",
+                    "Make sure the vendor client/runtime and any host-specific configuration already exist on the machine that runs the admin panel. Store the exact module path that this host resolves.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Validate behavior from the real module",
+                    "Use Test, Slots, Keys, and the PKCS#11 Lab to confirm what this vendor/module combination actually exposes. Capability differences should come from the live runtime, not assumption.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Use metadata for identity, not for hidden automation",
+                    "Vendor metadata is intended to improve operator context and future extensibility. It should not imply that vendor-native operational APIs are available through the current admin surface.",
+                    DeviceVendorHintTone.Boundary)
+            ],
+            IsKnownProfile: false,
+            IsVendorNeutral: false);
+    }
+}
+
+internal sealed record DeviceVendorProfileDefinition(
+    string SelectionId,
+    string DisplayName,
+    string VendorId,
+    string VendorName,
+    string? ProfileId,
+    string? ProfileName,
+    string Summary,
+    IReadOnlyList<DeviceVendorHint> Hints)
+{
+    public bool Matches(HsmDeviceVendorMetadata vendor)
+        => string.Equals(VendorId, vendor.VendorId, StringComparison.Ordinal)
+            && string.Equals(ProfileId, vendor.ProfileId, StringComparison.Ordinal);
+}
+
+internal sealed record DeviceVendorGuidance(
+    string Title,
+    string? ProfileName,
+    string Summary,
+    IReadOnlyList<DeviceVendorHint> Hints,
+    bool IsKnownProfile,
+    bool IsVendorNeutral);
+
+internal sealed record DeviceVendorHint(string Title, string Body, DeviceVendorHintTone Tone);
+
+internal enum DeviceVendorHintTone
+{
+    Info,
+    Warning,
+    Boundary
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Components/_Imports.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/_Imports.razor
@@ -16,3 +16,4 @@
 @using Pkcs11Wrapper.Admin.Web
 @using Pkcs11Wrapper.Admin.Web.Components
 @using Pkcs11Wrapper.Admin.Web.Components.Layout
+@using Pkcs11Wrapper.Admin.Web.Components.Shared

--- a/src/Pkcs11Wrapper.Admin.Web/wwwroot/app.css
+++ b/src/Pkcs11Wrapper.Admin.Web/wwwroot/app.css
@@ -538,6 +538,14 @@ textarea::placeholder {
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
+.vendor-guidance-card {
+    margin-bottom: 1.5rem;
+}
+
+.vendor-hint-item {
+    background: rgba(240, 249, 255, 0.66);
+}
+
 .surface-stack {
     display: flex;
     flex-direction: column;

--- a/tests/Pkcs11Wrapper.Admin.Tests/ConfigurationTransferTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/ConfigurationTransferTests.cs
@@ -13,7 +13,11 @@ public sealed class ConfigurationTransferTests
     {
         HsmAdminService service = CreateService(
         [
-            CreateProfile(Guid.NewGuid(), "Primary HSM", "/usr/lib/libpkcs11.so")
+            CreateProfile(
+                Guid.NewGuid(),
+                "Primary HSM",
+                "/usr/lib/libpkcs11.so",
+                new HsmDeviceVendorMetadata("thales", "Thales", "luna-standard", "Luna / standard PKCS#11"))
         ]);
 
         AdminConfigurationExportBundle bundle = await service.ExportConfigurationAsync();
@@ -25,6 +29,8 @@ public sealed class ConfigurationTransferTests
         Assert.Contains("ProtectedPinCache", bundle.ExcludedSections);
         Assert.Single(bundle.DeviceProfiles);
         Assert.Equal("Primary HSM", bundle.DeviceProfiles[0].Name);
+        Assert.Equal("Thales", bundle.DeviceProfiles[0].Vendor?.VendorName);
+        Assert.Equal("luna-standard", bundle.DeviceProfiles[0].Vendor?.ProfileId);
     }
 
     [Fact]
@@ -106,10 +112,10 @@ public sealed class ConfigurationTransferTests
         return new HsmAdminService(deviceProfiles, auditLog, new AdminSessionRegistry(), new AllowAllAuthorizationService());
     }
 
-    private static HsmDeviceProfile CreateProfile(Guid id, string name, string modulePath)
+    private static HsmDeviceProfile CreateProfile(Guid id, string name, string modulePath, HsmDeviceVendorMetadata? vendor = null)
     {
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        return new HsmDeviceProfile(id, name, modulePath, null, null, true, now, now);
+        return new HsmDeviceProfile(id, name, modulePath, null, null, true, now, now, vendor);
     }
 
     private sealed class InMemoryDeviceProfileStore(IReadOnlyList<HsmDeviceProfile> seed) : IDeviceProfileStore

--- a/tests/Pkcs11Wrapper.Admin.Tests/DeviceProfileServiceTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/DeviceProfileServiceTests.cs
@@ -40,6 +40,59 @@ public sealed class DeviceProfileServiceTests
     }
 
     [Fact]
+    public async Task UpsertAsyncStoresVendorMetadata()
+    {
+        InMemoryDeviceProfileStore store = new();
+        DeviceProfileService service = new(store);
+
+        HsmDeviceProfile created = await service.UpsertAsync(null, new HsmDeviceProfileInput
+        {
+            Name = "Vendor tagged",
+            ModulePath = "/usr/lib/libpkcs11.so",
+            VendorId = "Thales",
+            VendorName = "Thales",
+            VendorProfileId = "Luna Standard",
+            VendorProfileName = "Luna / standard PKCS#11"
+        });
+
+        Assert.NotNull(created.Vendor);
+        Assert.Equal("thales", created.Vendor!.VendorId);
+        Assert.Equal("Thales", created.Vendor.VendorName);
+        Assert.Equal("luna-standard", created.Vendor.ProfileId);
+        Assert.Equal("Luna / standard PKCS#11", created.Vendor.ProfileName);
+    }
+
+    [Fact]
+    public async Task ImportAsyncNormalizesVendorMetadataForCustomProfiles()
+    {
+        InMemoryDeviceProfileStore store = new();
+        DeviceProfileService service = new(store);
+
+        AdminConfigurationImportResult result = await service.ImportAsync(
+        [
+            new HsmDeviceProfile(
+                Guid.NewGuid(),
+                "Imported",
+                "/opt/vendor-pkcs11.so",
+                null,
+                null,
+                true,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
+                new HsmDeviceVendorMetadata("", "Future Vendor", null, "Client Wrapper A"))
+        ],
+        AdminConfigurationImportMode.Merge);
+
+        HsmDeviceProfile imported = Assert.Single(await service.GetAllAsync());
+        Assert.NotNull(imported.Vendor);
+        Assert.Equal("future-vendor", imported.Vendor!.VendorId);
+        Assert.Equal("Future Vendor", imported.Vendor.VendorName);
+        Assert.Equal("client-wrapper-a", imported.Vendor.ProfileId);
+        Assert.Equal("Client Wrapper A", imported.Vendor.ProfileName);
+        Assert.Equal(1, result.AddedDeviceProfileCount);
+    }
+
+    [Fact]
     public async Task UpsertAsyncRejectsMissingNameOrModulePath()
     {
         InMemoryDeviceProfileStore store = new();

--- a/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
@@ -13,13 +13,24 @@ public sealed class JsonStoresTests
         try
         {
             JsonDeviceProfileStore store = new(new AdminStorageOptions { DataRoot = root });
-            HsmDeviceProfile profile = new(Guid.NewGuid(), "Test", "/tmp/libpkcs11.so", "token", "notes", true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+            HsmDeviceProfile profile = new(
+                Guid.NewGuid(),
+                "Test",
+                "/tmp/libpkcs11.so",
+                "token",
+                "notes",
+                true,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
+                new HsmDeviceVendorMetadata("thales", "Thales", "luna-standard", "Luna / standard PKCS#11"));
             await store.SaveAllAsync([profile]);
 
             IReadOnlyList<HsmDeviceProfile> loaded = await store.GetAllAsync();
             Assert.Single(loaded);
             Assert.Equal(profile.Name, loaded[0].Name);
             Assert.Equal(profile.ModulePath, loaded[0].ModulePath);
+            Assert.Equal("Thales", loaded[0].Vendor?.VendorName);
+            Assert.Equal("luna-standard", loaded[0].Vendor?.ProfileId);
         }
         finally
         {


### PR DESCRIPTION
## Summary
Add vendor-aware device profiles and admin UI hints.

## Included work
- extensible vendor metadata on admin device profiles
- reusable vendor profile catalog and setup guidance component
- vendor-aware hints across Devices, Slots, Keys, and PKCS#11 Lab
- docs and admin test updates

## Notes
- metadata/guidance only; no vendor-native CA_* operational APIs are introduced here
- generic PKCS#11 workflows remain the default path

## Closes
Closes #49
