### PR TITLE
Add Google Cloud HSM support guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Current capabilities include:
 - [docs/luna-compatibility-audit.md](docs/luna-compatibility-audit.md) - public-doc audit of Thales Luna standard compatibility vs current wrapper/admin/runtime scope
 - [docs/cloudhsm-integration.md](docs/cloudhsm-integration.md) - practical AWS CloudHSM Client SDK 5 setup guidance for wrapper and admin-panel usage
 - [docs/cloudhsm-compatibility-audit.md](docs/cloudhsm-compatibility-audit.md) - public-doc audit of AWS CloudHSM standard PKCS#11 compatibility vs current wrapper/admin/runtime scope
+- [docs/google-cloud-hsm-integration.md](docs/google-cloud-hsm-integration.md) - practical Google Cloud KMS / Cloud HSM via kmsp11 setup guidance for wrapper and admin-panel usage
+- [docs/google-cloud-hsm-compatibility-audit.md](docs/google-cloud-hsm-compatibility-audit.md) - public-doc audit of Google Cloud HSM's indirect kmsp11 PKCS#11 path vs current wrapper/admin/runtime scope
 - [docs/luna-vendor-extension-design.md](docs/luna-vendor-extension-design.md) - proposed package/boundary/loading/test strategy for future Luna-only `CA_*` support
 - [docs/vendor-audit-integration.md](docs/vendor-audit-integration.md) - vendor-native audit evaluation starting with Thales Luna, including CLI/syslog/export/API path trade-offs vs wrapper telemetry
 - [docs/smoke.md](docs/smoke.md) - smoke sample behavior and troubleshooting
@@ -330,6 +332,7 @@ Current capabilities include:
 - Linux is still the primary benchmark/reference environment, even though Windows now also has fixture-backed NativeAOT smoke validation.
 - PKCS#11 v3 runtime behavior still depends on whether the target module actually exports the relevant v3 interface surface.
 - AWS CloudHSM support in the current repo is a documented/admin-readiness slice, not a claim of live cluster-backed CI validation yet.
+- Google Cloud HSM support in the current repo is an indirect kmsp11/Cloud KMS slice with docs and admin guardrails, not a claim of direct-HSM client support or live Google-backed CI validation yet.
 
 ## Contributing
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -33,5 +33,6 @@
 - PKCS#11 v3 runtime validation now uses a deterministic Linux-built shim rather than a vendor module, so it validates marshalling/runtime behavior but not vendor-specific semantics.
 - Windows NativeAOT validation now exists, but Linux still remains the deepest day-to-day validation environment because it is the primary benchmark baseline and the most feature-complete local automation path.
 - AWS CloudHSM now has a documented standard-PKCS#11 support path plus admin-panel read-only→read-write session fallback guidance, but it is not yet backed by live CloudHSM CI or a real-cluster regression lane.
+- Google Cloud HSM now has a documented indirect support path through Google's kmsp11 Cloud KMS adapter, but it still depends on real Google auth/config, host-level `KMS_PKCS11_CONFIG`, and live cloud access for honest end-to-end validation.
 - Mechanism parameter helpers are intentionally selective; uncommon mechanisms may still require raw parameter bytes.
 - Packaging discipline is defined in `docs/release.md`, but external package publication is still a maintainer action rather than an automated CI publish step.

