### PR TITLE
Expand admin container deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,12 @@ The image defaults to:
 - `AdminRuntime__DisableHttpsRedirection=true`
 - `ASPNETCORE_URLS=http://+:8080`
 
-See [docs/admin-container.md](docs/admin-container.md) for a full `docker run` example with persistent volumes, bind-mount permission notes for the non-root runtime user, a mounted host PKCS#11 library, and the local SoftHSM compose lab bundle.
+For the standalone container deployment path, start from:
+
+- [docs/admin-container.md](docs/admin-container.md)
+- `deploy/container/admin-panel.env.example`
+
+That guide covers the runtime contract, first-run bootstrap behavior, storage-root contents, PKCS#11 module mount patterns, non-root bind-mount permissions, upgrade/backup expectations, and the distinction between the standalone container image and the local SoftHSM compose lab.
 
 ### 2c) Run the local SoftHSM compose lab stack
 
@@ -297,7 +302,8 @@ Current capabilities include:
 - [docs/windows-local-setup.md](docs/windows-local-setup.md) - local Windows fixture/bootstrap path
 - [docs/benchmarks.md](docs/benchmarks.md) - benchmark scope, rerun flow, periodic tracking model
 - [docs/benchmarks/latest-linux-softhsm.md](docs/benchmarks/latest-linux-softhsm.md) - latest committed Linux benchmark baseline
-- [docs/admin-container.md](docs/admin-container.md) - admin container runtime contract plus local SoftHSM compose lab entry point
+- [docs/admin-container.md](docs/admin-container.md) - standalone admin-container deployment guide, volume layout, PKCS#11 mount patterns, and local/dev vs production-safe guidance
+- `deploy/container/admin-panel.env.example` - starter env template for the standalone admin container path
 - [deploy/compose/softhsm-lab/README.md](deploy/compose/softhsm-lab/README.md) - local/dev/lab compose stack for the admin panel + SoftHSM backend
 - [docs/admin-ops-recovery.md](docs/admin-ops-recovery.md) - local admin-panel operations and recovery runbook
 - [docs/vendor-regression.md](docs/vendor-regression.md) - vendor compatibility profile and env contract

--- a/deploy/compose/softhsm-lab/.env.example
+++ b/deploy/compose/softhsm-lab/.env.example
@@ -1,4 +1,12 @@
 # Copy this file to .env before running the compose lab stack.
+#
+# This file is for the LOCAL/DEV/LAB SoftHSM bundle only.
+# It is intentionally not a production container deployment template.
+# For the standalone admin container path, use:
+#   deploy/container/admin-panel.env.example
+# and read:
+#   docs/admin-container.md
+#
 # The defaults intentionally match the repository's SoftHSM fixture labels/PINs
 # so local demos and troubleshooting line up with existing docs/tests.
 

--- a/deploy/compose/softhsm-lab/README.md
+++ b/deploy/compose/softhsm-lab/README.md
@@ -9,9 +9,14 @@ It is intentionally **not** a production orchestration recipe:
 - bootstrap credentials live in the compose env file unless you override them
 - SoftHSM state is a local named volume meant for demos, smoke-style checks, onboarding, and lab work
 
+If you need the **standalone container deployment** path for the admin panel, use:
+
+- `docs/admin-container.md`
+- `deploy/container/admin-panel.env.example`
+
 ## What the stack includes
 
-- `admin` - a lab-flavored admin-panel image that preserves the existing container runtime contract:
+- `admin` - a lab-flavored admin-panel image that preserves the existing container runtime contract for local use:
   - `AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin`
   - `AdminRuntime__DisableHttpsRedirection=true`
   - SoftHSM module exposed at `/opt/pkcs11/lib/libsofthsm2.so`
@@ -94,3 +99,4 @@ docker compose down -v
 - Rotate the bootstrap admin password from the `Users` page after first sign-in if the stack will live longer than a quick demo.
 - The `admin-data` volume includes the bootstrap notice, local users, Data Protection keys, device profiles, telemetry retention files, audit log, lab templates, and protected PIN cache.
 - The SoftHSM lab state lives entirely in the `softhsm-state` named volume; deleting that volume resets the token/config.
+- For persistent non-lab container deployments, back up and preserve the admin data volume intentionally rather than treating this compose bundle as the long-term deployment model.

