### PR TITLE
Add AWS CloudHSM support guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Current capabilities include:
 - [docs/vendor-regression.md](docs/vendor-regression.md) - vendor compatibility profile and env contract
 - [docs/luna-integration.md](docs/luna-integration.md) - practical Thales Luna client/module setup guidance for wrapper, admin panel, smoke, and vendor regression
 - [docs/luna-compatibility-audit.md](docs/luna-compatibility-audit.md) - public-doc audit of Thales Luna standard compatibility vs current wrapper/admin/runtime scope
+- [docs/cloudhsm-integration.md](docs/cloudhsm-integration.md) - practical AWS CloudHSM Client SDK 5 setup guidance for wrapper and admin-panel usage
+- [docs/cloudhsm-compatibility-audit.md](docs/cloudhsm-compatibility-audit.md) - public-doc audit of AWS CloudHSM standard PKCS#11 compatibility vs current wrapper/admin/runtime scope
 - [docs/luna-vendor-extension-design.md](docs/luna-vendor-extension-design.md) - proposed package/boundary/loading/test strategy for future Luna-only `CA_*` support
 - [docs/vendor-audit-integration.md](docs/vendor-audit-integration.md) - vendor-native audit evaluation starting with Thales Luna, including CLI/syslog/export/API path trade-offs vs wrapper telemetry
 - [docs/smoke.md](docs/smoke.md) - smoke sample behavior and troubleshooting
@@ -327,6 +329,7 @@ Current capabilities include:
 - The current admin auth/security model is intentionally local-host oriented; external IdP/IAM, MFA, and centralized secret governance are not part of the app yet.
 - Linux is still the primary benchmark/reference environment, even though Windows now also has fixture-backed NativeAOT smoke validation.
 - PKCS#11 v3 runtime behavior still depends on whether the target module actually exports the relevant v3 interface surface.
+- AWS CloudHSM support in the current repo is a documented/admin-readiness slice, not a claim of live cluster-backed CI validation yet.
 
 ## Contributing
 

