### PR TITLE
Add OCI Dedicated KMS support guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Current capabilities include:
 - [docs/cloudhsm-compatibility-audit.md](docs/cloudhsm-compatibility-audit.md) - public-doc audit of AWS CloudHSM standard PKCS#11 compatibility vs current wrapper/admin/runtime scope
 - [docs/google-cloud-hsm-integration.md](docs/google-cloud-hsm-integration.md) - practical Google Cloud KMS / Cloud HSM via kmsp11 setup guidance for wrapper and admin-panel usage
 - [docs/google-cloud-hsm-compatibility-audit.md](docs/google-cloud-hsm-compatibility-audit.md) - public-doc audit of Google Cloud HSM's indirect kmsp11 PKCS#11 path vs current wrapper/admin/runtime scope
+- [docs/oci-dedicated-kms-integration.md](docs/oci-dedicated-kms-integration.md) - practical Oracle OCI Dedicated KMS setup guidance for wrapper/admin-panel usage and the direct-vs-OCI-Vault boundary
+- [docs/oci-dedicated-kms-compatibility-audit.md](docs/oci-dedicated-kms-compatibility-audit.md) - public-doc audit of Oracle OCI Dedicated KMS PKCS#11 fit vs current wrapper/admin/runtime scope
 - [docs/luna-vendor-extension-design.md](docs/luna-vendor-extension-design.md) - proposed package/boundary/loading/test strategy for future Luna-only `CA_*` support
 - [docs/vendor-audit-integration.md](docs/vendor-audit-integration.md) - vendor-native audit evaluation starting with Thales Luna, including CLI/syslog/export/API path trade-offs vs wrapper telemetry
 - [docs/smoke.md](docs/smoke.md) - smoke sample behavior and troubleshooting
@@ -333,6 +335,7 @@ Current capabilities include:
 - PKCS#11 v3 runtime behavior still depends on whether the target module actually exports the relevant v3 interface surface.
 - AWS CloudHSM support in the current repo is a documented/admin-readiness slice, not a claim of live cluster-backed CI validation yet.
 - Google Cloud HSM support in the current repo is an indirect kmsp11/Cloud KMS slice with docs and admin guardrails, not a claim of direct-HSM client support or live Google-backed CI validation yet.
+- Oracle OCI Dedicated KMS support in the current repo is a documented Linux-first direct-PKCS#11 slice with vendor guidance, not a claim of generic OCI Vault coverage, Windows CNG/KSP support through this PKCS#11 surface, or live OCI-backed CI validation yet.
 
 ## Contributing
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -34,5 +34,6 @@
 - Windows NativeAOT validation now exists, but Linux still remains the deepest day-to-day validation environment because it is the primary benchmark baseline and the most feature-complete local automation path.
 - AWS CloudHSM now has a documented standard-PKCS#11 support path plus admin-panel read-only→read-write session fallback guidance, but it is not yet backed by live CloudHSM CI or a real-cluster regression lane.
 - Google Cloud HSM now has a documented indirect support path through Google's kmsp11 Cloud KMS adapter, but it still depends on real Google auth/config, host-level `KMS_PKCS11_CONFIG`, and live cloud access for honest end-to-end validation.
+- Oracle OCI Dedicated KMS now has a documented direct PKCS#11 support path for the current repo, but that path is Linux-first (`oci-hsm-client` + `oci-hsm-pkcs11` + `client_daemon`) and is not yet backed by live OCI CI or a checked-in vendor-regression profile; Oracle's reviewed Windows docs remain CNG/KSP rather than the current PKCS#11 wrapper/admin boundary.
 - Mechanism parameter helpers are intentionally selective; uncommon mechanisms may still require raw parameter bytes.
 - Packaging discipline is defined in `docs/release.md`, but external package publication is still a maintainer action rather than an automated CI publish step.