--- a/deploy/container/admin-panel.env.example
+++ b/deploy/container/admin-panel.env.example
@@ -1,0 +1,41 @@
+# Copy this file to an operator-controlled path and pass it with:
+#   docker run --env-file /path/to/admin-panel.env ...
+# or the equivalent option in your orchestrator.
+#
+# This file is for the standalone admin container deployment path.
+# For the local/dev/lab SoftHSM compose stack, use:
+#   deploy/compose/softhsm-lab/.env.example
+#
+# Bootstrap variables only seed the first run when the storage root is empty.
+# After admin-users.json or device-profiles.json exists, changing these values
+# does not overwrite persisted state.
+
+ASPNETCORE_URLS=http://+:8080
+AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin
+
+# First-run bootstrap admin account.
+# Rotate this password after first sign-in and retire bootstrap-admin.txt.
+LocalAdminBootstrap__UserName=admin
+LocalAdminBootstrap__Password=ChangeMe!123456
+
+# Optional first-run bootstrap device profile.
+# IMPORTANT: ModulePath must be the in-container path, not the host path.
+AdminBootstrapDevice__Name=Mounted PKCS#11 module
+AdminBootstrapDevice__ModulePath=/opt/pkcs11/lib/libvendorpkcs11.so
+AdminBootstrapDevice__DefaultTokenLabel=
+AdminBootstrapDevice__Notes=Container-mounted PKCS#11 module. Replace with your real module path and notes.
+AdminBootstrapDevice__VendorId=
+AdminBootstrapDevice__VendorName=
+AdminBootstrapDevice__VendorProfileId=
+AdminBootstrapDevice__VendorProfileName=
+AdminBootstrapDevice__IsEnabled=true
+
+# Keep true when TLS terminates upstream and the container only serves private HTTP.
+# Change only if you intentionally configure container-local HTTPS.
+AdminRuntime__DisableHttpsRedirection=true
+
+# Optional telemetry retention overrides.
+# AdminTelemetry__ActiveFileMaxBytes=1048576
+# AdminTelemetry__RetentionDays=14
+# AdminTelemetry__MaxArchivedFiles=8
+# AdminTelemetry__ExportMaxEntries=5000

--- a/docs/admin-container.md
+++ b/docs/admin-container.md
@@ -1,13 +1,33 @@
-# Admin panel container image
+# Admin panel container deployment
 
-The admin panel now ships with a production-oriented multi-stage Docker build at `src/Pkcs11Wrapper.Admin.Web/Dockerfile`.
+This guide covers the **standalone container deployment** story for the `Pkcs11Wrapper` admin panel.
 
-## Why this image looks the way it does
+It builds on the repository's existing container image at `src/Pkcs11Wrapper.Admin.Web/Dockerfile` and the existing **local/dev/lab** SoftHSM compose bundle under `deploy/compose/softhsm-lab`, but keeps the focus on the operational questions a real container deployment needs answered:
 
-- it uses the official .NET `aspnet:10.0-noble` runtime image instead of Alpine so mounted PKCS#11 vendor libraries have a better chance of loading cleanly on glibc-based hosts
-- it publishes only the admin web app into the final image
-- it runs as a non-root UID by default
-- runtime state is externalized to `/var/lib/pkcs11wrapper-admin` instead of relying on repo-local mutable `App_Data`
+- which environment variables matter
+- what must be persisted
+- where telemetry/audit/bootstrap data lives
+- how PKCS#11 libraries should be mounted into the container
+- which parts are safe for local/dev only versus longer-lived deployments
+
+## Pick the right deployment path
+
+Use the path that matches your goal:
+
+| Scenario | Recommended path | Notes |
+| --- | --- | --- |
+| Local source-tree development | `cd src/Pkcs11Wrapper.Admin.Web && dotnet run` | Uses `App_Data` by default when not running in a container. |
+| Single-container admin deployment | `src/Pkcs11Wrapper.Admin.Web/Dockerfile` | The main image expects external persistence and operator-supplied PKCS#11 mounts. |
+| Reproducible local/dev/lab stack with SoftHSM | `deploy/compose/softhsm-lab` | Includes a lab-flavored admin image plus a helper SoftHSM container. Not a production recipe. |
+
+The main admin image and the compose lab are related, but they are **not** the same thing:
+
+- the main image does **not** bundle vendor PKCS#11 client libraries for you
+- the main image does **not** bundle production TLS termination/cert handling
+- the compose lab intentionally adds SoftHSM tooling so local demos and troubleshooting stay friction-free
+
+If you only need a safe local sandbox, use the compose lab.
+If you need to run the admin panel as a real containerized app, use the main image and the guidance below.
 
 ## Build the image
 