--- a/docs/cloudhsm-compatibility-audit.md
+++ b/docs/cloudhsm-compatibility-audit.md
@@ -1,0 +1,254 @@
+# AWS CloudHSM PKCS#11 compatibility audit
+
+See also:
+
+- `docs/cloudhsm-integration.md` for the practical wrapper/admin-panel setup path
+- `docs/compatibility-matrix.md` for the repo-wide support summary
+- `docs/vendor-regression.md` for the current vendor-lane boundary
+
+## Scope
+
+This document audits **publicly documented AWS CloudHSM PKCS#11 compatibility** against the current `Pkcs11Wrapper` repository.
+
+It is intentionally conservative:
+
+- it distinguishes **documented CloudHSM standard PKCS#11 support** from **unsupported/unlisted PKCS#11 surfaces**
+- it separates **already good repo alignment** from **capability-gated** or **unvalidated** areas
+- it does **not** claim support that requires a real AWS CloudHSM runtime when no live cluster was available during issue #66
+
+## AWS public references reviewed
+
+- AWS CloudHSM PKCS#11 library overview: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-library.html>
+- PKCS#11 install path / SDK 5 runtime layout: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-library-install.html>
+- cluster bootstrap / certificate requirements: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/cluster-connect.html>
+- Client SDK 5 configure-tool parameters/examples: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-tool-params5.html>
+- PKCS#11 authentication model: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-pin.html>
+- supported API operations: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-apis.html>
+- supported mechanisms: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-mechanisms.html>
+- multi-slot behavior: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-library-configs-multi-slot.html>
+- known issues: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/ki-pkcs11-sdk.html>
+- SDK 3 -> 5 migration notes: <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-migrate-to-sdk-5.html>
+- latest release page reviewed during this issue: Client SDK **5.17.1**
+
+## Repository areas reviewed
+
+### Core wrapper
+
+- `src/Pkcs11Wrapper`
+- `src/Pkcs11Wrapper.Native`
+
+### Admin surface
+
+- `src/Pkcs11Wrapper.Admin.Application`
+- `src/Pkcs11Wrapper.Admin.Web`
+
+### Runtime / validation / docs
+
+- `samples/Pkcs11Wrapper.Smoke`
+- `docs/vendor-regression.md`
+- `docs/smoke.md`
+- `docs/compatibility-matrix.md`
+- `README.md`
+
+## Executive summary
+
+The current repo is in a **good position for standard AWS CloudHSM PKCS#11 usage** when the scenario stays inside the AWS-documented Client SDK 5 contract.
+
+The most important compatibility conclusions are:
+
+1. **Standard PKCS#11 usage is the right support path.**
+   - The wrapper already models the standard `C_*` surface AWS documents for Client SDK 5.
+   - No separate AWS-specific extension package is required for the first useful slice.
+
+2. **CloudHSM’s session semantics are the biggest immediate repo mismatch.**
+   - AWS documents that SDK 5 rejects read-only `C_OpenSession`.
+   - Generic PKCS#11 tooling often assumes RO-by-default browse sessions.
+   - This issue now fixes that mismatch in the admin panel by retrying a failed RO open as RW.
+
+3. **Some current repo admin/runtime features should not be described as CloudHSM-ready yet.**
+   - AWS’s supported-API page does not list several operations used elsewhere in the repo, such as `C_CopyObject`, `C_SetAttributeValue`, `C_InitToken`, `C_InitPIN`, `C_SetPIN`, `C_GetOperationState`, `C_SetOperationState`, and PKCS#11 v3-only features.
+   - Those paths must remain unclaimed, capability-gated, or future work for CloudHSM.
+
+4. **Vendor-defined mechanisms/types exist, but first-class wrapper coverage is partial.**
+   - CloudHSM documents vendor-defined AES-GCM / AES-wrap mechanisms and vendor-defined KDF types.
+   - The wrapper can still carry raw numeric mechanism/type values, but there is not yet a polished first-class CloudHSM-specific helper layer.
+
+5. **A real CloudHSM runtime is still required for honest end-to-end validation.**
+   - This issue improves readiness and documentation, but does not pretend that compile-time work equals live-cluster proof.
+
+## Compatibility assessment
+
+| CloudHSM area | AWS public documentation | Current repo status | Assessment |
+| --- | --- | --- | --- |
+| Core module lifecycle (`C_Initialize`, `C_Finalize`, `C_GetInfo`, `C_GetFunctionList`) | Documented as supported | Fully wrapped in core | **Already good** |
+| Slot / token / mechanism enumeration | Documented as supported | Fully wrapped and used by admin/smoke tooling | **Already good** |
+| `C_OpenSession` / `C_GetSessionInfo` / `C_Login` / `C_Logout` / `C_CloseSession` / `C_CloseAllSessions` | Documented as supported, with RW-session requirement | Fully wrapped; admin panel now includes RO->RW compatibility retry | **Already good with CloudHSM-specific caveat** |
+| PKCS#11 login credential format | AWS documents `username:password` CU login | Wrapper/admin can pass arbitrary bytes; docs now capture CloudHSM semantics | **Already good once documented** |
+| `C_CreateObject` / `C_DestroyObject` / `C_FindObjects*` / `C_GetAttributeValue` | Documented as supported | Wrapped in core; used heavily by admin flows | **Already good** |
+| `C_GenerateKey` / `C_GenerateKeyPair` / `C_WrapKey` / `C_UnWrapKey` / `C_DeriveKey` | Documented as supported | Wrapped in core; admin panel already exposes many of these paths | **Already good for standard documented cases** |
+| Single-part sign/verify and encrypt/decrypt | Documented as supported | Wrapped in core; admin lab supports them | **Already good** |
+| Multipart digest/sign/encrypt/decrypt | Supported APIs and mechanisms are documented, but known-issues page warns about multipart hashing/signing history and AES-GCM caveats | Wrapped in core; smoke/lab can drive them generically | **Treat as version-sensitive; requires real-runtime validation** |
+| `C_CopyObject` | Not listed by AWS supported-API page reviewed here | Wrapper/admin support exists generically | **Do not assume on CloudHSM** |
+| `C_SetAttributeValue` | Not listed by AWS supported-API page reviewed here | Wrapper/admin support exists generically | **Do not assume on CloudHSM** |
+| `C_GetObjectSize` | Not listed by AWS supported-API page reviewed here | Wrapper/admin support exists generically | **Do not assume on CloudHSM** |
+| `C_InitToken` / `C_InitPIN` / `C_SetPIN` | Not listed by AWS supported-API page reviewed here | Wrapper/admin support exists generically | **Do not assume on CloudHSM** |
+| `C_GetOperationState` / `C_SetOperationState` | Not listed by AWS supported-API page reviewed here | Wrapper/smoke support exists generically | **Do not assume on CloudHSM** |
+| `C_WaitForSlotEvent` | Not listed by AWS supported-API page reviewed here | Wrapper exposes it generically | **Treat as unavailable / unclaimed** |
+| PKCS#11 v3 interface discovery (`C_GetInterface*`) | Not listed by AWS supported-API page reviewed here | Wrapper supports it generically | **Unclaimed for CloudHSM** |
+| PKCS#11 v3 message APIs (`C_Message*`) | Not listed by AWS supported-API page reviewed here | Wrapper supports them generically | **Unclaimed for CloudHSM** |
+| `C_LoginUser` / `C_SessionCancel` | Not listed by AWS supported-API page reviewed here | Wrapper supports them generically | **Unclaimed for CloudHSM** |
+| Vendor-defined AES-GCM / AES-wrap mechanisms | AWS documents them | Numeric mechanism IDs are possible; first-class helper polish is partial | **Potentially usable, but not yet a polished named helper path** |
+| Vendor-defined KDF types for ECDH | AWS documents them | Numeric representation is possible; structured/live validation absent here | **Potentially usable, but requires real-runtime proof** |
+
+## Where compatibility is already good
+
+### 1. Standard `C_*` wrapper architecture matches the CloudHSM support path
+
+The repo already exposes the standard Cryptoki surface that AWS documents for Client SDK 5.
+
+That means the first useful CloudHSM path does **not** require a new AWS-specific wrapper assembly just to get started.
+
+### 2. Explicit module-path loading is the right operational model
+
+`Pkcs11Wrapper` already expects an explicit library path. That matches CloudHSM well because AWS requires a host-local installed SDK/runtime and host-local bootstrap/configuration.
+
+### 3. Numeric mechanism/type escape hatches help with CloudHSM vendor diversity
+
+The wrapper’s numeric PKCS#11 types can carry raw values, which matters because CloudHSM documents vendor-defined mechanisms and KDF types beyond the common standard constants.
+
+### 4. The admin panel now addresses the biggest immediate CloudHSM mismatch
+
+This issue adds a compatibility improvement in `HsmAdminService` so a read-only session request that fails with `CKR_FUNCTION_FAILED` is retried as read-write.
+
+That directly improves the CloudHSM path for:
+
+- session opening
+- key browsing
+- object detail inspection
+- PKCS#11 Lab browse/inspect operations
+
+## Where compatibility is capability-gated or future work
+
+### 1. CloudHSM does not look like a full fit for every current admin feature
+
+Because AWS’s supported-API documentation does not currently list `C_CopyObject`, `C_SetAttributeValue`, or `C_GetObjectSize`, the repo should not describe object-copy/edit/detail-size flows as broadly CloudHSM-supported.
+
+This does **not** mean those methods can never work on any runtime build. It means the repo should not claim them from public docs alone.
+
+### 2. Token/PIN administration should stay unclaimed
+
+The supported-API page reviewed here does not list:
+
+- `C_InitToken`
+- `C_InitPIN`
+- `C_SetPIN`
+
+So generic repo support for those calls must not be translated into CloudHSM support claims.
+
+### 3. Operation-state and wait-for-slot-event should stay out of the CloudHSM promise
+
+The supported-API page reviewed here does not list:
+
+- `C_GetOperationState`
+- `C_SetOperationState`
+- `C_WaitForSlotEvent`
+
+That means:
+
+- smoke/sample paths that assume those features are not a clean CloudHSM validation story today
+- CloudHSM should not be added casually to the existing vendor lane without additional capability gating
+
+### 4. PKCS#11 v3 should remain unclaimed for CloudHSM
+
+The repo supports optional PKCS#11 v3 interfaces, but AWS’s supported-API page reviewed for issue #66 does not list:
+
+- `C_GetInterface*`
+- `C_LoginUser`
+- `C_SessionCancel`
+- `C_Message*`
+
+So the correct current stance is:
+
+- wrapper support exists generically
+- CloudHSM support is **not** claimed from public docs
+
+### 5. Multipart behavior requires real-version validation
+
+AWS documentation is mixed here:
+
+- multipart entry points appear in the supported-API page
+- the known-issues page also documents multipart hashing/signing caveats and AES-GCM limitations
+
+The safe conclusion is:
+
+- do not claim multipart behavior from documentation alone
+- validate against the exact Client SDK 5 version you deploy
+
+## CloudHSM-specific operational constraints that affect repo design
+
+### 1. Read-write sessions are mandatory
+
+This is the most important practical constraint.
+
+AWS documents that read-only session opens fail with `CKR_FUNCTION_FAILED`.
+
+Repo implications:
+
+- generic RO browse flows need adaptation
+- admin panel required a compatibility fix
+- future CloudHSM-specific smoke/regression work must be careful not to assume RO defaults
+
+### 2. Handles are session-specific
+
+AWS’s migration notes document session-specific handles in SDK 5.
+
+Repo implication:
+
+- object lookup by label/ID/class is the safer long-term pattern
+- persistent cached-handle assumptions should be avoided for CloudHSM
+
+### 3. Vendor-defined mechanisms/types exist but need real-runtime proof
+
+AWS documents vendor-defined items such as:
+
+- `CKM_CLOUDHSM_AES_GCM`
+- `CKM_CLOUDHSM_AES_KEY_WRAP_*`
+- vendor-defined ECDH KDF types
+
+Repo implication:
+
+- raw numeric use is possible
+- polished named helpers and structured validation are still future work
+
+## What could be validated locally in issue #66
+
+Without a real CloudHSM runtime, this issue could validate:
+
+- documentation correctness against AWS public docs
+- compile/build correctness of the admin-panel compatibility change
+- unit-test coverage of the RO->RW retry decision logic
+- AWS vendor-profile catalog wiring in the admin panel
+
+## What could not be validated honestly in issue #66
+
+Without a live AWS CloudHSM environment, this issue could **not** honestly validate:
+
+- actual SDK installation path resolution on Linux/Windows
+- real cluster bootstrap/configuration
+- real CU login behavior
+- real slot/token/mechanism exposure
+- real multipart behavior on Client SDK 5.17.1 or any other deployed version
+- real create/generate/wrap/unwrap compatibility under a CloudHSM policy
+- real admin-panel end-to-end behavior against AWS hardware
+- real smoke or vendor-regression success on CloudHSM
+
+## Practical conclusion
+
+The current repo should describe AWS CloudHSM support as:
+
+- **good candidate for standard PKCS#11 integration via Client SDK 5**
+- **admin-panel-ready enough for device registration, inspection, and standard diagnostics, with RO->RW compatibility fallback now added**
+- **not yet live-validated in CI or local automation without a real CloudHSM environment**
+- **not a blanket claim for every PKCS#11 method the wrapper exposes**
+
+That is the honest and useful first support slice for issue #66.