--- a/docs/google-cloud-hsm-compatibility-audit.md
+++ b/docs/google-cloud-hsm-compatibility-audit.md
@@ -1,0 +1,252 @@
+# Google Cloud HSM PKCS#11 compatibility audit
+
+See also:
+
+- `docs/google-cloud-hsm-integration.md` for the practical wrapper/admin-panel setup path
+- `docs/compatibility-matrix.md` for the repo-wide support summary
+- `docs/vendor-regression.md` for the current vendor-lane boundary
+
+## Scope
+
+This document audits **publicly documented Google Cloud HSM / Cloud KMS PKCS#11 compatibility** against the current `Pkcs11Wrapper` repository.
+
+It is intentionally conservative:
+
+- it distinguishes **Google's documented kmsp11 PKCS#11 subset** from the broader PKCS#11 surface exposed by the wrapper
+- it separates **already good repo alignment** from **abstraction-boundary mismatches** and **real-runtime-only validation**
+- it does **not** claim support that requires a real Google Cloud environment when no live Cloud KMS / Cloud HSM access was available during issue #67
+
+## Google public references reviewed
+
+- Cloud HSM overview: <https://cloud.google.com/kms/docs/hsm>
+- Cloud KMS PKCS#11 library reference page: <https://cloud.google.com/kms/docs/reference/pkcs11-library>
+- kmsp11 user guide: <https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md>
+- Google authentication getting started: <https://cloud.google.com/docs/authentication/getting-started>
+- latest kmsp11 release assets reviewed during this issue: `libkmsp11.so` / `kmsp11.dll` from the `GoogleCloudPlatform/kms-integrations` release page
+
+## Repository areas reviewed
+
+### Core wrapper
+
+- `src/Pkcs11Wrapper`
+- `src/Pkcs11Wrapper.Native`
+
+### Admin surface
+
+- `src/Pkcs11Wrapper.Admin.Application`
+- `src/Pkcs11Wrapper.Admin.Web`
+
+### Runtime / validation / docs
+
+- `docs/vendor-regression.md`
+- `docs/compatibility-matrix.md`
+- `README.md`
+
+## Executive summary
+
+The current repo is in a **good position for standard kmsp11 usage**, but the support path is importantly different from AWS CloudHSM or vendor client SDK integrations.
+
+The most important compatibility conclusions are:
+
+1. **The right support boundary is indirect PKCS#11 via kmsp11, not direct Google HSM client integration.**
+   - Google Cloud HSM lives behind Cloud KMS.
+   - The official PKCS#11 story is Google's `kmsp11` adapter.
+   - So repo support should be described as **Cloud KMS / Cloud HSM through kmsp11**, not as direct hardware-client integration.
+
+2. **The wrapper is already structurally compatible with the documented kmsp11 surface.**
+   - Standard module loading, slot enumeration, object search, attribute reads, crypto calls, and raw numeric attribute handling all line up with Google's documented path.
+   - No new Google-specific wrapper assembly is required for the first useful slice.
+
+3. **The admin panel needed honesty guardrails more than a new runtime shim.**
+   - kmsp11 intentionally does not support `C_CreateObject`, `C_CopyObject`, `C_SetAttributeValue`, wrap/unwrap/derive, PIN admin, digest, operation-state, or wait-for-slot-event.
+   - kmsp11 key generation also depends on Google-specific `CKA_KMS_*` template attributes.
+   - So the current generic admin key-management forms should not be advertised as fully Google-ready.
+
+4. **The current repo has one meaningful abstraction-boundary gap: kmsp11 config-path delivery.**
+   - Google documents `C_Initialize` `pReserved` or `KMS_PKCS11_CONFIG` for config-path delivery.
+   - The current wrapper/admin path does not yet expose `pReserved` directly.
+   - Therefore the practical support path today is host-level `KMS_PKCS11_CONFIG`.
+
+5. **A real Google Cloud environment is still required for honest end-to-end validation.**
+   - This issue improves documentation and admin readiness.
+   - It does not pretend that compile-time work equals real Cloud KMS / Cloud HSM proof.
+
+## Compatibility assessment
+
+| Google / kmsp11 area | Google public documentation | Current repo status | Assessment |
+| --- | --- | --- | --- |
+| Core module lifecycle (`C_Initialize`, `C_Finalize`, `C_GetInfo`, `C_GetFunctionList`) | Documented as supported | Fully wrapped in core | **Already good** |
+| Slot / token / mechanism enumeration | Documented as supported | Fully wrapped and used by admin tooling | **Already good** |
+| `C_OpenSession` / `C_GetSessionInfo` / `C_Login` / `C_Logout` / `C_CloseSession` / `C_CloseAllSessions` | Documented as supported; `CKF_SERIAL_SESSION` required; login optional and PIN ignored | Fully wrapped; admin/runtime can already use this shape | **Already good with kmsp11-specific semantics** |
+| Config-path delivery (`pReserved` or `KMS_PKCS11_CONFIG`) | Documented by Google | Host env path works now; direct `pReserved` path not exposed in current managed API | **Supported through env-var path; partial abstraction mismatch** |
+| `C_FindObjects*` / `C_GetAttributeValue` / `C_DestroyObject` | Documented as supported | Wrapped in core; used by admin flows | **Already good** |
+| Sign / verify / encrypt / decrypt | Documented as supported for supported Cloud KMS-backed algorithms | Wrapped in core; admin lab can drive these generically | **Already good, but requires real-runtime validation** |
+| `C_GenerateKey` / `C_GenerateKeyPair` | Documented as supported with `CKA_KMS_*` template rules | Wrapper can carry raw attrs; current generic admin forms do not model those attrs | **Wrapper-capable, admin abstraction not yet vendor-aware** |
+| `C_GenerateRandom` | Documented as supported | Wrapped in core | **Already good** |
+| `C_CreateObject` | Documented as unsupported | Wrapper/admin support exists generically | **Do not assume on Google** |
+| `C_CopyObject` | Documented as unsupported | Wrapper/admin support exists generically | **Do not assume on Google** |
+| `C_SetAttributeValue` | Documented as unsupported | Wrapper/admin support exists generically | **Do not assume on Google** |
+| `C_GetObjectSize` | Documented as unsupported | Wrapper/admin support exists generically | **Do not assume on Google** |
+| `C_WrapKey` / `C_UnwrapKey` / `C_DeriveKey` | Documented as unsupported | Wrapper/admin support exists generically | **Do not assume on Google** |
+| `C_Digest*` | Documented as unsupported | Wrapper/lab support exists generically | **Do not assume on Google** |
+| `C_GetOperationState` / `C_SetOperationState` | Documented as unsupported | Wrapper support exists generically | **Do not assume on Google** |
+| `C_InitToken` / `C_InitPIN` / `C_SetPIN` | Documented as unsupported | Wrapper/admin support exists generically | **Do not assume on Google** |
+| `C_WaitForSlotEvent` / `C_GetFunctionStatus` / `C_CancelFunction` | Documented as unsupported | Wrapper support exists generically | **Treat as unavailable / unclaimed** |
+| PKCS#11 v3-only interfaces (`C_GetInterface*`, `C_Message*`, `C_LoginUser`, `C_SessionCancel`) | Not part of the documented kmsp11 v2.40 story reviewed here | Wrapper supports them generically | **Unclaimed for Google** |
+
+## Where compatibility is already good
+
+### 1. Standard `C_*` wrapper architecture matches Google's published path
+
+The repo already exposes the standard Cryptoki surface that Google documents for kmsp11.
+
+That means the first useful Google slice does **not** require a dedicated Google wrapper package just to consume the documented standard surface.
+
+### 2. Explicit module-path loading is the right operational model
+
+`Pkcs11Wrapper` already expects an explicit library path.
+
+That matches kmsp11 well because Google expects a host-local library plus host-local config/auth environment rather than a repo-managed provisioning step.
+
+### 3. Raw numeric attribute/mechanism types are enough for the first wrapper slice
+
+The wrapper's numeric PKCS#11 types can carry raw values, which matters because Google documents vendor-specific key-generation attributes such as `CKA_KMS_ALGORITHM`, `CKA_KMS_PROTECTION_LEVEL`, and `CKA_KMS_CRYPTO_KEY_BACKEND`.
+
+That keeps wrapper-level Google support plausible even before higher-level helper polish exists.
+
+### 4. The admin panel can already serve as a consumer/diagnostics surface
+
+Once kmsp11 is installed and the host provides config/auth correctly, the admin panel is already a reasonable fit for:
+
+- device registration
+- connection testing
+- slot/mechanism inventory
+- object discovery
+- read-oriented inspection
+- selected lab diagnostics over the documented kmsp11 surface
+
+## Where compatibility is capability-gated or future work
+
+### 1. Google support is not a direct-HSM integration story
+
+This is the biggest conceptual difference from other vendors.
+
+The repo should not talk about Google Cloud HSM the way it talks about Luna or AWS client runtimes. The actual boundary is:
+
+- `Pkcs11Wrapper` / admin panel -> **kmsp11**
+- kmsp11 -> **Cloud KMS**
+- Cloud KMS protection level -> **Cloud HSM**
+
+That means control-plane and auth/setup boundaries remain fundamentally outside this repo.
+
+### 2. The current admin key-management forms are not a clean fit for Google generation
+
+Google documents `C_GenerateKey` / `C_GenerateKeyPair`, but with strong template constraints:
+
+- `CKA_LABEL` is required
+- `CKA_KMS_ALGORITHM` is required
+- optional Google-specific attributes affect protection-level/backend behavior
+- for key-pair generation, the public key template must not be specified
+
+The wrapper can express these at the raw PKCS#11 layer, but the current admin AES/RSA forms are generic token-oriented forms. So the repo should not claim Google-ready admin generation from docs alone.
+
+### 3. Generic import/copy/edit flows are the wrong abstraction for kmsp11
+
+Google's kmsp11 function table explicitly marks these as unsupported:
+
+- `C_CreateObject`
+- `C_CopyObject`
+- `C_SetAttributeValue`
+
+So the repo should treat generic import/copy/edit as **Google-incompatible on purpose**, not as “maybe works if we're lucky.”
+
+### 4. Config-path delivery is only partially modeled in the wrapper today
+
+Google documents two supported config-delivery methods:
+
+- `pReserved` in `C_Initialize`
+- `KMS_PKCS11_CONFIG`
+
+The repo currently only has a clean practical story for the second one.
+
+That is good enough for the first useful slice, but it is still a real abstraction boundary to keep visible in docs.
+
+### 5. kmsp11 caching changes operational expectations
+
+Google documents that kmsp11 reads and caches configured key-ring contents during initialization.
+
+Repo implication:
+
+- `C_Initialize` cost scales with configured inventory
+- Cloud KMS changes are not necessarily instantly visible
+- admin/runtime behavior may look “stale” unless refresh/reinitialize behavior is understood
+
+## Google-specific operational constraints that affect repo design
+
+### 1. Login is not a real security boundary in kmsp11
+
+Google documents that:
+
+- login is optional
+- only `CKU_USER` is accepted
+- any supplied PIN is ignored
+
+Repo implication:
+
+- generic UI patterns that assume a meaningful token PIN should be treated carefully
+- docs should describe auth as **Google service-account/IAM driven**, not token-PIN driven
+
+### 2. Key visibility depends on Cloud KMS metadata, not local-token semantics
+
+Google documents that only keys with supported purpose, protection level, and enabled state are surfaced.
+
+Repo implication:
+
+- object inventory depends on Cloud KMS policy/state
+- “missing objects” can be a Cloud KMS configuration issue rather than a PKCS#11 parsing/runtime issue
+
+### 3. Admin and wrapper users should expect Cloud KMS identifiers to leak into PKCS#11 identity
+
+Google documents that:
+
+- `CKA_LABEL` maps to the Cloud KMS CryptoKey identifier
+- `CKA_ID` maps to the full CryptoKeyVersion resource name
+
+Repo implication:
+
+- long IDs and cloud-resource-shaped identifiers are normal
+- lookup-by-label/ID remains viable, but should be understood in Cloud KMS terms rather than token-object terms
+
+## What could be validated locally in issue #67
+
+Without a real Google Cloud environment, this issue could validate:
+
+- documentation correctness against Google public docs
+- compile/build correctness of the new admin Google guardrails
+- compile/build correctness of the new Google vendor-profile wiring
+- unit-test coverage of the Google vendor-profile catalog mapping
+- repo-level analysis of the wrapper/admin abstraction boundary
+
+## What could not be validated honestly in issue #67
+
+Without a live Google-authenticated environment, this issue could **not** honestly validate:
+
+- real kmsp11 initialization against a real config file and key-ring inventory
+- real IAM/auth success and failure behavior
+- real Linux/Windows deployment quirks beyond the published prerequisites
+- real Cloud HSM-backed key visibility and operation success
+- real `C_GenerateKey` / `C_GenerateKeyPair` behavior with Google-specific templates
+- real admin-panel end-to-end behavior against Google Cloud services
+- real vendor-regression or smoke success against kmsp11 and Cloud HSM-backed keys
+
+## Practical conclusion
+
+The current repo should describe Google Cloud HSM support as:
+
+- **good candidate for standard PKCS#11 integration via kmsp11**
+- **wrapper-compatible for Google's documented standard subset**
+- **admin-panel-ready enough for device registration, inspection, and honest guardrails**
+- **not a blanket claim for every PKCS#11 method the wrapper exposes**
+- **not yet live-validated without real Google Cloud access**
+
+That is the honest and useful first support slice for issue #67.

