### PR TITLE
Add production-safe container hardening and health checks

### DIFF
--- a/deploy/compose/softhsm-lab/README.md
+++ b/deploy/compose/softhsm-lab/README.md
@@ -19,6 +19,7 @@ If you need the **standalone container deployment** path for the admin panel, us
 - `admin` - a lab-flavored admin-panel image that preserves the existing container runtime contract for local use:
   - `AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin`
   - `AdminRuntime__DisableHttpsRedirection=true`
+  - built-in `/health/live` and `/health/ready` endpoints plus a compose healthcheck wired to the readiness probe
   - SoftHSM module exposed at `/opt/pkcs11/lib/libsofthsm2.so`
 - `softhsm` - a utility/backend container that owns the shared SoftHSM config/token store and can seed or reset the token with `softhsm2-util` + `pkcs11-tool`
 
@@ -32,6 +33,12 @@ cp .env.example .env
 # edit .env if you want different admin credentials, token label, or PINs
 
 docker compose up --build -d
+```
+
+You can optionally confirm both services reached a healthy state with:
+
+```bash
+docker compose ps
 ```
 
 Then open <http://localhost:8080> and sign in with the bootstrap admin credential from `.env`.
@@ -96,6 +103,7 @@ docker compose down -v
 
 - This stack is for **local/dev/lab** usage only.
 - The admin service still runs without HTTPS redirection, by design, to stay friction-free for local compose use.
+- The admin service now reports healthy only after its storage-backed readiness probe succeeds, which makes startup status easier to understand from `docker compose ps`.
 - Rotate the bootstrap admin password from the `Users` page after first sign-in if the stack will live longer than a quick demo.
 - The `admin-data` volume includes the bootstrap notice, local users, Data Protection keys, device profiles, telemetry retention files, audit log, lab templates, and protected PIN cache.
 - The SoftHSM lab state lives entirely in the `softhsm-state` named volume; deleting that volume resets the token/config.

--- a/deploy/compose/softhsm-lab/admin.Dockerfile
+++ b/deploy/compose/softhsm-lab/admin.Dockerfile
@@ -31,13 +31,17 @@ ENV ASPNETCORE_URLS=http://+:8080 \
     DOTNET_EnableDiagnostics=0 \
     AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin \
     AdminRuntime__DisableHttpsRedirection=true \
+    HOME=/var/lib/pkcs11wrapper-admin/home \
+    TMPDIR=/var/lib/pkcs11wrapper-admin/tmp \
     SOFTHSM2_CONF=/opt/pkcs11/softhsm/softhsm2.conf
 WORKDIR /app
 COPY --from=publish /app/publish ./
-RUN mkdir -p /var/lib/pkcs11wrapper-admin /opt/pkcs11/lib /opt/pkcs11/softhsm/tokens \
+RUN mkdir -p /var/lib/pkcs11wrapper-admin/home /var/lib/pkcs11wrapper-admin/keys /var/lib/pkcs11wrapper-admin/tmp /opt/pkcs11/lib /opt/pkcs11/softhsm/tokens \
     && ln -sf /usr/lib/softhsm/libsofthsm2.so /opt/pkcs11/lib/libsofthsm2.so \
     && chown -R ${APP_UID}:0 /app /var/lib/pkcs11wrapper-admin /opt/pkcs11 \
     && chmod -R g=u /app /var/lib/pkcs11wrapper-admin /opt/pkcs11
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["dotnet", "Pkcs11Wrapper.Admin.Web.dll", "--container-healthcheck", "http://127.0.0.1:8080/health/ready"]
 VOLUME ["/var/lib/pkcs11wrapper-admin", "/opt/pkcs11/softhsm"]
 EXPOSE 8080
 USER ${APP_UID}

--- a/deploy/compose/softhsm-lab/compose.yaml
+++ b/deploy/compose/softhsm-lab/compose.yaml
@@ -47,6 +47,12 @@ services:
     volumes:
       - admin-data:/var/lib/pkcs11wrapper-admin
       - softhsm-state:/opt/pkcs11/softhsm
+    healthcheck:
+      test: ["CMD", "dotnet", "Pkcs11Wrapper.Admin.Web.dll", "--container-healthcheck", "http://127.0.0.1:8080/health/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 6
+      start_period: 20s
 
 volumes:
   admin-data:

--- a/deploy/container/admin-panel.env.example
+++ b/deploy/container/admin-panel.env.example
@@ -11,6 +11,8 @@
 # does not overwrite persisted state.
 
 ASPNETCORE_URLS=http://+:8080
+# The image also keeps HOME/TMPDIR/Data Protection keys under this storage root
+# so it remains compatible with read-only root filesystem deployments.
 AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin
 
 # First-run bootstrap admin account.

--- a/docs/admin-container.md
+++ b/docs/admin-container.md
@@ -47,13 +47,35 @@ The main image sets these defaults:
 - `DOTNET_EnableDiagnostics=0`
 - `AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin`
 - `AdminRuntime__DisableHttpsRedirection=true`
+- `HOME=/var/lib/pkcs11wrapper-admin/home`
+- `TMPDIR=/var/lib/pkcs11wrapper-admin/tmp`
 
 The image also creates:
 
 - `/var/lib/pkcs11wrapper-admin` - default persisted admin data root
+- `/var/lib/pkcs11wrapper-admin/keys` - ASP.NET Core Data Protection key ring location
+- `/var/lib/pkcs11wrapper-admin/home` - explicit writable home directory for non-root runtime helpers
+- `/var/lib/pkcs11wrapper-admin/tmp` - explicit writable temp path so the app can stay compatible with read-only root filesystem deployments
 - `/opt/pkcs11/lib` - convenient mount point for PKCS#11 modules/client libraries
 
 The container runs as non-root UID `64198` by default.
+
+## Built-in health endpoints and container healthcheck
+
+The admin image now exposes two unauthenticated health endpoints:
+
+- `/health/live` - lightweight liveness probe for process availability
+- `/health/ready` - readiness probe that verifies the admin storage root plus the app's writable runtime directories are present and writable
+
+The image also bakes in a Docker `HEALTHCHECK` that probes `http://127.0.0.1:8080/health/ready` from inside the container, so a plain `docker ps` / `docker inspect` workflow can see whether the container is healthy without extra operator wiring.
+
+Operationally, this is meant to catch practical container problems such as:
+
+- mounted admin storage that is missing or no longer writable
+- read-only or permission-broken runtime writable paths
+- an app process that is up but not actually ready to serve requests
+
+The readiness check is intentionally **storage-focused** and low-risk. It does **not** attempt to prove that a specific HSM is online or that every configured PKCS#11 module is reachable, because those concerns can legitimately vary across operators, maintenance windows, and device states.
 
 ## Environment template
 