--- a/docs/cloudhsm-integration.md
+++ b/docs/cloudhsm-integration.md
@@ -1,0 +1,320 @@
+# AWS CloudHSM integration guide
+
+See also:
+
+- `docs/cloudhsm-compatibility-audit.md` for the conservative compatibility audit against AWS public documentation
+- `docs/compatibility-matrix.md` for the repo-wide support summary and current limits
+- `docs/vendor-regression.md` for why there is not yet a checked-in CloudHSM vendor-regression profile
+
+## Purpose
+
+This guide turns the CloudHSM research from issue #66 into a practical setup path for the current repository.
+
+It is intentionally conservative:
+
+- it describes how to use **standard PKCS#11 `C_*` flows** with **AWS CloudHSM Client SDK 5**
+- it shows the practical current path for the **wrapper** and **admin panel**
+- it documents the Linux/Windows bootstrap/auth/session constraints that matter operationally
+- it distinguishes what is **ready now**, what is **capability-gated**, and what still needs a **real CloudHSM environment** to validate honestly
+
+## What “AWS CloudHSM support” means in this repo today
+
+The current repo is a reasonable fit for **standard AWS CloudHSM PKCS#11 usage** when the scenario stays inside the subset that AWS documents for Client SDK 5.
+
+That means the practical support story is:
+
+### Supported well enough to use now
+
+- explicit AWS CloudHSM PKCS#11 module-path loading through `Pkcs11Module.Load(...)`
+- standard module / slot / token / mechanism enumeration
+- user login via standard `C_Login`
+- standard object search and attribute reads through `C_FindObjects*` / `C_GetAttributeValue`
+- standard create / destroy / generate / wrap / unwrap flows that AWS documents for Client SDK 5
+- admin-panel device profiles via the new **AWS CloudHSM / standard PKCS#11** vendor profile
+- admin-panel browse/lab compatibility improvement for CloudHSM’s **read-write-session-only** behavior
+
+### Important boundaries
+
+- this repo does **not** implement AWS control-plane operations such as cluster bootstrap, cluster lifecycle, VPC/network setup, trust-anchor management, or CloudHSM CLI/CMU user administration
+- this repo does **not** currently provide a checked-in CloudHSM smoke or vendor-regression profile, because some existing validation flows assume semantics that AWS SDK 5 does not expose
+- vendor-defined CloudHSM mechanisms/types are **not** currently represented by first-class named constants throughout the wrapper, even though the core numeric types can still carry raw values
+
+## AWS CloudHSM Client SDK 5 model that matters here
+
+From AWS public documentation, the key integration facts are:
+
+- the PKCS#11 library is documented as **PKCS#11 v2.40-compliant**
+- the runtime lives under:
+  - **Linux**: `/opt/cloudhsm`
+  - **Windows binaries**: `C:\Program Files\Amazon\CloudHSM`
+  - **Windows config/logs**: `C:\ProgramData\Amazon\CloudHSM`
+- the client must be bootstrapped to a cluster using the AWS configure tool and the cluster/customer CA certificate
+- the PKCS#11 login PIN format is **`<crypto-user-name>:<password>`**
+- **read-only sessions are not supported in SDK 5**; `C_OpenSession` without `CKF_RW_SESSION` is documented to fail with `CKR_FUNCTION_FAILED`
+- key handles are **session-specific** in SDK 5 and should be reacquired per run/session
+- multi-slot mode in SDK 5 represents **multiple cluster connections** from one application, not just arbitrary local token fan-out
+
+## Prerequisites
+
+Before pointing this repo at CloudHSM, make sure:
+
+1. the host or container that runs the code already has **AWS CloudHSM Client SDK 5** installed
+2. the host has the required **customer/issuing certificate** in place
+3. the client has already been **bootstrapped/configured** to the target cluster
+4. the process can resolve the intended PKCS#11 module path from that installed SDK
+5. you have a valid **crypto user (CU)** and password for application login
+6. if you plan to use object-management flows, you understand the current object ownership/sharing model for that CU
+
+## Linux and Windows setup expectations
+
+### Install/runtime layout
+
+The repo does not auto-discover CloudHSM for you. You must provide the exact PKCS#11 module path that the current host can load.
+
+Practical guidance:
+
+- on Linux, expect the relevant files under `/opt/cloudhsm`
+- on Windows, expect binaries under `C:\Program Files\Amazon\CloudHSM`
+- keep the **exact** library path in app configuration / device profile instead of hard-coding it in source
+- if you run the admin panel in a container, the SDK runtime and config must exist **inside that container**, not only on the host
+
+Because AWS’s public install page documents install roots rather than a single hard-coded library filename, the safest repo guidance is:
+
+- use the exact PKCS#11 library path visible on the machine that runs the code
+- verify that path with the host/container runtime itself before assuming the admin panel or tests can load it
+
+### Bootstrap/configuration expectations
+
+AWS documents two bootstrap styles for Client SDK 5:
+
+- bootstrap using an HSM ENI IP (`-a <ip>`)
+- bootstrap using `--cluster-id` plus optional `--region` / `--endpoint`
+
+Operationally, this means:
+
+- cluster reachability and VPC/security-group routing must already be correct
+- the customer CA certificate must already be present or explicitly configured
+- if the host cannot reach the CloudHSM control plane or HSM ENIs, repo-side changes will not fix that
+
+AWS also documents `--disable-key-availability-check` for cases where you intentionally operate a single-HSM cluster configuration. Treat that as an AWS runtime decision, not a repo default.
+
+## Authentication and session constraints
+
+These are the biggest CloudHSM-specific constraints for this repo:
+
+### 1. Login PIN is `username:password`
+
+CloudHSM does not use a plain opaque PIN string in the way many local fixture modules do. AWS documents `C_Login` PIN input as:
+
+```text
+<CU_user_name>:<password>
+```
+
+That matters for:
+
+- wrapper examples
+- the smoke sample if you adapt it manually
+- admin-panel operator instructions
+- secret handling and rotation expectations
+
+### 2. Read-only `C_OpenSession` is not supported
+
+AWS explicitly documents that Client SDK 5 rejects read-only session opens with `CKR_FUNCTION_FAILED`.
+
+That matters a lot because many generic PKCS#11 tools assume RO-by-default browsing sessions.
+
+For this repo today:
+
+- **wrapper consumers should open read-write sessions explicitly** when targeting CloudHSM
+- the **admin panel now retries a failed read-only open as read-write** for compatibility on browse/lab/session-open flows
+- write/destructive semantics are still controlled by the operation itself and the token policy; opening RW does not by itself imply mutation
+
+### 3. Key handles are session-specific
+
+AWS documents that SDK 5 key handles are session-specific and must be reacquired.
+
+Practical implication:
+
+- do not persist CloudHSM key handles across runs and assume they remain valid forever
+- use label/ID/object-class lookup and reacquire handles in each new process/session
+- this already aligns with how the admin panel and most repo guidance prefer to discover objects dynamically
+
+## Point the core wrapper at CloudHSM
+
+The simplest current integration path is still the direct module load plus an explicit RW session:
+
+```csharp
+using Pkcs11Wrapper;
+
+using Pkcs11Module module = Pkcs11Module.Load("/exact/path/from-the-installed-cloudhsm-sdk");
+module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+Pkcs11SlotId slotId = module.GetSlotIds(tokenPresentOnly: true)[0];
+using Pkcs11Session session = module.OpenSession(slotId, readWrite: true);
+session.Login(Pkcs11UserType.User, System.Text.Encoding.UTF8.GetBytes("CryptoUser:SecretPassword"));
+```
+
+Practical guidance:
+
+- prefer explicit RW sessions on CloudHSM
+- reacquire handles in each run instead of caching them long-term
+- treat AWS’s supported API list as the contract, not the full PKCS#11 surface exposed by the wrapper
+- if you need vendor-defined mechanisms/types, pass raw numeric IDs carefully and validate against a real CloudHSM runtime
+
+## Point the admin panel at CloudHSM
+
+The current admin path is:
+
+1. run `src/Pkcs11Wrapper.Admin.Web` on a machine/container that already has the CloudHSM SDK installed and bootstrapped
+2. open the **Devices** page
+3. create or edit a device profile with:
+   - **Name**: your operational cluster/profile label
+   - **PKCS#11 Module Path**: the exact CloudHSM PKCS#11 library path on that host
+   - **Default Token Label**: optional token label if your environment exposes a stable label you want to default to
+   - **Vendor profile**: **AWS CloudHSM / standard PKCS#11**
+   - **Notes**: optional CU/cluster/version/operator reminders
+4. use the built-in **Test** action before relying on the profile
+
+### What is improved in this slice
+
+The admin panel now has two CloudHSM-specific readiness improvements:
+
+- a built-in **AWS CloudHSM vendor profile** with setup/auth/scope hints
+- a compatibility retry path that upgrades a failed **read-only** session open to **read-write** when the module returns `CKR_FUNCTION_FAILED`
+
+That makes CloudHSM materially more usable in these admin surfaces:
+
+- **Devices** connection testing
+- **Slots / Keys** browsing
+- **Sessions** tracked-session opening
+- **PKCS#11 Lab** browse/inspect/sign/verify/encrypt/decrypt/wrap/read-attribute flows that do not inherently require a different unsupported API
+
+### What not to expect from the admin panel today
+
+Do **not** assume that every admin operation maps cleanly onto CloudHSM SDK 5.
+
+Based on AWS’s documented API list, the following repo admin features should be treated as **not currently assumed supported** on CloudHSM unless a live runtime proves otherwise:
+
+- object copy via `C_CopyObject`
+- attribute editing via `C_SetAttributeValue`
+- token/bootstrap PIN administration via `C_InitToken`, `C_InitPIN`, `C_SetPIN`
+- PKCS#11 v3-only session/message features
+
+The best current admin-panel fit for CloudHSM is therefore:
+
+- device registration
+- live slot/mechanism inspection
+- key/object discovery and detail reads
+- controlled lab diagnostics over the standard documented `C_*` surface
+- selected key-management flows that use documented CloudHSM APIs (`C_CreateObject`, `C_GenerateKey`, `C_GenerateKeyPair`, `C_DestroyObject`, `C_WrapKey`, `C_UnWrapKey`)
+
+## Compatibility notes that matter for wrapper/admin usage
+
+### Standard APIs AWS documents
+
+AWS publicly documents support for standard operations including:
+
+- lifecycle / info: `C_Initialize`, `C_Finalize`, `C_GetInfo`, `C_GetFunctionList`
+- slot/token/mechanism enumeration
+- session open/info/login/logout/close/close-all
+- object search + selected object management: `C_CreateObject`, `C_DestroyObject`, `C_GetAttributeValue`, `C_FindObjects*`
+- crypto: encrypt/decrypt, digest, sign/verify, generate/generate-pair, wrap/unwrap, derive, random
+
+### APIs the current repo should not assume on CloudHSM
+
+AWS’s supported-API page does **not** currently list support for:
+
+- `C_CopyObject`
+- `C_SetAttributeValue`
+- `C_GetObjectSize`
+- `C_InitToken`
+- `C_InitPIN`
+- `C_SetPIN`
+- `C_GetOperationState` / `C_SetOperationState`
+- `C_WaitForSlotEvent`
+- `C_LoginUser`
+- `C_SessionCancel`
+- `C_GetInterface*`
+- `C_Message*`
+
+So those should remain out-of-scope, capability-gated, or explicitly unclaimed for CloudHSM in this repo.
+
+### Multipart caveat
+
+AWS’s public docs are mixed here:
+
+- the supported-API page lists multipart-style entry points such as `C_DigestUpdate`, `C_SignUpdate`, and friends
+- the CloudHSM known-issues page also warns that multipart hashing/signing behavior has historically been problematic and version-sensitive
+
+So the honest repo stance is:
+
+- **do not claim CloudHSM multipart parity from documentation alone**
+- validate multipart digest/sign flows only against a real CloudHSM SDK/runtime you actually operate
+
+### AES-GCM caveat
+
+AWS documents important AES-GCM specifics:
+
+- standard `CKM_AES_GCM` expects the IV to be generated by the HSM
+- CloudHSM also exposes a vendor-defined `CKM_CLOUDHSM_AES_GCM` safer variant
+- AES-GCM buffers have documented size limits/caveats in known issues
+
+For the current repo, that means:
+
+- standard AES-GCM may work for targeted experiments, but payload-size and IV-handling rules are vendor-specific
+- vendor-defined AES-GCM is **not** currently a first-class named helper path here; it would require raw numeric use plus real-runtime validation
+
+## What can and cannot be validated locally without a real AWS CloudHSM environment
+
+### What this issue validates locally
+
+Without a real CloudHSM cluster, this repo slice can still validate:
+
+- the documentation/research path itself
+- compile/build correctness of the admin-panel compatibility change
+- admin test coverage for the RO->RW fallback decision logic
+- vendor-profile catalog wiring in the Devices page
+
+### What cannot be validated honestly without a real CloudHSM runtime
+
+Without a live CloudHSM environment, we cannot honestly prove:
+
+- actual module-path resolution for a real installed AWS SDK
+- cluster bootstrap success
+- CA certificate placement correctness
+- CU login behavior with real CloudHSM users
+- mechanism exposure for a real cluster/partition/user policy
+- multipart behavior on the exact SDK version you deploy
+- vendor-defined mechanism usability
+- live admin write-path compatibility for create/generate/wrap/unwrap flows
+- end-to-end smoke or regression success against AWS CloudHSM
+
+## Why there is no checked-in CloudHSM regression profile yet
+
+The repo already has a generic vendor lane, but CloudHSM currently needs a more careful capability contract because:
+
+- SDK 5 rejects RO sessions
+- AWS does not document support for several admin/provisioning calls currently assumed elsewhere in the repo (`C_InitToken`, `C_InitPIN`, `C_SetPIN`, `C_CopyObject`, `C_SetAttributeValue`, `C_GetOperationState`, etc.)
+- smoke/vendor-regression flows would need CloudHSM-aware capability gating before they could be described as reliable
+
+That is why this issue delivers:
+
+- solid CloudHSM documentation
+- admin-panel readiness improvements
+- a clearer support boundary
+
+rather than pretending the existing full regression stack is already CloudHSM-proven.
+
+## Recommended real-environment validation order
+
+When a real CloudHSM environment is available, validate in this order:
+
+1. **module load + initialize + slot listing**
+2. **RW session open + `username:password` login**
+3. **object search by label/ID**
+4. **mechanism inventory from the live slot**
+5. **single-part sign/verify and encrypt/decrypt**
+6. **generate/create/destroy flows with a disposable test user/object namespace**
+7. only then evaluate multipart, wrap/unwrap, and any vendor-defined mechanisms
+
+That sequence matches the repo’s current support depth far better than trying to start with the most advanced CloudHSM-specific paths.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -32,5 +32,6 @@
 
 - PKCS#11 v3 runtime validation now uses a deterministic Linux-built shim rather than a vendor module, so it validates marshalling/runtime behavior but not vendor-specific semantics.
 - Windows NativeAOT validation now exists, but Linux still remains the deepest day-to-day validation environment because it is the primary benchmark baseline and the most feature-complete local automation path.