--- a/docs/google-cloud-hsm-integration.md
+++ b/docs/google-cloud-hsm-integration.md
@@ -1,0 +1,320 @@
+# Google Cloud HSM integration guide
+
+See also:
+
+- `docs/google-cloud-hsm-compatibility-audit.md` for the conservative compatibility audit against Google public documentation
+- `docs/compatibility-matrix.md` for the repo-wide support summary and current limits
+- `docs/vendor-regression.md` for why there is not yet a checked-in Google Cloud HSM vendor-regression profile
+
+## Purpose
+
+This guide turns the Google Cloud HSM research from issue #67 into a practical setup path for the current repository.
+
+It is intentionally conservative:
+
+- it describes the official Google path for PKCS#11 consumption of Cloud HSM-backed keys
+- it shows the practical current path for the **wrapper** and **admin panel**
+- it documents the Linux/Windows/config/auth constraints that matter operationally
+- it distinguishes what is **ready now**, what is **blocked by abstraction boundaries**, and what still needs a **real Google Cloud environment** to validate honestly
+
+## What “Google Cloud HSM support” means in this repo today
+
+The key design fact is that **Google Cloud HSM is not exposed to this repo as a direct vendor HSM client SDK**.
+
+The official Google story is:
+
+- Cloud HSM keys live behind **Cloud KMS**
+- Google publishes **kmsp11**, a PKCS#11 v2.40 library that translates PKCS#11 calls into Cloud KMS operations
+- applications that need PKCS#11 interact with **kmsp11** (`libkmsp11.so` / `kmsp11.dll`), not with a direct network-attached HSM client in the AWS/Thales sense
+
+So the practical support story here is:
+
+### Supported well enough to use now
+
+- explicit kmsp11 module-path loading through `Pkcs11Module.Load(...)`
+- standard module / slot / token / mechanism enumeration over kmsp11
+- object search and attribute reads through `C_FindObjects*` / `C_GetAttributeValue`
+- standard sign / verify / encrypt / decrypt flows that kmsp11 documents as supported for Cloud KMS-backed keys
+- destroy flows via `C_DestroyObject`
+- admin-panel device profiles via the new **Google Cloud KMS / Cloud HSM via kmsp11** vendor profile
+- admin-panel guardrails that keep unsupported generic-token flows honest for Google profiles
+
+### Important boundaries
+
+- this repo does **not** implement Google Cloud control-plane operations such as key-ring creation, IAM management, service-account bootstrap, policy administration, or broader Cloud KMS lifecycle tasks
+- this repo does **not** currently provide a checked-in Google vendor-regression lane, because kmsp11 needs real Cloud KMS configuration/auth and its supported PKCS#11 surface is intentionally narrower than a classic token
+- the current wrapper surface does **not** expose kmsp11's `C_Initialize` `pReserved` config-path channel, so the practical current path is to set `KMS_PKCS11_CONFIG` on the host that runs the wrapper/admin app
+- the current generic admin key-generation forms are **not** a clean fit for kmsp11 key creation, because Google documents vendor-specific `CKA_KMS_*` template attributes for `C_GenerateKey` / `C_GenerateKeyPair`
+
+## Google Cloud model that matters here
+
+From Google's public docs, the key integration facts are:
+
+- Cloud HSM is a **Cloud KMS protection level** rather than a separate customer-managed network HSM client runtime
+- the official PKCS#11 path is the **Cloud KMS PKCS#11 library (`kmsp11`)**
+- kmsp11 is configured by:
+  - passing the config-file path in `C_Initialize` `pReserved`, or
+  - setting `KMS_PKCS11_CONFIG=/path/to/config.yaml`
+- each configured `tokens:` entry in the YAML file becomes a PKCS#11 token/slot view, typically backed by a Cloud KMS key ring
+- authentication uses **Google service account credentials / Google auth** rather than a classic on-device token PIN model
+- `C_Login` exists only for compatibility; Google documents that login is optional and any supplied PIN is ignored
+
+## Prerequisites
+
+Before pointing this repo at Google Cloud HSM through kmsp11, make sure:
+
+1. the host or container that runs the code already has the official **kmsp11** library available
+2. the host has a valid kmsp11 **YAML config file** with the intended `tokens:` entries
+3. the process has working **Google authentication** (typically a service account / ADC-backed runtime)
+4. the service account has the IAM permissions needed for the operations you intend to run
+5. the process can resolve the intended PKCS#11 module path from that installed kmsp11 runtime
+6. you understand that token/slot/object visibility comes from Cloud KMS configuration and IAM, not from local HSM provisioning tools
+
+### Authentication expectations
+
+Google's kmsp11 user guide states that the library authenticates with **service account credentials** and requires IAM permissions including:
+
+- `cloudkms.cryptoKeys.list`
+- `cloudkms.cryptoKeyVersions.list`
+- `cloudkms.cryptoKeyVersions.viewPublicKey`
+- `cloudkms.cryptoKeyVersions.useToDecrypt` or `cloudkms.cryptoKeyVersions.useToSign` depending on the key usage
+- `cloudkms.cryptoKeys.create` if you intend to create keys
+- `cloudkms.cryptoKeyVersions.destroy` if you intend to destroy keys
+
+For local/dev hosts, the practical auth model is usually Application Default Credentials or an explicitly supplied service-account credential chain on the machine/container that runs the process.
+
+## Linux and Windows setup expectations
+
+### Runtime/library layout
+
+The repo does not auto-discover kmsp11 for you. You must provide the exact PKCS#11 module path that the current host can load.
+
+Practical guidance:
+
+- on Linux, Google's release packages expose **`libkmsp11.so`**
+- on Windows, Google's release packages expose **`kmsp11.dll`**
+- if the admin panel runs in a container, the library and its config/auth context must exist **inside that container**, not only on the host
+
+### Published platform expectations
+
+Google's kmsp11 user guide documents:
+
+- **Linux**: `libkmsp11.so` is compatible with Linux distributions that provide **glibc 2.17 or newer**
+- **Windows**: supported on **Windows Server 2012 R2 / Windows 8.1 x64 and newer**
+- **Older Windows versions**: prior to Windows 10 / Server 2016, the **Visual C++ 2022 x64 Redistributable** must already be installed
+
+## kmsp11 configuration expectations
+
+Google documents two ways to supply the kmsp11 config file path:
+
+- `C_Initialize` `pReserved`
+- `KMS_PKCS11_CONFIG`
+
+The current repo support slice should assume the **environment-variable path**:
+
+```bash
+export KMS_PKCS11_CONFIG=/secure/path/kmsp11.yaml
+```
+
+Why this matters:
+
+- `Pkcs11Wrapper` already supports standard initialize flags and mutex callbacks
+- but the current API surface does **not** yet expose a direct managed way to populate kmsp11's `pReserved` config path
+- so the cleanest current wrapper/admin path is to set `KMS_PKCS11_CONFIG` before the process starts
+
+Google's guide also requires the config file to be writable only by the owner.
+
+### Sample shape
+
+Google's documented sample looks like this:
+
+```yaml
+---
+tokens:
+  - key_ring: "projects/my-project/locations/us/keyRings/my-key-ring"
+    label: "my key ring"
+log_directory: "/var/log/kmsp11"
+```
+
+Practical implications for this repo:
+
+- slot numbering is driven by the `tokens:` list order
+- token labels come from the YAML `label:` field or the underlying key-ring identity
+- the admin panel should be treated as a **consumer** of this prepared view, not as the place that authors it
+
+## Point the core wrapper at Google Cloud HSM
+
+The simplest current integration path is the standard module load plus a host-provided config path:
+
+```csharp
+using Pkcs11Wrapper;
+
+Environment.SetEnvironmentVariable("KMS_PKCS11_CONFIG", "/secure/path/kmsp11.yaml");
+
+using Pkcs11Module module = Pkcs11Module.Load("/exact/path/to/libkmsp11.so");
+module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+Pkcs11SlotId slotId = module.GetSlotIds(tokenPresentOnly: true)[0];
+using Pkcs11Session session = module.OpenSession(slotId, readWrite: false);
+
+// Optional for compatibility-oriented clients; Google documents that login is not required
+// and any supplied PIN is ignored.
+session.Login(Pkcs11UserType.User, System.Text.Encoding.UTF8.GetBytes("ignored-by-kmsp11"));
+```
+
+Practical guidance:
+
+- set `KMS_PKCS11_CONFIG` before the process starts when using the current repo surface
+- treat kmsp11 as the PKCS#11 boundary and Cloud KMS as the real backing system
+- prefer label/ID-based lookup over assumptions about locally provisioned token objects
+- remember that Google documents a narrower supported PKCS#11 surface than a classic local token
+
+## Point the admin panel at Google Cloud HSM
+
+The current admin path is:
+
+1. run `src/Pkcs11Wrapper.Admin.Web` on a machine/container that already has kmsp11 plus Google auth configured
+2. set `KMS_PKCS11_CONFIG` in that process environment before the app starts
+3. open the **Devices** page
+4. create or edit a device profile with:
+   - **Name**: your operational Google/KMS profile label
+   - **PKCS#11 Module Path**: the exact kmsp11 library path on that host (`libkmsp11.so` / `kmsp11.dll`)
+   - **Default Token Label**: optional label matching your kmsp11 token config
+   - **Vendor profile**: **Google Cloud KMS / Cloud HSM via kmsp11**
+   - **Notes**: optional project/location/key-ring/operator breadcrumbs
+5. use the built-in **Test** action before relying on the profile
+
+### What is improved in this slice
+
+The admin panel now has two Google-specific readiness improvements:
+
+- a built-in **Google Cloud KMS / Cloud HSM via kmsp11** vendor profile with config/auth/scope hints
+- guardrails that disable or explicitly reject generic admin flows that do not map honestly to kmsp11 today (`C_CreateObject`, `C_CopyObject`, `C_SetAttributeValue`, and the current generic AES/RSA generation forms)
+
+That makes the Google path materially clearer in these admin surfaces:
+
+- **Devices** connection testing
+- **Slots / Keys** browsing and capability inspection
+- **Sessions** / **PKCS#11 Lab** diagnostics that stay inside kmsp11's documented standard surface
+- controlled destroy and read-oriented workflows once the environment is real
+
+### What not to expect from the admin panel today
+
+Do **not** assume that every generic admin operation maps cleanly onto kmsp11.
+
+Based on Google's documented function table and generation-template rules, the following admin features should be treated as **not currently supported on the generic admin surface** for Google profiles:
+
+- raw AES import via `C_CreateObject`
+- generic object copy via `C_CopyObject`
+- generic attribute editing via `C_SetAttributeValue`
+- generic AES/RSA generation forms that do not emit the required `CKA_KMS_*` attributes
+- wrap / unwrap / derive / PIN-administration workflows
+- Cloud KMS provisioning/control-plane work such as key-ring setup or IAM changes
+
+The best current admin-panel fit for Google is therefore:
+
+- device registration
+- live slot/mechanism inspection
+- object discovery and detail reads
+- selected standard diagnostics in the PKCS#11 Lab
+- honest documentation of the wrapper/admin boundary
+
+## Compatibility notes that matter for wrapper/admin usage
+
+### Standard APIs Google documents as supported
+
+Google's kmsp11 user guide documents support for standard operations including:
+
+- lifecycle / info: `C_Initialize`, `C_Finalize`, `C_GetInfo`, `C_GetFunctionList`
+- slot/token/mechanism enumeration
+- session open/info/login/logout/close/close-all
+- object search + selected object access: `C_DestroyObject`, `C_GetAttributeValue`, `C_FindObjects*`
+- crypto: encrypt/decrypt, sign/verify, multipart encrypt/decrypt/sign/verify variants
+- creation flows: `C_GenerateKey`, `C_GenerateKeyPair` with Google-specific template constraints
+- random: `C_GenerateRandom`
+
+### APIs the current repo should not assume on Google
+
+Google's kmsp11 user guide marks these as unsupported:
+
+- `C_InitToken`
+- `C_InitPIN`
+- `C_SetPIN`
+- `C_CreateObject`
+- `C_CopyObject`
+- `C_GetObjectSize`
+- `C_SetAttributeValue`
+- `C_Digest*`
+- `C_GetOperationState` / `C_SetOperationState`
+- `C_WrapKey`
+- `C_UnwrapKey`
+- `C_DeriveKey`
+- `C_WaitForSlotEvent`
+- `C_GetFunctionStatus` / `C_CancelFunction`
+
+So those should remain out-of-scope, capability-gated, or explicitly unclaimed for Google Cloud HSM in this repo.
+
+### Key-generation caveat
+
+Google documents that:
+
+- `C_GenerateKey` requires `CKA_LABEL` and **`CKA_KMS_ALGORITHM`**
+- `C_GenerateKeyPair` requires a private-key template with **`CKA_LABEL`** and **`CKA_KMS_ALGORITHM`**, and a public template must not be specified
+- optional `CKA_KMS_PROTECTION_LEVEL` / `CKA_KMS_CRYPTO_KEY_BACKEND` fields affect HSM vs single-tenant HSM behavior
+
+That means the **wrapper** is still a reasonable fit for Google generation work if the caller supplies the right raw PKCS#11 attributes, but the **current generic admin forms are not yet the right abstraction** for that path.
+
+### Object visibility caveat
+
+Google documents that usable key versions must be:
+
+- in purpose `ASYMMETRIC_SIGN`, `ASYMMETRIC_DECRYPT`, `RAW_ENCRYPT_DECRYPT`, or `MAC`
+- in protection level `HSM` or `HSM_SINGLE_TENANT` (or `SOFTWARE` only if explicitly enabled)
+- in state `ENABLED`
+
+Keys outside that envelope are ignored by kmsp11 and therefore simply do not appear like a classic local token object set.
+
+### Caching caveat
+
+Google documents that kmsp11 reads configured key-ring contents during initialization and caches them in memory.
+
+Practical implication:
+
+- `C_Initialize` latency scales with configured key volume
+- newly created/changed keys may remain stale until refresh or reinitialize
+- admin operators should not assume immediate reflection of Cloud KMS control-plane changes unless the config/runtime is set up for refresh
+
+## What can vs cannot be validated locally without real Google Cloud access
+
+### What can be validated locally in issue #67
+
+Without real Google Cloud access, this issue could validate:
+
+- documentation correctness against Google public docs
+- compile/build correctness of the admin-panel guardrails and vendor-profile wiring
+- unit-test coverage of the Google vendor-profile catalog wiring
+- repo-level analysis of where the current abstraction boundary is honest vs misleading
+
+### What cannot be validated honestly without real Google Cloud access
+
+Without a real Google-authenticated environment, this issue could **not** honestly validate:
+
+- kmsp11 end-to-end initialization against a real config file and real Cloud KMS inventory
+- actual IAM/auth failures or success paths
+- real Linux/Windows host deployment behavior beyond documented prerequisites
+- real slot/token/object exposure for a live key ring
+- real sign/verify/encrypt/decrypt behavior against HSM-backed Cloud KMS keys
+- real create/destroy behavior against Google Cloud HSM-backed keys
+- real admin-panel end-to-end behavior against kmsp11 and Google Cloud services
+
+## Practical conclusion
+
+The current repo should describe Google Cloud HSM support as:
+
+- **indirect PKCS#11 support via Cloud KMS + kmsp11**
+- **good wrapper-level fit for standard documented kmsp11 flows**
+- **admin-panel-ready enough for device registration, inspection, diagnostics, and honest boundary-setting**
+- **not a blanket claim that the current generic admin key-management forms are Google-ready**
+- **not yet live-validated without a real Google Cloud environment**
+
+That is the honest and useful first support slice for issue #67.