--- a/docs/oci-dedicated-kms-compatibility-audit.md
+++ b/docs/oci-dedicated-kms-compatibility-audit.md
@@ -1,0 +1,232 @@
+# OCI Dedicated KMS PKCS#11 compatibility audit
+
+See also:
+
+- `docs/oci-dedicated-kms-integration.md` for the practical wrapper/admin-panel setup path
+- `docs/compatibility-matrix.md` for the repo-wide support summary
+- `docs/vendor-regression.md` for the current vendor-lane boundary
+
+## Scope
+
+This document audits the **Oracle Cloud Infrastructure HSM / Key Management product mapping** and the **publicly documented OCI Dedicated KMS PKCS#11 fit** against the current `Pkcs11Wrapper` repository.
+
+It is intentionally conservative:
+
+- it distinguishes **OCI Dedicated KMS direct PKCS#11 support** from **OCI Vault / Key Management API surfaces** and other Oracle client surfaces
+- it separates **already good repo alignment** from **real-runtime-only validation** and **different abstraction-boundary cases**
+- it does **not** claim support that requires a real OCI environment when no live OCI HSM access was available during issue #68
+
+## Oracle public references reviewed
+
+- Dedicated KMS overview: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms.htm>
+- Dedicated KMS getting started: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_getting_started.htm>
+- PKCS#11 library overview: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_pkcs_library.htm>
+- PKCS#11 install path / package expectations: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_installation_pkcs_11.htm>
+- PKCS#11 config path: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_configuring_pkcs_11.htm>
+- PKCS#11 authentication model: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_pkcs_authentication.htm>
+- client OS support: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dkms_installation_supported_system.htm>
+- client parameter and certificate/daemon expectations: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dkms_configure_client_component_parameters.htm>
+- Linux client installation flow: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dkms_linux_support.htm>
+- client daemon configuration/start: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_installation_configure_daemon.htm> and <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Reference/reference_dedicated_kms_installation_start_daemon.htm>
+- Windows client / CNG-KSP path: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dkms_windows_CLI_download_install.htm> and <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dkms_windows_cng_ksp.htm>
+- client changelog/download packaging: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dkms_downloads.htm>
+- broader Vault / Key Management overview for product-boundary comparison: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Concepts/keyoverview.htm>
+- public encrypt/decrypt mechanism page reviewed during this issue: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_pkcs_encrypt_decrypt.htm>
+- public sign/verify mechanism page reviewed during this issue: <https://docs.oracle.com/en-us/iaas/Content/KeyManagement/Tasks/dedicated_kms_pkcs_sign_verify.htm>
+
+## Repository areas reviewed
+
+### Core wrapper
+
+- `src/Pkcs11Wrapper`
+- `src/Pkcs11Wrapper.Native`
+
+### Admin surface
+
+- `src/Pkcs11Wrapper.Admin.Application`
+- `src/Pkcs11Wrapper.Admin.Web`
+
+### Runtime / validation / docs
+
+- `docs/vendor-regression.md`
+- `docs/compatibility-matrix.md`
+- `README.md`
+
+## Executive summary
+
+The current repo is in a **good position for OCI Dedicated KMS as a direct Linux PKCS#11 integration**, but the issue only becomes clean once Oracle’s product boundary is stated explicitly.
+
+The most important compatibility conclusions are:
+
+1. **The practical direct-PKCS#11 target is OCI Dedicated KMS, not generic OCI Vault.**
+   - Oracle’s Dedicated KMS docs explicitly describe a PKCS#11 v2.40 library and direct HSM interaction without OCI APIs.
+   - Oracle’s broader Vault / Key Management docs describe an OCI service/API resource model instead.
+   - So repo support should be described as **OCI Dedicated KMS direct PKCS#11 support**, not as blanket OCI Vault support.
+
+2. **The wrapper is already structurally compatible with the documented Dedicated KMS PKCS#11 shape.**
+   - Explicit module loading, standard session/login flows, object discovery, and generic standard mechanisms line up with the Oracle docs reviewed here.
+   - No Oracle-specific wrapper assembly is required for the first useful slice.
+
+3. **The direct current repo fit is Linux-first.**
+   - Oracle’s reviewed docs publish Linux PKCS#11 packages and installation paths under `/opt/oci/hsm`.
+   - The reviewed Windows docs describe client service + CNG/KSP flows instead of a documented Windows PKCS#11 DLL path for the current repo boundary.
+
+4. **Admin-panel work needed operator clarity more than runtime shims.**
+   - The most valuable first repo change is to keep Oracle product/setup boundaries visible in the device profile UX.
+   - That is more honest than pretending the admin panel can provision OCI or consume Windows CNG/KSP.
+
+5. **A real OCI environment is still required for honest end-to-end validation.**
+   - This issue improves documentation and admin readiness.
+   - It does not pretend that compile-time work equals live OCI HSM proof.
+
+## Compatibility assessment
+
+| OCI area | Oracle public documentation | Current repo status | Assessment |
+| --- | --- | --- | --- |
+| OCI Dedicated KMS direct PKCS#11 boundary | Explicitly documented by Oracle | Wrapper/admin already consume standard PKCS#11 modules | **Correct direct fit** |
+| OCI Vault / Key Management service boundary | Documented as OCI vault/key service resources and OCI-native key-management concepts | Repo is a PKCS#11 wrapper/admin surface, not an OCI SDK client | **Different abstraction boundary** |
+| OCI External KMS / HYOK style boundary | Documented as external-key-management model in OCI KMS overview | Repo has no OCI external-KMS API integration layer | **Different abstraction boundary** |
+| Core module lifecycle (`C_Initialize`, `C_Finalize`, `C_GetInfo`, `C_GetFunctionList`) | Oracle documents PKCS#11 v2.40 library availability | Fully wrapped in core | **Already good, pending live runtime** |
+| Slot / token / mechanism enumeration | Inherent to the documented PKCS#11 library model | Fully wrapped and used by admin tooling | **Already good, pending live runtime** |
+| `C_Login` credential format | Oracle explicitly documents `username:password` CU login | Wrapper/admin can already pass arbitrary login bytes; docs now capture Oracle semantics | **Already good once documented** |
+| Standard encrypt/decrypt using documented mechanisms (`CKM_AES_*`, `CKM_RSA_PKCS`, `CKM_RSA_PKCS_OAEP`) | Explicitly documented | Wrapped in core; lab/admin can drive generic flows | **Already good for documented mechanism families, pending live runtime** |
+| Standard sign/verify using documented RSA/ECDSA/HMAC mechanisms | Explicitly documented | Wrapped in core; lab/admin can drive generic flows | **Already good for documented mechanism families, pending live runtime** |
+| Generic object discovery / detail / attribute reads | Fits the documented PKCS#11 usage model, but reviewed Oracle docs do not publish a full supported-API matrix | Wrapped heavily in core/admin | **Reasonable fit, but not exhaustively proven from docs alone** |
+| Generic create/import/copy/edit/destroy flows | Oracle docs reviewed for this issue do not publish a complete function-by-function matrix that proves these individually | Wrapper/admin support exists generically | **Treat as plausible but real-runtime-dependent** |
+| PKCS#11 v3 interface discovery (`C_GetInterface*`) | Oracle docs reviewed here describe PKCS#11 v2.40 | Wrapper supports it generically | **Unclaimed for OCI** |
+| PKCS#11 v3 message APIs (`C_Message*`) | Oracle docs reviewed here describe PKCS#11 v2.40 | Wrapper supports them generically | **Unclaimed for OCI** |
+| `C_LoginUser` / `C_SessionCancel` | Not documented in reviewed OCI v2.40 material | Wrapper supports them generically | **Unclaimed for OCI** |
+| Linux client runtime requirements | Explicitly documented (`oci-hsm-client`, `oci-hsm-pkcs11`, `/opt/oci/hsm`, `client_daemon`) | Repo assumes host-local runtime already exists | **Already aligned operationally** |
+| Windows support path | Oracle documents Windows client + CNG/KSP | Repo consumes PKCS#11 modules, not CNG/KSP | **Outside current repo boundary** |
+
+## Where compatibility is already good
+
+### 1. Standard `C_*` wrapper architecture matches the Dedicated KMS direction
+
+The repo already exposes the standard Cryptoki surface that Oracle’s Dedicated KMS PKCS#11 docs imply.
+
+That means the first useful OCI slice does **not** require a new Oracle-specific wrapper package just to get started.
+
+### 2. Explicit module-path loading is the right operational model
+
+`Pkcs11Wrapper` already expects an explicit module path.
+
+That matches OCI Dedicated KMS well because Oracle expects a host-local client runtime with host-local config, certs, and daemon processes before the module is used.
+
+### 3. The admin panel can already act as a consumer/diagnostics surface
+
+Once the OCI runtime is installed and the daemon is working, the admin panel is already a reasonable fit for:
+
+- device registration
+- connection testing
+- slot/mechanism inspection
+- key/object discovery
+- read-oriented diagnostics in the PKCS#11 Lab
+
+## Where compatibility is capability-gated or future work
+
+### 1. OCI support should not be described as blanket OCI Vault support
+
+This is the most important conceptual boundary.
+
+The repo should talk about Oracle support as:
+
+- **direct PKCS#11 through OCI Dedicated KMS**
+
+not as:
+
+- generic **OCI Vault support**
+
+because those are different operational and API surfaces.
+
+### 2. Windows Oracle support is not the same as Windows PKCS#11 support here
+
+Oracle clearly documents Windows client + CNG/KSP usage.
+
+That is real Oracle support, but it is **not the abstraction boundary this repo currently implements**. So the current repo should not imply that Oracle’s Windows docs automatically equal a Windows `Pkcs11Wrapper` device-profile path.
+
+### 3. Broad object-management claims should stay conservative
+
+The reviewed Oracle docs confirm the overall PKCS#11 direction plus authentication and specific crypto mechanisms, but they do **not** provide the same kind of exhaustive function table that some other vendors publish.
+
+So the repo should avoid over-claiming support for every object-management/admin flow from docs alone.
+
+### 4. PKCS#11 v3 should remain unclaimed for OCI
+
+The reviewed OCI material explicitly talks about a **PKCS#11 v2.40** library.
+
+Therefore the repo should not infer OCI support for:
+
+- `C_GetInterface*`
+- `C_Message*`
+- `C_LoginUser`
+- `C_SessionCancel`
+
+just because the wrapper can model them generically.
+
+## OCI-specific operational constraints that affect repo design
+
+### 1. The client daemon is part of the real runtime contract
+
+Oracle’s Linux client flow depends on a configured and running `client_daemon`.
+
+Repo implication:
+
+- module-path correctness alone is insufficient
+- admin-panel connection failures may be client-daemon/bootstrap problems rather than wrapper bugs
+
+### 2. Certificate/bootstrap material is outside the repo boundary
+
+Oracle’s client config depends on artifacts such as:
+
+- `cert-c`
+- `pkey-c`
+- `partitionOwnerCert.pem`
+
+Repo implication:
+
+- the repo should document these requirements clearly
+- it should not pretend to generate or manage them for the user
+
+### 3. Key visibility is CU-scoped and replica-sensitive
+
+Oracle documents that the app runs as a CU and can manage only keys it owns or shares, and that customers are responsible for synchronizing users/keys across replicas.
+
+Repo implication:
+
+- object inventory is legitimately environment/user dependent
+- “it works in one partition/replica but not another” can be an OCI prep issue rather than a wrapper bug
+
+## What could be validated locally in issue #68
+
+Without a real OCI environment, this issue could validate:
+
+- Oracle product mapping and abstraction-boundary analysis
+- documentation correctness against Oracle public docs
+- compile/build correctness of the new Oracle vendor-profile wiring
+- unit-test coverage of the Oracle vendor-profile catalog entry
+
+## What could not be validated honestly in issue #68
+
+Without a live OCI Dedicated KMS environment, this issue could **not** honestly validate:
+
+- actual client RPM installation behavior
+- actual module-path resolution on a prepared Oracle Linux host
+- daemon connectivity to a real HSM cluster
+- CU login and key-ownership/sharing behavior
+- real slot/token/mechanism exposure
+- create/import/copy/edit/destroy behavior against real OCI policy/runtime
+- end-to-end admin-panel behavior against OCI Dedicated KMS
+- real smoke or vendor-regression success against OCI Dedicated KMS
+
+## Practical conclusion
+
+The current repo should describe Oracle cloud HSM support as:
+
+- **direct PKCS#11 support through OCI Dedicated KMS on the documented Linux client path**
+- **not a blanket claim that OCI Vault/private-vault service flows are direct PKCS#11 targets**
+- **not a blanket Windows claim, because Oracle’s reviewed Windows docs are CNG/KSP rather than the current repo boundary**
+- **admin-panel-ready enough for device registration, inspection, and operator guidance**
+- **not yet live-validated without real OCI access**
+
+That is the honest and useful first support slice for issue #68.