@@ -19,98 +39,337 @@ docker build -f src/Pkcs11Wrapper.Admin.Web/Dockerfile -t pkcs11wrapper-admin .
 
 ## Default runtime contract
 
-The image sets these defaults:
+The main image sets these defaults:
 
 - `ASPNETCORE_URLS=http://+:8080`
+- `ASPNETCORE_HTTP_PORTS=8080`
+- `DOTNET_RUNNING_IN_CONTAINER=true`
+- `DOTNET_EnableDiagnostics=0`
 - `AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin`
 - `AdminRuntime__DisableHttpsRedirection=true`
 
-Persist `/var/lib/pkcs11wrapper-admin` with a named volume or bind mount. The container runs as UID `64198` by default, so a host bind mount must be writable by that UID (or you can prefer a named volume).
+The image also creates:
 
-## First-run bootstrap via environment variables
+- `/var/lib/pkcs11wrapper-admin` - default persisted admin data root
+- `/opt/pkcs11/lib` - convenient mount point for PKCS#11 modules/client libraries
 
-Supported externalized settings:
+The container runs as non-root UID `64198` by default.
 
-- `AdminStorage__DataRoot`
-- `LocalAdminBootstrap__UserName`
-- `LocalAdminBootstrap__Password`
-- `AdminBootstrapDevice__Name`
-- `AdminBootstrapDevice__ModulePath`
-- `AdminBootstrapDevice__DefaultTokenLabel`
-- `AdminBootstrapDevice__Notes`
-- `AdminBootstrapDevice__VendorId`
-- `AdminBootstrapDevice__VendorName`
-- `AdminBootstrapDevice__VendorProfileId`
-- `AdminBootstrapDevice__VendorProfileName`
-- `AdminBootstrapDevice__IsEnabled`
-- `AdminRuntime__DisableHttpsRedirection`
+## Environment template
 
-`AdminBootstrapDevice__ModulePath` is intended for first-run seeding when the storage root is empty. Once `device-profiles.json` already exists, the bootstrap device seed is ignored so persisted admin data is not overwritten on restart.
+A starter env template for the standalone container path lives at:
 