--- a/docs/vendor-regression.md
+++ b/docs/vendor-regression.md
@@ -2,6 +2,8 @@
 
 See also: `docs/luna-integration.md` for the practical Luna client/module setup path across wrapper, admin panel, smoke, and vendor regression.
 See also: `docs/luna-compatibility-audit.md` for the current Thales Luna-specific scope boundary and extension-gap audit.
+See also: `docs/cloudhsm-integration.md` and `docs/cloudhsm-compatibility-audit.md` for the current AWS CloudHSM support boundary.
+See also: `docs/google-cloud-hsm-integration.md` and `docs/google-cloud-hsm-compatibility-audit.md` for the current Google Cloud HSM / kmsp11 support boundary.
 See also: `docs/luna-vendor-extension-design.md` for the proposed package/boundary/loading strategy for future Luna-only `CA_*` support.
 
 ## Purpose
@@ -156,6 +158,28 @@ So the current CloudHSM support slice is:
 
 - strong documentation
 - admin-panel readiness improvements
+- explicit wrapper/admin setup guidance
+
+rather than a premature vendor-lane profile that would overstate validation depth.
+
+## Why there is not yet a checked-in Google Cloud HSM profile
+
+See also: `docs/google-cloud-hsm-integration.md` and `docs/google-cloud-hsm-compatibility-audit.md`.
+
+Google Cloud HSM is now a documented target for the repo, but there is intentionally **no** checked-in `google-*` vendor-regression profile yet.
+
+Reason:
+
+- the official Google PKCS#11 path is **indirect** through `kmsp11` and Cloud KMS rather than a direct local HSM client/runtime contract
+- kmsp11 requires a real config file plus real Google authentication/IAM, so a checked-in profile would risk implying repeatable local/CI coverage that the repo cannot honestly provide without live cloud access
+- Google's documented function table intentionally excludes operations assumed elsewhere in the broader vendor lane, including `C_CreateObject`, `C_CopyObject`, `C_SetAttributeValue`, `C_WrapKey`, `C_UnwrapKey`, `C_DeriveKey`, `C_InitToken`, `C_InitPIN`, `C_SetPIN`, `C_Digest*`, and operation-state paths
+- kmsp11 key creation depends on Google-specific `CKA_KMS_*` template attributes, which the current generic vendor lane does not model cleanly
+- the current wrapper/admin path depends on host-level `KMS_PKCS11_CONFIG` rather than a repo-managed per-profile initialize-argument channel
+
+So the current Google support slice is:
+
+- strong documentation
+- admin-panel readiness improvements and guardrails
 - explicit wrapper/admin setup guidance
 
 rather than a premature vendor-lane profile that would overstate validation depth.

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -562,13 +562,40 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         bool supportsAesGen = mechanisms.Any(x => x.Name == "CKM_AES_KEY_GEN" && x.SupportsGenerate);
         bool supportsRsaGen = mechanisms.Any(x => x.Name == "CKM_RSA_PKCS_KEY_PAIR_GEN" && x.SupportsGenerateKeyPair);
         bool supportsCreateObject = tokenPresent;