--- a/docs/oci-dedicated-kms-integration.md
+++ b/docs/oci-dedicated-kms-integration.md
@@ -1,0 +1,364 @@
+# OCI Dedicated KMS integration guide
+
+See also:
+
+- `docs/oci-dedicated-kms-compatibility-audit.md` for the conservative compatibility audit against Oracle public documentation
+- `docs/compatibility-matrix.md` for the repo-wide support summary and current limits
+- `docs/vendor-regression.md` for why there is not yet a checked-in OCI Dedicated KMS vendor-regression profile
+
+## Purpose
+
+This guide turns the Oracle Cloud Infrastructure HSM research from issue #68 into a practical setup path for the current repository.
+
+It is intentionally conservative:
+
+- it clarifies which **OCI product boundary** is the real fit for `Pkcs11Wrapper`
+- it shows the practical current path for the **wrapper** and **admin panel**
+- it documents the Linux/Windows/client/setup/auth constraints that matter operationally
+- it distinguishes what is **ready now**, what fits only behind a **different abstraction boundary**, and what still needs a **real OCI environment** to validate honestly
+
+## What “OCI HSM support” means in this repo today
+
+The most important design fact is that **OCI is not one single PKCS#11 story**.
+
+Oracle’s public docs currently describe three materially different paths:
+
+1. **OCI Dedicated KMS**
+   - a managed, single-tenant HSM partition service
+   - explicitly documented with a **PKCS#11 v2.40** client library
+   - the only OCI path that currently looks like a **direct PKCS#11 fit** for this repo
+
+2. **OCI Vault / Key Management / virtual private vaults**
+   - OCI-managed vault/key resources consumed through OCI APIs, CLI, Console, and OCI SDKs
+   - not documented in the reviewed material as a host-local PKCS#11 module for generic apps like this repo
+   - better understood as an **OCI API/SDK integration boundary**, not a direct `Pkcs11Wrapper` module-path scenario
+
+3. **OCI External KMS / HYOK style integrations**
+   - key material stays in a third-party key management system outside OCI
+   - this is a **different control-plane/integration problem**, not an OCI-native PKCS#11 target for the current admin panel
+
+So the practical repo support story is:
+
+### Supported well enough to use now
+
+- explicit Oracle PKCS#11 module-path loading through `Pkcs11Module.Load(...)` when the host already has the **OCI Dedicated KMS Linux client** installed
+- standard module / slot / token / mechanism enumeration against the installed OCI PKCS#11 module
+- CU login via standard `C_Login` using the documented `username:password` format
+- standard object discovery / attribute-read / live diagnostics flows that work against the real module runtime
+- standard encrypt/decrypt and sign/verify experiments through the mechanisms Oracle publicly documents
+- admin-panel device profiles via the new **Oracle OCI Dedicated KMS / standard PKCS#11** vendor profile
+
+### Important boundaries
+
+- this repo does **not** implement OCI control-plane provisioning such as HSM-cluster creation, network/certificate bootstrap, or Oracle user/partition administration
+- this repo does **not** currently claim a direct PKCS#11 path for **OCI Vault** or **virtual private vault** usage; those remain better treated as OCI API/SDK integrations
+- Oracle’s reviewed docs currently document **PKCS#11 client packages on Oracle Linux** and **CNG/KSP on Windows**; this repo therefore treats the direct OCI PKCS#11 fit as **Linux-first**, not as a blanket Windows story
+- this repo does **not** currently provide a checked-in OCI Dedicated KMS smoke or vendor-regression profile because no live OCI HSM environment was available during issue #68
+
+## OCI product mapping that matters here
+
+### 1. OCI Dedicated KMS = direct PKCS#11 fit
+
+Oracle documents Dedicated KMS as a managed, highly available service that gives the customer a **single-tenant HSM partition** and explicitly says that PKCS#11 can be used for cryptographic operations **without the need for OCI APIs or modules**.
+
+That is the path that maps naturally to `Pkcs11Wrapper`.
+
+### 2. OCI Vault / Key Management = different abstraction boundary
+
+Oracle’s broader Vault / Key Management docs describe OCI vaults, OCI key resources, protection modes, and OCI-native key operations through OCI service surfaces.
+
+That means the correct integration boundary for standard Vault usage is:
+
+- application -> OCI SDK / CLI / REST / service integration
+
+not:
+
+- application -> host-local PKCS#11 module
+
+So the current repo should **not** describe generic OCI Vault support as if it were already a direct PKCS#11 device profile.
+
+### 3. Windows CNG/KSP = different client surface
+
+Oracle also documents Dedicated KMS support for **Windows CNG and KSP**.
+
+That is useful operationally, but it is **not the same thing as a documented Windows PKCS#11 module path** for this repo. `Pkcs11Wrapper` and the current admin panel consume PKCS#11 modules, not Windows CNG/KSP providers.
+
+## OCI Dedicated KMS model that matters here
+
+From Oracle’s public documentation, the key integration facts are:
+
+- Dedicated KMS is a **single-tenant HSM partition** service
+- the PKCS#11 library is documented as **PKCS#11 v2.40**
+- getting started requires:
+  1. provisioning an HSM cluster
+  2. installing client components
+  3. using the PKCS#11 library for cryptographic operations
+- Oracle documents a dedicated Linux PKCS#11 package that depends on the **OCI HSM client** and a running **`client_daemon`**
+- the Linux PKCS#11 libraries are installed under **`/opt/oci/hsm/lib`**
+- PKCS#11 logging is configured through **`/opt/oci/hsm/data/pkcs11.cfg`**
+- client connectivity/configuration depends on client cert/key material such as **`cert-c`**, **`pkey-c`**, and **`partitionOwnerCert.pem`** plus cluster hostname/port configuration in the client daemon config
+- Oracle documents PKCS#11 authentication as **CU login** through `C_Login` using **`<CU_user_name>:<password>`**
+- customers are responsible for synchronizing users and keys across all replicas in the HSM cluster; if that drift exists, application availability can be affected
+
+## Prerequisites
+
+Before pointing this repo at OCI Dedicated KMS, make sure:
+
+1. an **OCI Dedicated KMS HSM cluster** already exists
+2. the host that runs the code already has the **OCI HSM client** installed
+3. the host also has the **OCI PKCS#11 package** installed
+4. the host has the required client certificate/key material available (`cert-c`, `pkey-c`, `partitionOwnerCert.pem`)
+5. `client_daemon.cfg` is already configured with the real cluster hostname/port and certificate paths
+6. the **`client_daemon`** is running successfully before the .NET process starts
+7. you have a valid **crypto user (CU)** for PKCS#11 login
+8. the process can resolve the exact OCI PKCS#11 shared library path from the installed client runtime
+
+## Linux and Windows setup expectations
+
+### Supported client operating systems Oracle documents
+
+Oracle’s reviewed docs list supported client-component operating systems as:
+
+- **Oracle Linux 7**
+- **Oracle Linux 8**
+- **Oracle Linux 9**
+- **Windows Server 2019**
+
+### Direct PKCS#11 path in this repo: treat it as Linux-first
+
+For the direct PKCS#11 path, the Oracle docs reviewed for this issue document:
+
+- Linux PKCS#11 installation through `oci-hsm-pkcs11`
+- a dependency on `oci-hsm-client-<version>.x86_64.rpm`
+- Linux PKCS#11 libraries under **`/opt/oci/hsm/lib`**
+- Linux PKCS#11 config under **`/opt/oci/hsm/data/pkcs11.cfg`**
+
+That is the clean practical fit for `Pkcs11Wrapper` and the admin panel.
+
+### Windows path in Oracle docs: CNG/KSP, not the current repo boundary
+
+Oracle’s reviewed Windows docs focus on:
+
+- the Windows client service
+- CNG / KSP provider registration and use
+- the `n3fips_password=<username>:<password>` system environment variable for Windows provider usage
+
+Those are meaningful Oracle client/runtime features, but they do **not** currently give this repo a documented Windows PKCS#11 module story.
+
+So the conservative current repo stance is:
+
+- **Linux**: direct OCI Dedicated KMS PKCS#11 support path
+- **Windows**: Oracle-documented support exists through **CNG/KSP**, but that is **outside the current PKCS#11 wrapper/admin abstraction boundary**
+
+## Client/bootstrap expectations on Linux
+
+Oracle’s reviewed Linux docs show a multi-step client contract:
+
+1. install the OCI HSM client package
+2. copy `pkey-c`, `cert-c`, and `partitionOwnerCert.pem` into **`/opt/oci/hsm/data`**
+3. configure **`/opt/oci/hsm/data/client_daemon.cfg`** with:
+   - certificate paths
+   - CA path
+   - owner certificate path
+   - cluster hostname
+   - cluster port
+   - reconnect/logging settings
+4. start the daemon:
+
+```bash
+/opt/oci/hsm/bin/client_daemon /opt/oci/hsm/data/client_daemon.cfg
+```
+
+5. install the PKCS#11 package
+6. optionally tune PKCS#11 logging in **`/opt/oci/hsm/data/pkcs11.cfg`**
+7. only then point the .NET app at the resolved PKCS#11 library under **`/opt/oci/hsm/lib`**
+
+Operationally, this means:
+
+- if the daemon is not configured/running, repo-side code changes will not fix connectivity
+- if the host/container does not have the OCI client runtime inside it, the admin panel cannot use the host installation magically from outside that runtime boundary
+- the exact `.so` path should stay in app configuration / device profile rather than being hard-coded in source
+
+## Authentication and session expectations
+
+### 1. PKCS#11 login is CU-based and uses `username:password`
+
+Oracle documents `C_Login` input for the PKCS#11 library as:
+
+```text
+<CU_user_name>:<password>
+```
+
+That matters for:
+
+- wrapper examples
+- admin-panel operator instructions
+- secret handling expectations
+- local lab or smoke attempts against a real OCI environment
+
+### 2. Key visibility is CU-scoped
+
+Oracle documents that the application runs as a **crypto user (CU)** and can view/manage only keys that the CU owns or that are shared with that CU.
+
+Practical implication:
+
+- “missing” keys may be an OCI user/ownership/sharing issue rather than a wrapper bug
+- object discovery in the admin panel will reflect the real CU scope, not a global appliance inventory
+
+### 3. Replica synchronization matters operationally
+
+Oracle documents that customers are responsible for synchronizing users and keys across all replicas in the HSM cluster.
+
+Practical implication:
+
+- module connectivity alone is not enough to guarantee availability
+- if users/keys are not consistently present across replicas, session success and object visibility can drift in ways the repo cannot mask
+
+## Point the core wrapper at OCI Dedicated KMS
+
+The practical current integration path is the standard module load against the installed Linux PKCS#11 library:
+
+```csharp
+using Pkcs11Wrapper;
+
+using Pkcs11Module module = Pkcs11Module.Load("/exact/path/from-the-installed-oci-pkcs11-library.so");
+module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+Pkcs11SlotId slotId = module.GetSlotIds(tokenPresentOnly: true)[0];
+using Pkcs11Session session = module.OpenSession(slotId, readWrite: true);
+session.Login(Pkcs11UserType.User, System.Text.Encoding.UTF8.GetBytes("CryptoUser:SecretPassword"));
+```
+
+Practical guidance:
+
+- use the **exact** `.so` path that exists on the Oracle Linux host/container running the process
+- do not assume a specific filename from repo docs if Oracle’s installed package layout differs on your host
+- prefer validating slot/mechanism exposure from the live module before assuming a generic mechanism baseline
+- treat object visibility as CU/policy dependent
+
+## Point the admin panel at OCI Dedicated KMS
+
+The current admin path is:
+
+1. run `src/Pkcs11Wrapper.Admin.Web` on an **Oracle Linux** machine/container that already has the OCI client runtime and daemon working
+2. open the **Devices** page
+3. create or edit a device profile with:
+   - **Name**: your operational OCI cluster/profile label
+   - **PKCS#11 Module Path**: the exact OCI PKCS#11 library path on that host under `/opt/oci/hsm/lib`
+   - **Default Token Label**: optional token label if your environment exposes a stable label you want to default to
+   - **Vendor profile**: **Oracle OCI Dedicated KMS / standard PKCS#11**
+   - **Notes**: optional cluster/partition/CU/client-version/operator breadcrumbs
+4. use the built-in **Test** action before relying on the profile
+
+### What is improved in this slice
+
+The admin panel now has a built-in **Oracle OCI Dedicated KMS / standard PKCS#11** vendor profile that keeps the most important Oracle-specific guidance visible:
+
+- Dedicated KMS is the direct PKCS#11 fit
+- Linux PKCS#11 runtime/daemon prerequisites must already exist on the host
+- Windows Oracle guidance is currently CNG/KSP rather than the PKCS#11 boundary this app consumes
+- OCI Vault/control-plane/user-admin boundaries stay outside the admin UI
+
+### What not to expect from the admin panel today
+
+Do **not** expect the admin panel to:
+
+- provision an OCI HSM cluster
+- create or synchronize OCI HSM users across replicas
+- generate/sign client certificates or bootstrap `cert-c` / `pkey-c` / `partitionOwnerCert.pem`
+- configure or launch the OCI client daemon for you
+- consume Windows CNG/KSP providers in place of a PKCS#11 module
+- act as a replacement for OCI Vault / KMS APIs when the real integration boundary is not direct PKCS#11
+
+## Compatibility notes that matter for wrapper/admin usage
+
+### Publicly documented mechanism families reviewed for this issue
+
+Oracle’s public PKCS#11 docs reviewed here explicitly document encrypt/decrypt mechanisms such as:
+
+- `CKM_AES_CBC`
+- `CKM_AES_CBC_PAD`
+- `CKM_AES_ECB`
+- `CKM_AES_CTR`
+- `CKM_AES_GCM`
+- `CKM_RSA_PKCS`
+- `CKM_RSA_PKCS_OAEP`
+
+The reviewed docs also explicitly document sign/verify mechanisms such as:
+
+- RSA PKCS / PSS families
+- ECDSA families
+- HMAC families
+
+### What this repo should still keep conservative
+
+Unlike some other vendors, the Oracle public docs reviewed for this issue did **not** provide a single exhaustive function-by-function supported-API matrix that cleanly maps every `C_*` entry point the repo exposes.
+
+So the honest current stance is:
+
+- standard direct PKCS#11 integration for OCI Dedicated KMS looks **plausible and practical**
+- wrapper/admin support should stay focused on **standard module loading, session/login, object discovery, and live diagnostics** unless a real OCI runtime proves broader behavior
+- generic advanced flows that depend on vendor policy or unreviewed API details should be treated as **real-runtime validation items**, not as paper guarantees from docs alone
+
+### PKCS#11 v3 remains unclaimed for OCI
+
+Oracle’s reviewed Dedicated KMS PKCS#11 docs describe a **PKCS#11 v2.40** library.
+
+That means the current repo should **not** infer OCI support for PKCS#11 v3 interface discovery, message APIs, `C_LoginUser`, or `C_SessionCancel` from repo capability alone.
+
+## What can and cannot be validated locally without a real OCI environment
+
+### What this issue validates locally
+
+Without a real OCI Dedicated KMS environment, this repo slice can still validate:
+
+- the Oracle product mapping itself
+- documentation correctness against Oracle public docs
+- compile/build correctness of the new Oracle vendor-profile wiring
+- unit-test coverage for the admin vendor-profile catalog entry
+
+### What cannot be validated honestly without real OCI access
+
+Without a live OCI environment, we cannot honestly prove:
+
+- real OCI client installation behavior on the target host
+- correct client certificate / owner certificate setup
+- successful daemon connectivity to a real HSM cluster
+- real CU login behavior and key visibility
+- real slot/token/mechanism exposure for a prepared cluster
+- actual object-management behavior against OCI Dedicated KMS policy/runtime
+- end-to-end admin-panel behavior against a real OCI HSM environment
+- whether any existing vendor-regression flow assumptions need OCI-specific capability gating
+
+## Why there is no checked-in OCI Dedicated KMS regression profile yet
+
+The repo already has a generic vendor lane, but OCI Dedicated KMS still needs real-environment proof before a named checked-in profile would be honest.
+
+Reasons:
+
+- the direct PKCS#11 path depends on a real OCI cluster, client cert/key material, and a running daemon
+- the reviewed public docs do not publish the same kind of exhaustive supported-API matrix that would let the repo claim broad compatibility from documentation alone
+- Windows Oracle docs currently describe CNG/KSP rather than a documented Windows PKCS#11 path for this repo
+- no live OCI environment was available during issue #68 to validate the current vendor lane contract end to end
+
+That is why this issue delivers:
+
+- solid OCI product-mapping and integration documentation
+- admin-panel vendor-profile guidance
+- a clearer direct-vs-indirect support boundary
+
+rather than pretending OCI-backed regression automation already exists.
+
+## Recommended real-environment validation order
+
+When a real OCI Dedicated KMS environment is available, validate in this order:
+
+1. **client daemon connectivity + module load + initialize**
+2. **slot/token listing from the live module**
+3. **CU login with `username:password`**
+4. **object search / attribute reads for known test objects**
+5. **mechanism inventory from the live slot**
+6. **single-part encrypt/decrypt and sign/verify using documented mechanisms**
+7. only then evaluate create/generate/import/destroy and any broader regression expectations
+
+That sequence matches the current support depth much better than claiming blanket OCI parity without live-runtime evidence.