-## Example: run with mounted PKCS#11 library and persistent state
+- `deploy/container/admin-panel.env.example`
+
+Copy it to an operator-controlled location, edit it, then pass it to `docker run --env-file ...` or your orchestrator's equivalent.
+
+Example:
+
+```bash
+cp deploy/container/admin-panel.env.example /etc/pkcs11wrapper/admin-panel.env
+# edit /etc/pkcs11wrapper/admin-panel.env
+```
+
+## First-run bootstrap behavior
+
+The bootstrap environment variables are intentionally **first-run seeds**, not ongoing configuration management.
+
+### Bootstrap admin user
+
+`LocalAdminBootstrap__UserName` and `LocalAdminBootstrap__Password` are used only when the admin user store does not exist yet.
+
+On first successful seed, the app writes:
+
+- `admin-users.json`
+- `bootstrap-admin.txt`
+
+under the configured storage root.
+
+Important behavior:
+
+- if you leave `LocalAdminBootstrap__Password` empty, the app generates a password and writes it to `bootstrap-admin.txt`
+- once `admin-users.json` already exists, changing the env vars later does **not** rotate existing credentials
+- after first sign-in, rotate the bootstrap password from the UI and retire `bootstrap-admin.txt`
+
+### Bootstrap device profile
+
+`AdminBootstrapDevice__*` values behave the same way for the first device profile.
+
+Important behavior:
+
+- seeding happens only when no device profiles exist yet
+- `AdminBootstrapDevice__ModulePath` must be the **in-container path**, not the host path
+- once `device-profiles.json` exists, later env changes do **not** overwrite persisted device profiles
+
+That design prevents accidental data loss on restart, but it also means env changes are **not** a substitute for normal admin operations once the volume is already initialized.
+
+## What must be persisted
+
+For container deployments, the real unit of state is the admin storage root:
+
+- `/var/lib/pkcs11wrapper-admin` by default
+- or whatever you set through `AdminStorage__DataRoot`
+
+Persist that path with a Docker named volume or a carefully permissioned bind mount.
+
+### Storage-root contents
+
+The admin panel writes its mutable state under the storage root.
+
+Typical files/directories include:
+
+| Path under storage root | Purpose |
+| --- | --- |
+| `admin-users.json` | local admin user database |
+| `bootstrap-admin.txt` | first-run plaintext bootstrap notice |
+| `device-profiles.json` | saved PKCS#11 device profiles |
+| `audit-log.jsonl` | append-only chained audit log |
+| `audit-log.jsonl.bak` | crash-safe replacement backup of the current audit file when applicable |
+| `pkcs11-telemetry.jsonl` | active redacted PKCS#11 telemetry log |
+| `pkcs11-telemetry-*.jsonl` | rotated telemetry archives |
+| `lab-templates.json` | saved PKCS#11 Lab templates |
+| `protected-pins.json` | locally protected cached PIN metadata/storage |
+| `keys/` | ASP.NET Core Data Protection key ring |
+| `*.bak` companions for JSON files | crash-safe replacement backups kept during atomic writes |
+
+Operationally, this means the storage-root volume is where these concerns live together:
+
+- local users
+- bootstrap notice file
+- device profiles
+- audit history
+- PKCS#11 telemetry retention
+- saved lab templates
+- protected PIN cache
+- Data Protection keys
+
+### Volume layout at a glance
+
+Use a layout like this as your mental model:
+
+| Container path | Persist? | Purpose | Recommended strategy |
+| --- | --- | --- | --- |
+| `/var/lib/pkcs11wrapper-admin` | Yes | admin app state | named volume or bind mount |
+| `/opt/pkcs11/lib` | Usually yes as host input | PKCS#11 shared libraries/client bundle | bind mount read-only from host |
+| vendor-specific writable client path | If vendor requires it | vendor cache/config/runtime state | separate dedicated mount, not inside admin data root |
+| `/opt/pkcs11/softhsm` | Only for the compose lab | shared SoftHSM token/config state | lab-only named volume |
+
+A practical host-side layout often looks like this:
+
+```text
+/srv/pkcs11wrapper-admin/
+  env/
+    admin-panel.env
+  data/
+  pkcs11-client/
+  vendor-state/   # only if the vendor library truly requires writable side files
+```
+
+One possible mapping would then be:
+
+- `/srv/pkcs11wrapper-admin/data -> /var/lib/pkcs11wrapper-admin`
+- `/srv/pkcs11wrapper-admin/pkcs11-client -> /opt/pkcs11/lib:ro`
+- `/srv/pkcs11wrapper-admin/vendor-state -> <vendor-required writable path>`
+
+Do **not** mix vendor-client writable runtime files into the admin storage root unless you intentionally want those lifecycle concerns tied together.
+
+## Example: standalone container run
+
+This example uses:
+
+- a persistent named volume for admin state
+- a read-only bind mount for PKCS#11 libraries
+- an env file for first-run bootstrap/device settings
 
 ```bash
 docker run --rm \
   --name pkcs11wrapper-admin \
   -p 8080:8080 \
-  -e LocalAdminBootstrap__UserName=admin \
-  -e LocalAdminBootstrap__Password='ChangeMe!123456' \
-  -e AdminBootstrapDevice__Name='SoftHSM demo' \
-  -e AdminBootstrapDevice__ModulePath=/opt/pkcs11/lib/libsofthsm2.so \
-  -e AdminBootstrapDevice__DefaultTokenLabel=dev-token \
+  --env-file /etc/pkcs11wrapper/admin-panel.env \
   -v pkcs11wrapper-admin-data:/var/lib/pkcs11wrapper-admin \
-  -v /usr/lib/softhsm:/opt/pkcs11/lib:ro \
+  -v /srv/pkcs11wrapper-admin/pkcs11-client:/opt/pkcs11/lib:ro \
   pkcs11wrapper-admin
 ```
 
-After first startup:
+If your vendor library requires additional writable client-side state, add a **separate** mount for that vendor path rather than making `/opt/pkcs11/lib` writable.
 