+        bool googleBlockedAesGen = false;
+        bool googleBlockedRsaGen = false;
 
-        if (!supportsAesGen)
+        if (IsGoogleCloudKmsp11(device))
+        {
+            warnings.Add("Google Cloud KMS / kmsp11 remains an indirect PKCS#11 adapter path in this repo. Browse/test/destroy flows are the realistic current admin fit; generic import/copy/edit flows are not.");
+            if (supportsAesGen)
+            {
+                warnings.Add("Google Cloud KMS / kmsp11 advertises CKM_AES_KEY_GEN, but the current admin AES generation form stays disabled because kmsp11 key creation requires Google-specific CKA_KMS_* template attributes.");
+                supportsAesGen = false;
+                googleBlockedAesGen = true;
+            }
+
+            if (supportsRsaGen)
+            {
+                warnings.Add("Google Cloud KMS / kmsp11 advertises CKM_RSA_PKCS_KEY_PAIR_GEN, but the current admin RSA generation form stays disabled because kmsp11 key creation requires Google-specific CKA_KMS_* template attributes.");
+                supportsRsaGen = false;
+                googleBlockedRsaGen = true;
+            }
+
+            if (supportsCreateObject)
+            {
+                warnings.Add("Google Cloud KMS / kmsp11 does not support C_CreateObject, so raw AES import/create stays disabled on this admin surface.");
+            }
+
+            supportsCreateObject = false;
+        }
+
+        if (!supportsAesGen && !googleBlockedAesGen)
         {
             warnings.Add("AES generate is gated because CKM_AES_KEY_GEN with generate support is not exposed by the selected slot.");
         }
 