@@ -130,6 +152,8 @@ Typical files/directories include:
 | `lab-templates.json` | saved PKCS#11 Lab templates |
 | `protected-pins.json` | locally protected cached PIN metadata/storage |
 | `keys/` | ASP.NET Core Data Protection key ring |
+| `home/` | explicit writable non-root home directory used by the container runtime when needed |
+| `tmp/` | explicit writable temp directory used by readiness checks and runtime temporary files |
 | `*.bak` companions for JSON files | crash-safe replacement backups kept during atomic writes |
 
 Operationally, this means the storage-root volume is where these concerns live together:
@@ -180,16 +204,28 @@ This example uses:
 - a persistent named volume for admin state
 - a read-only bind mount for PKCS#11 libraries
 - an env file for first-run bootstrap/device settings
+- low-risk hardening flags that fit the current image contract
 
 ```bash
 docker run --rm \
   --name pkcs11wrapper-admin \
   -p 8080:8080 \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --pids-limit 256 \
   --env-file /etc/pkcs11wrapper/admin-panel.env \
   -v pkcs11wrapper-admin-data:/var/lib/pkcs11wrapper-admin \
   -v /srv/pkcs11wrapper-admin/pkcs11-client:/opt/pkcs11/lib:ro \
   pkcs11wrapper-admin
 ```
+
+Why these flags are practical here:
+
+- `--read-only` works with the current image because the admin app's writable home/temp/key material is already redirected under the persisted storage root
+- `--cap-drop ALL` removes Linux capabilities the app does not need for its normal HTTP + file-backed admin workflow
+- `--security-opt no-new-privileges:true` prevents privilege escalation through executed child processes
+- `--pids-limit 256` adds a simple guardrail against runaway process creation without getting orchestration-specific
 
 If your vendor library requires additional writable client-side state, add a **separate** mount for that vendor path rather than making `/opt/pkcs11/lib` writable.
 
@@ -347,6 +383,8 @@ Minimum practical guidance:
 - rotate the bootstrap password immediately and retire the plaintext bootstrap notice file
 - prefer operator-managed secrets/env injection over leaving example credentials in files
 - persist and back up the storage root deliberately