--- a/docs/vendor-regression.md
+++ b/docs/vendor-regression.md
@@ -4,6 +4,7 @@ See also: `docs/luna-integration.md` for the practical Luna client/module setup 
 See also: `docs/luna-compatibility-audit.md` for the current Thales Luna-specific scope boundary and extension-gap audit.
 See also: `docs/cloudhsm-integration.md` and `docs/cloudhsm-compatibility-audit.md` for the current AWS CloudHSM support boundary.
 See also: `docs/google-cloud-hsm-integration.md` and `docs/google-cloud-hsm-compatibility-audit.md` for the current Google Cloud HSM / kmsp11 support boundary.
+See also: `docs/oci-dedicated-kms-integration.md` and `docs/oci-dedicated-kms-compatibility-audit.md` for the current Oracle OCI Dedicated KMS support boundary.
 See also: `docs/luna-vendor-extension-design.md` for the proposed package/boundary/loading strategy for future Luna-only `CA_*` support.
 
 ## Purpose
@@ -181,6 +182,27 @@ So the current Google support slice is:
 - strong documentation
 - admin-panel readiness improvements and guardrails
 - explicit wrapper/admin setup guidance
+
+rather than a premature vendor-lane profile that would overstate validation depth.
+
+## Why there is not yet a checked-in OCI Dedicated KMS profile
+
+See also: `docs/oci-dedicated-kms-integration.md` and `docs/oci-dedicated-kms-compatibility-audit.md`.
+
+Oracle OCI Dedicated KMS is now a documented target for the repo, but there is intentionally **no** checked-in `oci-*` vendor-regression profile yet.
+
+Reason:
+
+- the direct PKCS#11 path depends on a real OCI HSM cluster, client certificates/keys, and a running `client_daemon`
+- Oracle's reviewed public docs confirm the Linux PKCS#11 packaging path, login model, and some mechanism families, but they do **not** publish the kind of exhaustive supported-API matrix that would justify broad repo claims from docs alone
+- Oracle's reviewed Windows docs describe CNG/KSP rather than a Windows PKCS#11 path for the current repo boundary
+- no live OCI environment was available during issue #68 to prove the existing vendor lane contract end to end
+
+So the current OCI support slice is:
+
+- strong documentation
+- admin-panel vendor-profile guidance
+- explicit direct-vs-indirect Oracle product-boundary clarification
 
 rather than a premature vendor-lane profile that would overstate validation depth.
 

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Shared/DeviceVendorProfileCatalog.cs
@@ -118,6 +118,28 @@ internal static class DeviceVendorProfileCatalog
                     "Cloud KMS provisioning and policy remain outside this UI",
                     "Key rings, IAM, service accounts, protection-level choices, and broader Cloud KMS lifecycle/control-plane tasks stay in Google Cloud tooling and APIs. This profile only helps the repo/admin surface stay honest when consuming kmsp11 as a PKCS#11 module.",
                     DeviceVendorHintTone.Boundary)