-        if (!supportsRsaGen)
+        if (!supportsRsaGen && !googleBlockedRsaGen)
         {
             warnings.Add("RSA key-pair generate is gated because CKM_RSA_PKCS_KEY_PAIR_GEN with generate-key-pair support is not exposed by the selected slot.");
         }
@@ -584,6 +611,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         byte[] label = Encoding.UTF8.GetBytes(request.Label.Trim());
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
+        EnsureVendorKeyManagementSupported(device, VendorKeyManagementOperation.GenerateAesKey);
         using Pkcs11Module module = CreateInitializedModule(device);
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "generate AES keys");
@@ -605,6 +633,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         byte[] value = ParseRequiredHex(request.ValueHex, nameof(request.ValueHex));
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
+        EnsureVendorKeyManagementSupported(device, VendorKeyManagementOperation.ImportAesKey);
         using Pkcs11Module module = CreateInitializedModule(device);
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "import AES keys");
@@ -626,6 +655,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         byte[] exponent = ParseRequiredHex(request.PublicExponentHex, nameof(request.PublicExponentHex));
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
+        EnsureVendorKeyManagementSupported(device, VendorKeyManagementOperation.GenerateRsaKeyPair);
         using Pkcs11Module module = CreateInitializedModule(device);
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "generate RSA key pairs");
@@ -751,6 +781,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ValidateUpdateObjectAttributesRequest(request);
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
+        EnsureVendorKeyManagementSupported(device, VendorKeyManagementOperation.UpdateObjectAttributes);
         using Pkcs11Module module = CreateInitializedModule(device);
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "update object attributes");
@@ -770,6 +801,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ValidateCopyObjectRequest(request);
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
+        EnsureVendorKeyManagementSupported(device, VendorKeyManagementOperation.CopyObject);
         using Pkcs11Module module = CreateInitializedModule(device);
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "copy objects");
@@ -1631,6 +1663,28 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
     private static bool ShouldRetryReadWriteAfterOpenSessionFailure(bool readWriteRequested, Pkcs11Exception exception)
         => !readWriteRequested && exception.Result.Value == CkrFunctionFailed;