-1. open `http://localhost:8080`
-2. sign in with the bootstrap credential
-3. rotate the bootstrap password from the `Users` page
-4. retire `bootstrap-admin.txt` from the mounted storage root
+## PKCS#11 library and client mount patterns
 
-## Notes for host-provided PKCS#11 libraries
+The admin panel only knows how to load a PKCS#11 module from the path you configure. It does **not** automatically import host libraries into the container. You must make the required files visible inside the container yourself.
 
-- mount the host directory or exact shared object into the container read-only
-- set `AdminBootstrapDevice__ModulePath` or configure the device in the UI using the in-container path, not the host path
-- if a vendor library depends on additional shared libraries, mount/install those dependencies so the dynamic loader can resolve them inside the container too
-- keep the module mount read-only unless the vendor explicitly requires writable side files elsewhere
+### Pattern 1: mount a single shared library
 
-## Local/dev/lab SoftHSM compose stack
+Good when the vendor ships one self-contained `.so` and its runtime dependencies are already present in the image or the base OS.
 
-For a reproducible **local/dev/lab** stack that brings up the admin panel together with a SoftHSM-backed token environment, use `deploy/compose/softhsm-lab`.
+```bash
+-v /usr/local/lib/vendor/libvendorpkcs11.so:/opt/pkcs11/lib/libvendorpkcs11.so:ro
+```
 
-Quick start:
+Then set:
+
+```text
+AdminBootstrapDevice__ModulePath=/opt/pkcs11/lib/libvendorpkcs11.so
+```
+
+### Pattern 2: mount a whole client library directory
+
+Good when the module depends on adjacent helper libraries/config files.
+
+```bash
+-v /opt/vendor/pkcs11-client:/opt/pkcs11/lib:ro
+```
+
+Then point the module path at the in-container library file inside that mounted directory.
+
+### Pattern 3: mount a broader vendor client bundle
+
+Some vendors expect a larger client install tree plus separate writable paths for logs/cache/runtime config. In that case:
+
+- mount the immutable client binaries/config read-only
+- mount any required writable vendor state separately
+- keep the admin storage root separate from the vendor writable state
+
+The key rule is simple:
+
+> configure the app with the **container path it can actually open**, not the host path where the file originally lived.
+
+## Permissions and non-root runtime behavior
+
+The container runs as UID `64198`.
+
+That has two important consequences:
+
+1. the mounted admin data root must be writable by UID `64198` (or compatible through group permissions)
+2. the mounted PKCS#11 library path only needs to be readable, so prefer `:ro`
+
+### Easiest option: named volumes
+
+Docker named volumes are usually the least painful option for `/var/lib/pkcs11wrapper-admin` because Docker manages ownership/permissions for the containerized workload.
+
+### Bind-mount option
+
+If you prefer a host bind mount, make sure the directory is writable by UID `64198` before first start.
+
+Common approaches:
+
+- pre-create the host directory and `chown` it to `64198`
+- or align permissions so UID `64198` can write through a shared group policy on the host
+
+Avoid running the container as root just to paper over filesystem ownership mistakes.
+
+## Backup and restore guidance
+
+### What counts as a real backup
+
+A configuration export from the UI is useful, but it is **not** a full container-state backup.
+
+A real backup for a container deployment should capture the mounted admin storage root because that is where the app keeps:
+
+- users
+- device profiles
+- audit log
+- telemetry files
+- Data Protection keys
+- protected PIN cache
+- lab templates
+- bootstrap notice file
+
+If your PKCS#11 vendor/client setup also requires writable side files, back those up separately according to the vendor's own support model.
+
+### Recommended backup posture
+
+Before upgrades or host migration:
+
+1. export device profiles from the `Configuration` page for a human-readable portability snapshot
+2. take a filesystem/volume backup of the mounted admin storage root
+3. preserve any vendor-required writable client state separately if you use it
+4. treat the storage root and vendor client state as distinct restore units
+
+If you can, stop or quiesce the admin container before taking the storage-root backup.
+
+### Restore expectations
+
+To restore onto a replacement container:
+
+- mount the restored storage-root volume back at the same in-container path
+- reapply the same PKCS#11 module/client mounts
+- reapply any vendor-specific writable client mounts if used
+- start the new container with the same or equivalent runtime env
+
+If the `keys/` folder is missing or replaced, expect Data Protection-dependent features such as protected PIN storage and existing cookie/session material to stop lining up with the old host state.
+
+## Upgrade guidance
+
+Container upgrades should normally be **image replacement with the same mounted state**.
+
+Typical safe pattern:
+
+1. back up the storage root
+2. pull/build the new image
+3. stop the old container
+4. start the new container with the same data volume and PKCS#11 mounts
+5. verify sign-in, device visibility, and a basic read-only token operation
+
+Remember:
+
+- bootstrap env vars do not re-seed an already initialized storage root
+- changing module-path env values does not overwrite persisted device profiles
+- swapping images without preserving the storage-root volume creates a new empty admin instance
+
+## Local/dev/lab versus production-safe guidance
+
+The repository deliberately separates these two stories.
+
+### Local/dev/lab
+
+Use `deploy/compose/softhsm-lab` when you want:
+
+- a disposable sandbox
+- built-in SoftHSM availability
+- known demo credentials/PINs
+- reproducible local troubleshooting without vendor hardware
+
+This stack is intentionally optimized for convenience:
+
+- bootstrap credentials live in a compose env file
+- SoftHSM state is just a local named volume
+- HTTPS redirection stays disabled
+- the bundle is designed for demos, onboarding, and validation, not public exposure
+
+### Production-safe direction
+
+For any longer-lived or higher-trust deployment, treat the current admin container as an **internal administrative surface** and tighten the environment around it.
+
+Minimum practical guidance:
+
+- keep the container behind a trusted reverse proxy or other private access boundary
+- do not expose the raw HTTP listener broadly to the public internet
+- rotate the bootstrap password immediately and retire the plaintext bootstrap notice file
+- prefer operator-managed secrets/env injection over leaving example credentials in files
+- persist and back up the storage root deliberately
+- mount PKCS#11 modules read-only whenever possible
+- separate vendor-client writable state from admin app state
+- understand that the current app auth model is local-user/cookie based, not external IdP/MFA/secret-vault integrated
+
+If you need internet-facing exposure, centralized identity, MFA, or compliance-grade secret governance, plan additional infrastructure around the app rather than assuming the container alone provides that posture.
+
+## Local/dev/lab compose stack
+
+For the existing SoftHSM-backed lab stack:
 
 ```bash
 cd deploy/compose/softhsm-lab
 cp .env.example .env
-# optional: edit .env for different admin credentials / token label / PINs
+# optional: edit .env
 
 docker compose up --build -d
 ```
 