+            ]),
+        new(
+            "oracle-oci-dedicated-kms-standard",
+            "Oracle OCI Dedicated KMS / standard PKCS#11",
+            "oracle",
+            "Oracle",
+            "oci-dedicated-kms-standard",
+            "OCI Dedicated KMS / standard PKCS#11",
+            "Use this when the device profile points at Oracle Cloud Infrastructure Dedicated KMS on a host that already has the OCI Linux PKCS#11 client/runtime configured. The direct PKCS#11 fit is Dedicated KMS, not generic OCI Vault or Windows CNG/KSP flows.",
+            [
+                new DeviceVendorHint(
+                    "Run the admin app where the OCI Linux client and daemon are already working",
+                    "Point the profile at the exact OCI PKCS#11 library path visible to the running host/container and make sure the host already has the oci-hsm-client and oci-hsm-pkcs11 packages, the required cert-c/pkey-c/partitionOwnerCert.pem material, and a working client_daemon configuration before relying on the app operationally.",
+                    DeviceVendorHintTone.Info),
+                new DeviceVendorHint(
+                    "Treat the direct PKCS#11 path as Linux-first and CU-scoped",
+                    "Oracle's reviewed docs currently publish the PKCS#11 package for Oracle Linux and document C_Login CU credentials in the form username:password. Windows docs focus on CNG/KSP plus n3fips_password rather than the PKCS#11 module boundary this app consumes, so the current repo guidance keeps direct OCI PKCS#11 usage on the Linux client path.",
+                    DeviceVendorHintTone.Warning),
+                new DeviceVendorHint(
+                    "Vault/control-plane/user administration stay outside this UI",
+                    "This profile is for OCI Dedicated KMS as a standard PKCS#11 module only. OCI Vault/private-vault service operations, HSM-cluster provisioning, user/certificate bootstrap, and Windows CNG/KSP administration remain outside the current admin surface.",
+                    DeviceVendorHintTone.Boundary)
             ])
     ];
 