+
+    private static bool IsGoogleCloudKmsp11(HsmDeviceProfile? device)
+        => string.Equals(device?.Vendor?.VendorId, "google", StringComparison.Ordinal)
+            && string.Equals(device?.Vendor?.ProfileId, "cloud-kms-kmsp11", StringComparison.Ordinal);
+
+    private static void EnsureVendorKeyManagementSupported(HsmDeviceProfile device, VendorKeyManagementOperation operation)
+    {
+        if (!IsGoogleCloudKmsp11(device))
+        {
+            return;
+        }
+
+        throw operation switch
+        {
+            VendorKeyManagementOperation.GenerateAesKey => new InvalidOperationException("Google Cloud KMS / kmsp11 key generation is not yet wired through the generic admin AES form because kmsp11 requires Google-specific CKA_KMS_* template attributes."),
+            VendorKeyManagementOperation.ImportAesKey => new InvalidOperationException("Google Cloud KMS / kmsp11 does not support C_CreateObject, so raw AES import/create is not available through the current admin panel."),
+            VendorKeyManagementOperation.GenerateRsaKeyPair => new InvalidOperationException("Google Cloud KMS / kmsp11 key-pair generation is not yet wired through the generic admin RSA form because kmsp11 requires Google-specific CKA_KMS_* template attributes."),
+            VendorKeyManagementOperation.UpdateObjectAttributes => new InvalidOperationException("Google Cloud KMS / kmsp11 does not support C_SetAttributeValue, so generic attribute editing is not available through the current admin panel."),
+            VendorKeyManagementOperation.CopyObject => new InvalidOperationException("Google Cloud KMS / kmsp11 does not support C_CopyObject, so generic copy flows are not available through the current admin panel."),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, "Unsupported vendor-specific key-management operation.")
+        };
+    }
 
     private static string LoginLabSessionIfRequested(Pkcs11Session session, Pkcs11LabRequest request, List<string> notes)
     {
@@ -2749,6 +2803,15 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     private AdminSessionSnapshot GetRequiredSessionSnapshot(Guid sessionId)
         => sessionRegistry.GetSnapshots().FirstOrDefault(x => x.SessionId == sessionId)
             ?? throw new InvalidOperationException($"Tracked session '{sessionId}' was not found after the operation.");
+
+    private enum VendorKeyManagementOperation
+    {
+        GenerateAesKey,
+        ImportAesKey,
+        GenerateRsaKeyPair,
+        UpdateObjectAttributes,
+        CopyObject
+    }
 
     private enum AttributeValueKind
     {

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor.cs
@@ -45,13 +45,16 @@ public partial class Keys
         => Guid.TryParse(_selectedDeviceId, out Guid deviceId)
             ? _devices.FirstOrDefault(device => device.Id == deviceId)
             : null;
+    private bool IsGoogleCloudKmsp11Device
+        => string.Equals(SelectedDevice?.Vendor?.VendorId, "google", StringComparison.Ordinal)
+            && string.Equals(SelectedDevice?.Vendor?.ProfileId, "cloud-kms-kmsp11", StringComparison.Ordinal);
     private bool CanLoadKeys => Guid.TryParse(_selectedDeviceId, out _) && nuint.TryParse(_selectedSlotId, out _);
     private bool CanManageKeys => CanLoadKeys && !string.IsNullOrWhiteSpace(_userPin);
     private bool CanGenerateAes => CanManageKeys && _slotCapabilities?.SupportsAesKeyGeneration == true;
     private bool CanImportAes => CanManageKeys && _slotCapabilities?.SupportsAesObjectImport == true;
     private bool CanGenerateRsa => CanManageKeys && _slotCapabilities?.SupportsRsaKeyPairGeneration == true;
-    private bool CanSaveEdit => CanManageKeys && _editRequest is not null && (_selectedDetail?.EditCapabilities.CanEditAnyAttributes ?? true);
-    private bool CanCopyObject => CanManageKeys && _copyRequest is not null && _slotCapabilities?.TokenPresent == true;
+    private bool CanSaveEdit => CanManageKeys && !IsGoogleCloudKmsp11Device && _editRequest is not null && (_selectedDetail?.EditCapabilities.CanEditAnyAttributes ?? true);
+    private bool CanCopyObject => CanManageKeys && !IsGoogleCloudKmsp11Device && _copyRequest is not null && _slotCapabilities?.TokenPresent == true;
     private bool HasLoadedPage => _keyPage is not null;
     private bool HasNextPage => _keyPage?.HasNextPage == true && !string.IsNullOrWhiteSpace(_keyPage.NextCursor);
     private bool HasPreviousPage => _previousPageCursors.Count != 0;
@@ -542,6 +545,7 @@ public partial class Keys
     private IReadOnlyList<string> GetEditWarnings()
     {
         List<string> warnings = [];
+        if (IsGoogleCloudKmsp11Device) warnings.Add("Google Cloud KMS / kmsp11 does not support C_SetAttributeValue, so generic attribute-edit flows stay disabled for this vendor profile.");
         if (_selectedDetail?.EditCapabilities.CanEditAnyAttributes == false) warnings.Add("The selected object does not currently look modifiable, so SetAttributeValue is likely to fail.");
         if (string.IsNullOrWhiteSpace(_userPin)) warnings.Add("User PIN is required for write operations.");
         return warnings;
@@ -550,6 +554,7 @@ public partial class Keys
     private IReadOnlyList<string> GetCopyWarnings()
     {
         List<string> warnings = [];
+        if (IsGoogleCloudKmsp11Device) warnings.Add("Google Cloud KMS / kmsp11 does not support C_CopyObject, so generic copy flows stay disabled for this vendor profile.");
         if (string.IsNullOrWhiteSpace(_userPin)) warnings.Add("User PIN is required for write operations.");
         if (_slotCapabilities?.TokenPresent == false) warnings.Add("No token is present in the selected slot.");
         warnings.Add("Some tokens reject copy-time overrides for sensitive or policy-controlled attributes; unchanged fields can be left as 'keep existing'.");

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
@@ -96,6 +96,28 @@ internal static class DeviceVendorProfileCatalog
                     "Cluster/user administration stays outside this UI",
                     "This profile is for standard PKCS#11 device, slot, object, and lab workflows only. Cluster bootstrap, CloudHSM CLI/CMU user management, trust-anchor/TLS bootstrap, and other AWS control-plane operations remain out of scope here.",
                     DeviceVendorHintTone.Boundary)
+            ]),
+        new(
+            "google-cloud-kms-kmsp11",
+            "Google Cloud KMS / Cloud HSM via kmsp11",
+            "google",
+            "Google Cloud",
+            "cloud-kms-kmsp11",
+            "Cloud KMS / Cloud HSM via kmsp11",
+            "Use this when the device profile points at Google's kmsp11 PKCS#11 adapter for Cloud KMS-backed keys. The practical fit is indirect PKCS#11 through Cloud KMS, not a direct network-HSM client SDK.",
+            [
+                new DeviceVendorHint(
+                    "Config + Google auth must already exist on the admin host",
+                    "Point the profile at the exact kmsp11 library path visible to the running host/container and make sure the host already has a valid kmsp11 config file plus Google authentication/IAM in place. In the current repo slice, the admin host should provide KMS_PKCS11_CONFIG before starting the app because the wrapper does not yet pass kmsp11 config through C_Initialize pReserved.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Expect a narrower PKCS#11 surface than a classic token",
+                    "kmsp11 maps Cloud KMS into PKCS#11, so login is optional and any supplied PIN is ignored, but object import/copy/edit, wrap/unwrap, derive, PIN-admin, and several other classic token flows are not available. The current admin UI therefore treats Google support primarily as browse/test/destroy plus wrapper-level integration guidance rather than full generic key-management parity.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Cloud KMS provisioning and policy remain outside this UI",
+                    "Key rings, IAM, service accounts, protection-level choices, and broader Cloud KMS lifecycle/control-plane tasks stay in Google Cloud tooling and APIs. This profile only helps the repo/admin surface stay honest when consuming kmsp11 as a PKCS#11 module.",
+                    DeviceVendorHintTone.Boundary)
             ])
     ];
 