+- AWS CloudHSM now has a documented standard-PKCS#11 support path plus admin-panel read-only→read-write session fallback guidance, but it is not yet backed by live CloudHSM CI or a real-cluster regression lane.
 - Mechanism parameter helpers are intentionally selective; uncommon mechanisms may still require raw parameter bytes.
 - Packaging discipline is defined in `docs/release.md`, but external package publication is still a maintainer action rather than an automated CI publish step.

--- a/docs/vendor-regression.md
+++ b/docs/vendor-regression.md
@@ -140,6 +140,26 @@ Based on the completed audit, these should remain capability-gated, unsupported,
 
 If one of the capability-gated checks is absent because the Luna runtime or token policy does not expose it, that should be interpreted as a skipped/capability-gated result, not as proof that the wrapper is broken.
 
+## Why there is not yet a checked-in AWS CloudHSM profile
+
+See also: `docs/cloudhsm-integration.md` and `docs/cloudhsm-compatibility-audit.md`.
+
+AWS CloudHSM is now a documented target for the repo, but there is intentionally **no** checked-in `cloudhsm-*` vendor-regression profile yet.
+
+Reason:
+
+- AWS Client SDK 5 documents that read-only `C_OpenSession` is not supported
+- AWS’s supported-API page does not currently list several operations assumed elsewhere in the broader repo/runtime surface, including `C_CopyObject`, `C_SetAttributeValue`, `C_InitToken`, `C_InitPIN`, `C_SetPIN`, `C_GetOperationState`, and PKCS#11 v3-only paths
+- the existing smoke/vendor-regression flow would need CloudHSM-specific capability gating before a profile could be described as reliable rather than misleading
+
+So the current CloudHSM support slice is:
+
+- strong documentation
+- admin-panel readiness improvements
+- explicit wrapper/admin setup guidance
+
+rather than a premature vendor-lane profile that would overstate validation depth.
+
 ## Recommended local usage
 
 ```bash

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -14,6 +14,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private const string DestroyConfirmationPrefix = "DESTROY ";
     private const string ConfigurationFormat = "Pkcs11Wrapper.Admin.Configuration";
     private const int ConfigurationSchemaVersion = 1;
+    private const nuint CkrFunctionFailed = 0x00000006u;
 
     private static readonly string[] ConfigurationIncludedSections =
     [
@@ -78,6 +79,13 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         public static implicit operator LabExecutionPayload((string Summary, string OutputText, List<string> Notes) value)
             => new(value.Summary, value.OutputText, value.Notes);
+    }
+
+    private sealed record SessionOpenResult(Pkcs11Session Session, bool RequestedReadWrite, bool OpenedReadWrite, bool EscalatedToReadWrite)
+    {
+        public string ModeLabel => OpenedReadWrite ? "Read-write" : "Read-only";
+
+        public string ModeShortLabel => OpenedReadWrite ? "RW" : "RO";
     }
 
     public Task<IReadOnlyList<HsmDeviceProfile>> GetDevicesAsync(CancellationToken cancellationToken = default)
@@ -440,7 +448,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         authorization.DemandViewer();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
         using Pkcs11Module module = CreateInitializedModule(device);
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue));
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWriteRequested: false);
+        using Pkcs11Session session = sessionOpen.Session;
 
         string pinNote = LoginIfProvided(session, userPin);
         Pkcs11ObjectSearchParameters search = new(label: string.IsNullOrWhiteSpace(labelFilter) ? default : Encoding.UTF8.GetBytes(labelFilter));
@@ -457,7 +466,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
         using Pkcs11Module module = CreateInitializedModule(device);
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue));
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWriteRequested: false);
+        using Pkcs11Session session = sessionOpen.Session;
         string pinNote = LoginIfProvided(session, userPin);
 
         HsmKeyObjectPage page = HsmAdminKeyPageBrowser.ReadPage(deviceId, slotIdValue, session, request);
@@ -473,7 +483,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         authorization.DemandViewer();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
         using Pkcs11Module module = CreateInitializedModule(device);
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue));
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWriteRequested: false);
+        using Pkcs11Session session = sessionOpen.Session;
         string pinNote = LoginIfProvided(session, userPin);
 
         HsmObjectDetail detail = HsmAdminObjectCatalog.ReadObjectDetail(deviceId, slotIdValue, session, new Pkcs11ObjectHandle(handleValue));
@@ -638,7 +649,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         Pkcs11Module module = CreateInitializedModule(device);
         try
         {
-            Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite);
+            SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWrite);
+            Pkcs11Session session = sessionOpen.Session;
             string notes = "Public session";
             if (!string.IsNullOrWhiteSpace(userPin))
             {
@@ -646,8 +658,16 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
                 notes = "User-authenticated session";
             }
 
-            AdminSessionSnapshot snapshot = sessionRegistry.Register(device.Id, device.Name, module, session, readWrite, notes);
-            await auditLog.WriteAsync("Session", "Open", $"{device.Name}/slot-{slotIdValue}", "Success", $"Opened {(readWrite ? "read-write" : "read-only")} session.", cancellationToken: cancellationToken);
+            if (sessionOpen.EscalatedToReadWrite)
+            {
+                notes += " (opened as read-write after the module rejected a read-only session request)";
+            }
+
+            AdminSessionSnapshot snapshot = sessionRegistry.Register(device.Id, device.Name, module, session, sessionOpen.OpenedReadWrite, notes);
+            string auditDetail = sessionOpen.EscalatedToReadWrite
+                ? "Opened read-write session after the module rejected a read-only session request."
+                : $"Opened {(sessionOpen.OpenedReadWrite ? "read-write" : "read-only")} session.";
+            await auditLog.WriteAsync("Session", "Open", $"{device.Name}/slot-{slotIdValue}", "Success", auditDetail, cancellationToken: cancellationToken);
             return snapshot;
         }
         catch
@@ -1205,30 +1225,33 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static (string Summary, string OutputText, List<string> Notes) ExecuteSessionInfoLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11SessionInfo info = session.GetInfo();
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {info.SlotId.Value}");
-        output.AppendLine($"Mode: {(request.OpenReadWriteSession ? "Read-write" : "Read-only")}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"State: {info.State}");
         output.AppendLine($"Flags: {info.Flags}");
         output.AppendLine($"Device error: {info.DeviceError}");
-        return ($"Opened a transient {(request.OpenReadWriteSession ? "RW" : "RO")} session and read `C_GetSessionInfo`.", output.ToString(), notes);
+        return ($"Opened a transient {sessionOpen.ModeShortLabel} session and read `C_GetSessionInfo`.", output.ToString(), notes);
     }
 
     private static LabExecutionPayload ExecuteGenerateRandomLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), readWrite: false);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), readWriteRequested: false, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         byte[] random = new byte[request.RandomLength];
         session.GenerateRandom(random);
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Random length: {request.RandomLength}");
         output.AppendLine($"Random hex: {Convert.ToHexString(random)}");
@@ -1238,7 +1261,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static LabExecutionPayload ExecuteDigestTextLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), readWrite: false);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), readWriteRequested: false, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11MechanismType mechanismType = ResolveDigestMechanism(request.DigestAlgorithm);
         byte[] data = Encoding.UTF8.GetBytes(request.TextInput ?? string.Empty);
@@ -1251,6 +1275,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Mechanism: {DescribeMechanismType(mechanismType)}");
         output.AppendLine($"Input bytes: {data.Length}");
@@ -1262,7 +1287,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static LabExecutionPayload ExecuteSignDataLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11MechanismType mechanismType = ParseMechanismTypeText(request.MechanismTypeText!);
         byte[] mechanismParameter = CreateLabMechanismParameter(mechanismType, request, validateOnly: false, notes);
@@ -1278,7 +1304,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
-        output.AppendLine($"Mode: {(request.OpenReadWriteSession ? "Read-write" : "Read-only")}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Mechanism: {DescribeMechanismType(mechanismType)}");
         output.AppendLine($"Key handle: {keyHandle.Value}");
@@ -1296,7 +1322,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static (string Summary, string OutputText, List<string> Notes) ExecuteVerifySignatureLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11MechanismType mechanismType = ParseMechanismTypeText(request.MechanismTypeText!);
         byte[] mechanismParameter = CreateLabMechanismParameter(mechanismType, request, validateOnly: false, notes);
@@ -1308,7 +1335,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
-        output.AppendLine($"Mode: {(request.OpenReadWriteSession ? "Read-write" : "Read-only")}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Mechanism: {DescribeMechanismType(mechanismType)}");
         output.AppendLine($"Key handle: {keyHandle.Value}");
@@ -1326,7 +1353,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static LabExecutionPayload ExecuteEncryptDataLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11MechanismType mechanismType = ParseMechanismTypeText(request.MechanismTypeText!);
         byte[] mechanismParameter = CreateLabMechanismParameter(mechanismType, request, validateOnly: false, notes);
@@ -1342,7 +1370,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
-        output.AppendLine($"Mode: {(request.OpenReadWriteSession ? "Read-write" : "Read-only")}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Mechanism: {DescribeMechanismType(mechanismType)}");
         output.AppendLine($"Key handle: {keyHandle.Value}");
@@ -1359,7 +1387,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static LabExecutionPayload ExecuteDecryptDataLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11MechanismType mechanismType = ParseMechanismTypeText(request.MechanismTypeText!);
         byte[] mechanismParameter = CreateLabMechanismParameter(mechanismType, request, validateOnly: false, notes);
@@ -1376,7 +1405,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ReadOnlySpan<byte> plaintextSpan = plaintext.AsSpan(0, written);
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
-        output.AppendLine($"Mode: {(request.OpenReadWriteSession ? "Read-write" : "Read-only")}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Mechanism: {DescribeMechanismType(mechanismType)}");
         output.AppendLine($"Key handle: {keyHandle.Value}");
@@ -1391,7 +1420,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static (string Summary, string OutputText, List<string> Notes) ExecuteInspectObjectLab(Guid deviceId, Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), readWrite: false);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), readWriteRequested: false, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11ObjectHandle handle = ResolveLabObjectHandle(session, request.KeyHandleText, request.KeyLabel, request.KeyIdHex, request.KeyObjectClass, request.KeyType, "Key handle");
         HsmObjectDetail detail = HsmAdminObjectCatalog.ReadObjectDetail(deviceId, request.SlotId.Value, session, handle);
@@ -1403,6 +1433,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Handle: {detail.Handle}");
         output.Append(FormatObjectDetail(detail));
@@ -1412,7 +1443,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static LabExecutionPayload ExecuteWrapKeyLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), request.OpenReadWriteSession, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11MechanismType mechanismType = ParseMechanismTypeText(request.MechanismTypeText!);
         byte[] mechanismParameter = CreateLabMechanismParameter(mechanismType, request, validateOnly: false, notes);
@@ -1428,7 +1460,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
-        output.AppendLine($"Mode: {(request.OpenReadWriteSession ? "Read-write" : "Read-only")}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Mechanism: {DescribeMechanismType(mechanismType)}");
         output.AppendLine($"Wrapping key handle: {wrappingKeyHandle.Value}");
@@ -1520,11 +1552,13 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static (string Summary, string OutputText, List<string> Notes) ExecuteReadAttributeLab(Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), readWrite: false);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), readWriteRequested: false, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         Pkcs11ObjectHandle handle = ResolveLabObjectHandle(session, request.KeyHandleText, request.KeyLabel, request.KeyIdHex, request.KeyObjectClass, request.KeyType, "Key handle");
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Handle: {handle.Value}");
         IReadOnlyList<Pkcs11AttributeType> attributeTypes = ParseAttributeTypeListText(request.AttributeTypeText!);
@@ -1541,7 +1575,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private static (string Summary, string OutputText, List<string> Notes) ExecuteFindObjectsLab(Guid deviceId, Pkcs11Module module, Pkcs11LabRequest request)
     {
         List<string> notes = [];
-        using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(request.SlotId!.Value), readWrite: false);
+        SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(request.SlotId!.Value), readWriteRequested: false, notes);
+        using Pkcs11Session session = sessionOpen.Session;
         string authMode = LoginLabSessionIfRequested(session, request, notes);
         byte[] label = string.IsNullOrWhiteSpace(request.LabelFilter) ? [] : Encoding.UTF8.GetBytes(request.LabelFilter.Trim());
         byte[] id = ParseOptionalHex(request.IdHex, nameof(request.IdHex));
@@ -1561,6 +1596,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         StringBuilder output = new();
         output.AppendLine($"Slot: {request.SlotId.Value}");
+        output.AppendLine($"Mode: {sessionOpen.ModeLabel}");
         output.AppendLine($"Auth mode: {authMode}");
         output.AppendLine($"Max objects: {request.MaxObjects}");
         output.AppendLine($"Label filter: {(string.IsNullOrWhiteSpace(request.LabelFilter) ? "<none>" : request.LabelFilter.Trim())}");
@@ -1579,6 +1615,22 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
             : $"Found {handles.Count} object(s) matching the current search filters.";
         return (summaryText, output.ToString(), notes);
     }
+
+    private static SessionOpenResult OpenCompatibleSession(Pkcs11Module module, Pkcs11SlotId slotId, bool readWriteRequested, List<string>? notes = null)
+    {
+        try
+        {
+            return new(module.OpenSession(slotId, readWriteRequested), readWriteRequested, readWriteRequested, EscalatedToReadWrite: false);
+        }
+        catch (Pkcs11Exception ex) when (ShouldRetryReadWriteAfterOpenSessionFailure(readWriteRequested, ex))
+        {
+            notes?.Add("The module rejected a read-only C_OpenSession request with CKR_FUNCTION_FAILED, so the admin layer retried with a read-write session for compatibility.");
+            return new(module.OpenSession(slotId, readWrite: true), readWriteRequested, OpenedReadWrite: true, EscalatedToReadWrite: true);
+        }
+    }
+
+    private static bool ShouldRetryReadWriteAfterOpenSessionFailure(bool readWriteRequested, Pkcs11Exception exception)
+        => !readWriteRequested && exception.Result.Value == CkrFunctionFailed;
 
     private static string LoginLabSessionIfRequested(Pkcs11Session session, Pkcs11LabRequest request, List<string> notes)
     {

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
@@ -74,6 +74,28 @@ internal static class DeviceVendorProfileCatalog
                     "Stay on the vendor-neutral operational surface",
                     "This UI intentionally covers standard PKCS#11 workflows. Vendor-specific appliance or security-administration tasks remain out of scope and should stay in dedicated vendor tooling/processes.",
                     DeviceVendorHintTone.Boundary)
+            ]),
+        new(
+            "aws-cloudhsm-standard",
+            "AWS CloudHSM / standard PKCS#11",
+            "aws",
+            "AWS",
+            "cloudhsm-standard",
+            "CloudHSM / Client SDK 5",
+            "Use this when the profile targets the PKCS#11 library from AWS CloudHSM Client SDK 5 and you want the admin UI to keep the CloudHSM bootstrap/auth/session caveats visible while staying inside standard PKCS#11 flows.",
+            [
+                new DeviceVendorHint(
+                    "Client SDK 5 must already be installed and bootstrapped on this host",
+                    "Point the profile at the exact AWS CloudHSM PKCS#11 module path that the running host/container can resolve, and make sure the host already has the Client SDK 5 runtime, cluster certificate, and cluster bootstrap/configuration in place first.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "CloudHSM uses RW sessions and CU-style login semantics",
+                    "AWS documents that SDK 5 rejects read-only C_OpenSession calls and expects C_Login PINs in the form username:password for a crypto user (CU). The admin layer will retry a failed read-only open as read-write for compatibility, but operators should still expect CloudHSM sessions to behave as RW by default.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Cluster/user administration stays outside this UI",
+                    "This profile is for standard PKCS#11 device, slot, object, and lab workflows only. Cluster bootstrap, CloudHSM CLI/CMU user management, trust-anchor/TLS bootstrap, and other AWS control-plane operations remain out of scope here.",
+                    DeviceVendorHintTone.Boundary)
             ])
     ];
 

--- a/tests/Pkcs11Wrapper.Admin.Tests/HsmAdminServiceTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/HsmAdminServiceTests.cs
@@ -211,6 +211,45 @@ public sealed class HsmAdminServiceTests
     }
 
     [Fact]
+    public void ShouldRetryReadWriteAfterOpenSessionFailureReturnsTrueForReadOnlyFunctionFailed()
+    {
+        MethodInfo method = GetShouldRetryReadWriteAfterOpenSessionFailureMethod();
+        bool shouldRetry = (bool)method.Invoke(null,
+        [
+            false,
+            new Pkcs11Exception("C_OpenSession", new CK_RV(0x00000006))
+        ])!;
+
+        Assert.True(shouldRetry);
+    }
+
+    [Fact]
+    public void ShouldRetryReadWriteAfterOpenSessionFailureReturnsFalseForReadWriteRequests()
+    {
+        MethodInfo method = GetShouldRetryReadWriteAfterOpenSessionFailureMethod();
+        bool shouldRetry = (bool)method.Invoke(null,
+        [
+            true,
+            new Pkcs11Exception("C_OpenSession", new CK_RV(0x00000006))
+        ])!;
+
+        Assert.False(shouldRetry);
+    }
+
+    [Fact]
+    public void ShouldRetryReadWriteAfterOpenSessionFailureReturnsFalseForOtherErrors()
+    {
+        MethodInfo method = GetShouldRetryReadWriteAfterOpenSessionFailureMethod();
+        bool shouldRetry = (bool)method.Invoke(null,
+        [
+            false,
+            new Pkcs11Exception("C_OpenSession", new CK_RV(0x000000A0))
+        ])!;
+
+        Assert.False(shouldRetry);
+    }
+
+    [Fact]
     public void LoginUserToleratingAlreadyLoggedInSwallowsAlreadyLoggedInReturnValue()
     {
         MethodInfo method = GetLoginUserToleratingAlreadyLoggedInActionOverload();
@@ -240,6 +279,16 @@ public sealed class HsmAdminServiceTests
 
         Pkcs11Exception inner = Assert.IsType<Pkcs11Exception>(ex.InnerException);
         Assert.Equal((nuint)0xA0, (nuint)inner.RawResult);
+    }
+
+    private static MethodInfo GetShouldRetryReadWriteAfterOpenSessionFailureMethod()
+    {
+        return typeof(HsmAdminService)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name == "ShouldRetryReadWriteAfterOpenSessionFailure"
+                && method.GetParameters() is [{ ParameterType: var first }, { ParameterType: var second }]
+                && first == typeof(bool)
+                && second == typeof(Pkcs11Exception));
     }
 
     private static MethodInfo GetLoginUserToleratingAlreadyLoggedInActionOverload()


### PR DESCRIPTION
## Summary
Add the first practical AWS CloudHSM support slice.

## Included work
- AWS CloudHSM integration and compatibility research/docs
- honest support boundary for what is and is not validated without live service access
- admin-panel readiness improvement for CloudHSM SDK 5 read-only session incompatibility
- built-in AWS CloudHSM vendor profile/hints in the admin UI
- tests covering the RO -> RW fallback behavior

## Notes
- this is a documentation + low-risk compatibility slice, not a claim of live CloudHSM-backed regression coverage
- no AWS-specific wrapper package was added in this first phase

## Closes
Closes #66