+- keep the built-in `/health/live` and `/health/ready` probes available to your local Docker or upstream monitoring path
+- prefer `--read-only`, `--cap-drop ALL`, and `--security-opt no-new-privileges:true` when your runtime allows them
 - mount PKCS#11 modules read-only whenever possible
 - separate vendor-client writable state from admin app state
 - understand that the current app auth model is local-user/cookie based, not external IdP/MFA/secret-vault integrated

--- a/eng/run-admin-e2e.sh
+++ b/eng/run-admin-e2e.sh
@@ -202,11 +202,14 @@ export LocalAdminBootstrap__Password="$admin_password"
 server_pid="$!"
 server_running=true
 
-if ! wait_for_http "$admin_base_url/login"; then
-  printf 'Admin runtime failed to become ready at %s\n' "$admin_base_url/login" >&2
+if ! wait_for_http "$admin_base_url/health/ready"; then
+  printf 'Admin runtime failed to become ready at %s\n' "$admin_base_url/health/ready" >&2
   tail -n 200 "$artifact_root/admin-web.log" >&2 || true
   exit 1
 fi
+
+curl -fsS "$admin_base_url/health/live" > "$artifact_root/admin-health-live.json"
+curl -fsS "$admin_base_url/health/ready" > "$artifact_root/admin-health-ready.json"
 
 export ADMIN_E2E_BASE_URL="$admin_base_url"
 export ADMIN_E2E_USERNAME="$admin_user"