--- a/src/Pkcs11Wrapper.Admin.Web/Properties/AssemblyInfo.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Pkcs11Wrapper.Admin.Tests")]

--- a/tests/Pkcs11Wrapper.Admin.Tests/DeviceVendorProfileCatalogTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/DeviceVendorProfileCatalogTests.cs
@@ -1,0 +1,37 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Web.Components.Shared;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class DeviceVendorProfileCatalogTests
+{
+    private static readonly HsmDeviceVendorMetadata GoogleVendor = new(
+        "google",
+        "Google Cloud",
+        "cloud-kms-kmsp11",
+        "Cloud KMS / Cloud HSM via kmsp11");
+
+    [Fact]
+    public void GetSelectionId_ReturnsKnownGoogleProfileSelection()
+    {
+        string selectionId = DeviceVendorProfileCatalog.GetSelectionId(GoogleVendor);
+
+        Assert.Equal("google-cloud-kms-kmsp11", selectionId);
+    }
+
+    [Fact]
+    public void GetGuidance_ReturnsGoogleSpecificSummaryAndHints()
+    {
+        DeviceVendorGuidance guidance = DeviceVendorProfileCatalog.GetGuidance(GoogleVendor);
+
+        Assert.True(guidance.IsKnownProfile);
+        Assert.False(guidance.IsVendorNeutral);
+        Assert.Equal("Google Cloud", guidance.Title);
+        Assert.Equal("Cloud KMS / Cloud HSM via kmsp11", guidance.ProfileName);
+        Assert.Contains("indirect PKCS#11", guidance.Summary);
+        Assert.Equal(3, guidance.Hints.Count);
+        Assert.Contains(guidance.Hints, hint => hint.Body.Contains("KMS_PKCS11_CONFIG", StringComparison.Ordinal));
+        Assert.Contains(guidance.Hints, hint => hint.Body.Contains("PIN is ignored", StringComparison.Ordinal));
+        Assert.Contains(guidance.Hints, hint => hint.Body.Contains("Cloud KMS lifecycle/control-plane", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
Add the first practical Google Cloud HSM support slice.

## Included work
- Google Cloud HSM integration and compatibility research/docs
- explicit conclusion that the practical path is indirect PKCS#11 via Google Cloud KMS + kmsp11
- honest wrapper/admin support boundary for documented standard flows
- admin vendor profile and low-risk guardrails for Google/kmsp11 usage
- tests covering the vendor-profile/admin readiness additions

## Notes
- this is not a claim of live Google Cloud-backed regression coverage
- no fake generic-token parity was added where Google/kmsp11 has product-specific boundaries

## Closes
Closes #67