-This bundle is intentionally lab-oriented rather than production orchestration:
+That bundle adds a lab-specific admin image plus a helper `softhsm` service and a shared `/opt/pkcs11/softhsm` volume so the admin panel and the helper see the same SoftHSM token store.
 
-- the admin panel still uses the current container defaults (`AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin`, `AdminRuntime__DisableHttpsRedirection=true`)
-- the seeded bootstrap device points at `/opt/pkcs11/lib/libsofthsm2.so`
-- a shared named volume carries `SOFTHSM2_CONF` plus the SoftHSM token store so the admin container and the helper/backend container see the same state
-- the SoftHSM helper can re-seed or reset the local token with `docker compose exec softhsm seed-token ...`
+See:
 
-See `deploy/compose/softhsm-lab/README.md` for the full setup flow, default credentials/PINs, reset commands, and caveats.
+- `deploy/compose/softhsm-lab/README.md`
+- `deploy/compose/softhsm-lab/.env.example`
 
-## Data kept under the storage root
-
-The configured storage root contains the admin panel's mutable state, including:
-
-- local admin users
-- bootstrap notice file
-- Data Protection keys
-- device profiles
-- audit log
-- PKCS#11 telemetry retention files
-- saved lab templates
-- protected PIN cache
-
-That makes the volume the main unit to back up, migrate, or mount into a replacement container.
+for the local/dev/lab workflow.


### PR DESCRIPTION
## Summary
Add practical container deployment documentation, environment templates, and volume layout guidance for the admin panel.

## Included work
- expanded standalone admin container deployment guide
- explicit storage root / persisted file layout guidance
- PKCS#11 module mount and permissions guidance
- backup / restore / upgrade notes
- standalone env template for the admin image
- clearer separation between production-ish container usage and local/dev/lab SoftHSM compose usage

## Closes
Closes #57