--- a/tests/Pkcs11Wrapper.Admin.Tests/DeviceVendorProfileCatalogTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/DeviceVendorProfileCatalogTests.cs
@@ -11,6 +11,12 @@ public sealed class DeviceVendorProfileCatalogTests
         "cloud-kms-kmsp11",
         "Cloud KMS / Cloud HSM via kmsp11");
 
+    private static readonly HsmDeviceVendorMetadata OracleVendor = new(
+        "oracle",
+        "Oracle",
+        "oci-dedicated-kms-standard",
+        "OCI Dedicated KMS / standard PKCS#11");
+
     [Fact]
     public void GetSelectionId_ReturnsKnownGoogleProfileSelection()
     {
@@ -33,5 +39,29 @@ public sealed class DeviceVendorProfileCatalogTests
         Assert.Contains(guidance.Hints, hint => hint.Body.Contains("KMS_PKCS11_CONFIG", StringComparison.Ordinal));
         Assert.Contains(guidance.Hints, hint => hint.Body.Contains("PIN is ignored", StringComparison.Ordinal));
         Assert.Contains(guidance.Hints, hint => hint.Body.Contains("Cloud KMS lifecycle/control-plane", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GetSelectionId_ReturnsKnownOracleProfileSelection()
+    {
+        string selectionId = DeviceVendorProfileCatalog.GetSelectionId(OracleVendor);
+
+        Assert.Equal("oracle-oci-dedicated-kms-standard", selectionId);
+    }
+
+    [Fact]
+    public void GetGuidance_ReturnsOracleSpecificSummaryAndHints()
+    {
+        DeviceVendorGuidance guidance = DeviceVendorProfileCatalog.GetGuidance(OracleVendor);
+
+        Assert.True(guidance.IsKnownProfile);
+        Assert.False(guidance.IsVendorNeutral);
+        Assert.Equal("Oracle", guidance.Title);
+        Assert.Equal("OCI Dedicated KMS / standard PKCS#11", guidance.ProfileName);
+        Assert.Contains("Dedicated KMS", guidance.Summary);
+        Assert.Equal(3, guidance.Hints.Count);
+        Assert.Contains(guidance.Hints, hint => hint.Body.Contains("oci-hsm-pkcs11", StringComparison.Ordinal));
+        Assert.Contains(guidance.Hints, hint => hint.Body.Contains("username:password", StringComparison.Ordinal));
+        Assert.Contains(guidance.Hints, hint => hint.Body.Contains("Windows CNG/KSP", StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary
Add the first practical Oracle Cloud Infrastructure HSM support slice.

## Included work
- OCI Dedicated KMS integration and compatibility research/docs
- explicit clarification that direct PKCS#11 fit is OCI Dedicated KMS, not generic OCI Vault flows
- practical wrapper/admin support boundary and setup guidance
- Oracle OCI Dedicated KMS vendor guidance in the admin panel
- vendor profile tests

## Notes
- this is a documented/admin-readiness slice, not a claim of live OCI-backed runtime regression coverage
- Linux-first PKCS#11 path is the current support boundary; Oracle's Windows story is documented as CNG/KSP-oriented

## Closes
Closes #68