--- a/src/Pkcs11Wrapper.Admin.Web/Configuration/AdminHostDefaults.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Configuration/AdminHostDefaults.cs
@@ -4,6 +4,12 @@ public static class AdminHostDefaults
 {
     public const string ContainerDataRoot = "/var/lib/pkcs11wrapper-admin";
     public const string ContainerModuleMountRoot = "/opt/pkcs11/lib";
+    public const string KeysDirectoryName = "keys";
+    public const string HomeDirectoryName = "home";
+    public const string TempDirectoryName = "tmp";
+    public const string HealthLivePath = "/health/live";
+    public const string HealthReadyPath = "/health/ready";
+    public const string DefaultContainerHealthCheckUrl = "http://127.0.0.1:8080/health/ready";
 
     public static string ResolveStorageRoot(string? configuredDataRoot, string contentRootPath)
     {
@@ -28,4 +34,13 @@ public static class AdminHostDefaults
 
         return File.Exists("/.dockerenv");
     }
+
+    public static string GetKeysRoot(string dataRoot)
+        => Path.Combine(dataRoot, KeysDirectoryName);
+
+    public static string GetHomeRoot(string dataRoot)
+        => Path.Combine(dataRoot, HomeDirectoryName);
+
+    public static string GetTempRoot(string dataRoot)
+        => Path.Combine(dataRoot, TempDirectoryName);
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Dockerfile
+++ b/src/Pkcs11Wrapper.Admin.Web/Dockerfile
@@ -27,12 +27,17 @@ ENV ASPNETCORE_URLS=http://+:8080 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_EnableDiagnostics=0 \
     AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin \
-    AdminRuntime__DisableHttpsRedirection=true
+    AdminRuntime__DisableHttpsRedirection=true \
+    HOME=/var/lib/pkcs11wrapper-admin/home \
+    TMPDIR=/var/lib/pkcs11wrapper-admin/tmp
 WORKDIR /app
 COPY --from=publish /app/publish ./
-RUN mkdir -p /var/lib/pkcs11wrapper-admin /opt/pkcs11/lib \
+RUN mkdir -p /var/lib/pkcs11wrapper-admin/home /var/lib/pkcs11wrapper-admin/keys /var/lib/pkcs11wrapper-admin/tmp /opt/pkcs11/lib \
     && chown -R ${APP_UID}:0 /app /var/lib/pkcs11wrapper-admin /opt/pkcs11/lib \
     && chmod -R g=u /app /var/lib/pkcs11wrapper-admin /opt/pkcs11/lib
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["dotnet", "Pkcs11Wrapper.Admin.Web.dll", "--container-healthcheck", "http://127.0.0.1:8080/health/ready"]
 
 VOLUME ["/var/lib/pkcs11wrapper-admin"]
 EXPOSE 8080

--- a/src/Pkcs11Wrapper.Admin.Web/Health/AdminContainerHealthProbe.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Health/AdminContainerHealthProbe.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using Pkcs11Wrapper.Admin.Web.Configuration;
+
+namespace Pkcs11Wrapper.Admin.Web.Health;
+
+public static class AdminContainerHealthProbe
+{
+    private const string HealthCheckArgument = "--container-healthcheck";
+
+    public static async Task<bool> TryExecuteAsync(string[] args, CancellationToken cancellationToken = default)
+    {
+        if (!args.Any(argument => string.Equals(argument, HealthCheckArgument, StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        string probeUrl = ResolveProbeUrl(args);
+
+        try
+        {
+            using HttpClient client = new()
+            {
+                Timeout = TimeSpan.FromSeconds(5)
+            };
+
+            using HttpResponseMessage response = await client.GetAsync(probeUrl, cancellationToken);
+            Environment.ExitCode = response.StatusCode == HttpStatusCode.OK ? 0 : 1;
+            return true;
+        }
+        catch
+        {
+            Environment.ExitCode = 1;
+            return true;
+        }
+    }
+
+    private static string ResolveProbeUrl(IReadOnlyList<string> args)
+    {
+        int index = args
+            .Select((value, position) => new { value, position })
+            .First(candidate => string.Equals(candidate.value, HealthCheckArgument, StringComparison.Ordinal))
+            .position;
+
+        if (index + 1 < args.Count)
+        {
+            string candidate = args[index + 1].Trim();
+            if (!string.IsNullOrWhiteSpace(candidate) && !candidate.StartsWith("--", StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        return AdminHostDefaults.DefaultContainerHealthCheckUrl;
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Health/AdminHealthResponseWriter.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Health/AdminHealthResponseWriter.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Pkcs11Wrapper.Admin.Web.Health;
+
+public static class AdminHealthResponseWriter
+{
+    public static Task WriteAsync(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        AdminHealthResponse payload = new(
+            report.Status.ToString(),
+            report.TotalDuration.TotalMilliseconds,
+            report.Entries.ToDictionary(
+                static entry => entry.Key,
+                static entry => new AdminHealthCheckResponse(
+                    entry.Value.Status.ToString(),
+                    entry.Value.Description,
+                    entry.Value.Duration.TotalMilliseconds)));
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload));
+    }
+
+    private sealed record AdminHealthResponse(
+        string Status,
+        double TotalDurationMs,
+        IReadOnlyDictionary<string, AdminHealthCheckResponse> Checks);
+
+    private sealed record AdminHealthCheckResponse(
+        string Status,
+        string? Description,
+        double DurationMs);
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Health/AdminStorageHealthCheck.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Health/AdminStorageHealthCheck.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.Admin.Infrastructure;
+using Pkcs11Wrapper.Admin.Web.Configuration;
+
+namespace Pkcs11Wrapper.Admin.Web.Health;
+
+public sealed class AdminStorageHealthCheck(IOptions<AdminStorageOptions> options) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        string dataRoot = options.Value.DataRoot?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(dataRoot))
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy("Admin storage root is not configured."));
+        }
+
+        try
+        {
+            Directory.CreateDirectory(dataRoot);
+            Directory.CreateDirectory(AdminHostDefaults.GetKeysRoot(dataRoot));
+            Directory.CreateDirectory(AdminHostDefaults.GetHomeRoot(dataRoot));
+
+            string tempRoot = AdminHostDefaults.GetTempRoot(dataRoot);
+            Directory.CreateDirectory(tempRoot);
+
+            string probePath = Path.Combine(tempRoot, $".healthcheck-{Guid.NewGuid():N}");
+            File.WriteAllText(probePath, "ok");
+            File.Delete(probePath);
+
+            return Task.FromResult(HealthCheckResult.Healthy("Admin storage root and runtime writable directories are available."));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy("Admin storage root or runtime writable directories are unavailable.", ex));
+        }
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -5,10 +5,17 @@ using Pkcs11Wrapper.Admin.Infrastructure;
 using Pkcs11Wrapper.Admin.Web.Lab;
 using Pkcs11Wrapper.Admin.Web.Components;
 using Pkcs11Wrapper.Admin.Web.Configuration;
+using Pkcs11Wrapper.Admin.Web.Health;
 using Pkcs11Wrapper.Admin.Web.Security;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+
+if (await AdminContainerHealthProbe.TryExecuteAsync(args))
+{
+    return;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseStaticWebAssets();
@@ -29,10 +36,15 @@ builder.Services.AddAuthorizationBuilder()
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+builder.Services.AddHealthChecks()
+    .AddCheck<AdminStorageHealthCheck>("admin-storage", tags: ["ready"]);
 
 AdminStorageOptions adminStorage = builder.Configuration.GetSection("AdminStorage").Get<AdminStorageOptions>() ?? new();
 adminStorage.DataRoot = AdminHostDefaults.ResolveStorageRoot(adminStorage.DataRoot, builder.Environment.ContentRootPath);
 Directory.CreateDirectory(adminStorage.DataRoot);
+Directory.CreateDirectory(AdminHostDefaults.GetKeysRoot(adminStorage.DataRoot));
+Directory.CreateDirectory(AdminHostDefaults.GetHomeRoot(adminStorage.DataRoot));
+Directory.CreateDirectory(AdminHostDefaults.GetTempRoot(adminStorage.DataRoot));
 
 AdminSessionRegistryOptions sessionOptions = builder.Configuration.GetSection("AdminSessionRegistry").Get<AdminSessionRegistryOptions>() ?? new();
 LocalAdminLoginThrottleOptions throttleOptions = builder.Configuration.GetSection("LocalAdminLoginThrottle").Get<LocalAdminLoginThrottleOptions>() ?? new();
@@ -54,7 +66,7 @@ builder.Services.AddSingleton<IOptions<AdminRuntimeOptions>>(Options.Create(runt
 builder.Services.AddSingleton(telemetryOptions);
 builder.Services.AddSingleton<IOptions<AdminPkcs11TelemetryOptions>>(Options.Create(telemetryOptions));
 builder.Services.AddDataProtection()
-    .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(adminStorage.DataRoot, "keys")));
+    .PersistKeysToFileSystem(new DirectoryInfo(AdminHostDefaults.GetKeysRoot(adminStorage.DataRoot)));
 builder.Services.AddSingleton<IDeviceProfileStore, JsonDeviceProfileStore>();
 builder.Services.AddSingleton<IAuditLogStore, JsonLineAuditLogStore>();
 builder.Services.AddSingleton<IPkcs11TelemetryStore, JsonLinePkcs11TelemetryStore>();
@@ -94,6 +106,16 @@ if (!runtimeOptions.DisableHttpsRedirection)
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseAntiforgery();
+app.MapHealthChecks(AdminHostDefaults.HealthLivePath, new HealthCheckOptions
+{
+    Predicate = static _ => false,
+    ResponseWriter = AdminHealthResponseWriter.WriteAsync
+});
+app.MapHealthChecks(AdminHostDefaults.HealthReadyPath, new HealthCheckOptions
+{
+    Predicate = static registration => registration.Tags.Contains("ready", StringComparer.Ordinal),
+    ResponseWriter = AdminHealthResponseWriter.WriteAsync
+});
 app.MapStaticAssets();
 app.MapPost("/account/login", (Delegate)AccountEndpoints.LoginAsync);
 app.MapPost("/account/logout", (Delegate)AccountEndpoints.LogoutAsync);

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminHealthCheckTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminHealthCheckTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.Admin.Infrastructure;
+using Pkcs11Wrapper.Admin.Web.Configuration;
+using Pkcs11Wrapper.Admin.Web.Health;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class AdminHealthCheckTests
+{
+    [Fact]
+    public async Task StorageHealthCheckReportsHealthyWhenWritableDirectoriesAreAvailable()
+    {
+        string rootPath = CreateTempDirectory();
+
+        try
+        {
+            AdminStorageHealthCheck healthCheck = CreateHealthCheck(rootPath);
+
+            HealthCheckResult result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.True(Directory.Exists(AdminHostDefaults.GetKeysRoot(rootPath)));
+            Assert.True(Directory.Exists(AdminHostDefaults.GetHomeRoot(rootPath)));
+            Assert.True(Directory.Exists(AdminHostDefaults.GetTempRoot(rootPath)));
+        }
+        finally
+        {
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StorageHealthCheckReportsUnhealthyWhenStorageRootIsAFile()
+    {
+        string parentPath = CreateTempDirectory();
+        string filePath = Path.Combine(parentPath, "not-a-directory");
+        await File.WriteAllTextAsync(filePath, "occupied");
+
+        try
+        {
+            AdminStorageHealthCheck healthCheck = CreateHealthCheck(filePath);
+
+            HealthCheckResult result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+        finally
+        {
+            Directory.Delete(parentPath, recursive: true);
+        }
+    }
+
+    private static AdminStorageHealthCheck CreateHealthCheck(string dataRoot)
+        => new(Options.Create(new AdminStorageOptions { DataRoot = dataRoot }));
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "pkcs11wrapper-admin-health-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary
Add production-safe container hardening and health checks for the admin panel.

## Included work
- built-in liveness/readiness endpoints
- storage-root backed readiness checks
- self-probe healthcheck mode for container health checks without curl/wget
- safer writable runtime defaults under persisted admin storage
- Docker/Compose healthcheck wiring
- docs/env template updates
- admin E2E helper updated to wait on readiness and capture health responses

## Closes
Closes #58
