### PR TITLE
Enhance telemetry operations UX

### DIFF
--- a/docs/admin-telemetry-operations.md
+++ b/docs/admin-telemetry-operations.md
@@ -82,6 +82,7 @@ Supported query parameters mirror the viewer filters:
 - `slot`
 - `operation`
 - `mechanism`
+- `minDurationMs`
 - `status`
 - `timeRange`
 
@@ -102,6 +103,14 @@ The telemetry viewer now surfaces request/audit correlation when the admin actio
 - auth type badge
 - request/session trace text
 - direct link into `/audit?q=...`
+
+The page now also adds an operator-focused console layer on top of the raw event table:
+
+- failure rate, slow-call threshold, P95 latency, and hottest-operation summary cards
+- one-click focus shortcuts for failures, returned-false paths, slow calls, and the last hour window
+- recent activity trend buckets that show where non-success volume is clustering
+- top-operation and failure-hotspot panels with direct “focus/investigate” actions that pre-fill the raw table filters
+- optional `minDurationMs` filtering so slow-path investigations and exports stay aligned
 
 The audit page search now matches session trace ids, remote IP, and user agent text so a telemetry row can pivot into a narrower operational review trail quickly.
 

--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryQuery.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminPkcs11TelemetryQuery.cs
@@ -7,5 +7,6 @@ public sealed record AdminPkcs11TelemetryQuery(
     string? SlotFilter = null,
     string? OperationFilter = null,
     string? MechanismFilter = null,
+    double? MinDurationMilliseconds = null,
     string StatusFilter = "all",
     string TimeRangeFilter = "all");

--- a/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryQueryEvaluator.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryQueryEvaluator.cs
@@ -58,6 +58,11 @@ public static class Pkcs11TelemetryQueryEvaluator
             filtered = filtered.Where(item => MatchesNumericFilter(item.MechanismType, mechanismTerm));
         }
 
+        if (query.MinDurationMilliseconds.HasValue && query.MinDurationMilliseconds.Value > 0)
+        {
+            filtered = filtered.Where(item => item.DurationMilliseconds >= query.MinDurationMilliseconds.Value);
+        }
+
         filtered = (query.StatusFilter ?? "all").ToLowerInvariant() switch
         {
             "success" => filtered.Where(IsSuccess),

--- a/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/Pkcs11TelemetryService.cs
@@ -44,10 +44,18 @@ public sealed class Pkcs11TelemetryService(IPkcs11TelemetryStore store, IAdminAc
         => new AdminPkcs11TelemetryListener(store, device, actorContext.GetCurrent(), Activity.Current?.TraceId.ToString());
 
     private AdminPkcs11TelemetryQuery NormalizeQuery(AdminPkcs11TelemetryQuery query)
-        => query with { Take = NormalizeTake(query.Take, defaultTake: 500) };
+        => query with
+        {
+            Take = NormalizeTake(query.Take, defaultTake: 500),
+            MinDurationMilliseconds = NormalizeMinDuration(query.MinDurationMilliseconds)
+        };
 
     private AdminPkcs11TelemetryQuery NormalizeExportQuery(AdminPkcs11TelemetryQuery query)
-        => query with { Take = NormalizeTake(query.Take, defaultTake: GetNormalizedExportMaxEntries()) };
+        => query with
+        {
+            Take = NormalizeTake(query.Take, defaultTake: GetNormalizedExportMaxEntries()),
+            MinDurationMilliseconds = NormalizeMinDuration(query.MinDurationMilliseconds)
+        };
 
     private int NormalizeTake(int take, int defaultTake)
     {
@@ -62,6 +70,11 @@ public sealed class Pkcs11TelemetryService(IPkcs11TelemetryStore store, IAdminAc
 
     private int GetNormalizedExportMaxEntries()
         => options.ExportMaxEntries <= 0 ? 5000 : options.ExportMaxEntries;
+
+    private static double? NormalizeMinDuration(double? minDurationMilliseconds)
+        => minDurationMilliseconds.HasValue && minDurationMilliseconds.Value > 0
+            ? minDurationMilliseconds.Value
+            : null;
 
     private sealed class AdminPkcs11TelemetryListener(IPkcs11TelemetryStore store, HsmDeviceProfile device, AdminActorInfo actor, string? activityTraceId) : IPkcs11OperationTelemetryListener
     {

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryInsights.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryInsights.cs
@@ -1,0 +1,221 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Web.Components.Pages;
+
+public sealed record Pkcs11TelemetryInsights(
+    int TotalCount,
+    int NonSuccessCount,
+    int SlowCount,
+    double FailureRate,
+    double SlowRate,
+    double P95DurationMilliseconds,
+    double MaxDurationMilliseconds,
+    string? HottestOperationName,
+    int HottestOperationCount,
+    Pkcs11TelemetryTrendBucket[] Trend,
+    Pkcs11TelemetryOperationSummary[] TopOperations,
+    Pkcs11TelemetryFailureHotspot[] FailureHotspots)
+{
+    public static Pkcs11TelemetryInsights Empty { get; } = new(
+        TotalCount: 0,
+        NonSuccessCount: 0,
+        SlowCount: 0,
+        FailureRate: 0,
+        SlowRate: 0,
+        P95DurationMilliseconds: 0,
+        MaxDurationMilliseconds: 0,
+        HottestOperationName: null,
+        HottestOperationCount: 0,
+        Trend: [],
+        TopOperations: [],
+        FailureHotspots: []);
+
+    public static Pkcs11TelemetryInsights Build(
+        IReadOnlyList<AdminPkcs11TelemetryEntry> items,
+        DateTimeOffset nowUtc,
+        double slowOperationThresholdMilliseconds,
+        int trendBucketCount = 6,
+        int maxTopOperations = 5,
+        int maxFailureHotspots = 5)
+    {
+        if (items.Count == 0)
+        {
+            return Empty;
+        }
+
+        int nonSuccessCount = items.Count(static item => !IsSuccess(item));
+        int slowCount = slowOperationThresholdMilliseconds > 0
+            ? items.Count(item => item.DurationMilliseconds >= slowOperationThresholdMilliseconds)
+            : 0;
+        double[] orderedDurations = [.. items.Select(item => item.DurationMilliseconds).OrderBy(static value => value)];
+
+        Pkcs11TelemetryOperationSummary[] topOperations =
+        [
+            .. items
+                .GroupBy(item => item.OperationName, StringComparer.Ordinal)
+                .Select(group => new Pkcs11TelemetryOperationSummary(
+                    group.Key,
+                    group.Count(),
+                    group.Count(static item => !IsSuccess(item)),
+                    group.Average(static item => item.DurationMilliseconds),
+                    group.Max(static item => item.DurationMilliseconds),
+                    group.Select(static item => item.DeviceName)
+                        .Distinct(StringComparer.Ordinal)
+                        .OrderBy(static name => name, StringComparer.Ordinal)
+                        .ToArray()))
+                .OrderByDescending(static summary => summary.TotalCount)
+                .ThenByDescending(static summary => summary.NonSuccessCount)
+                .ThenByDescending(static summary => summary.MaxDurationMilliseconds)
+                .ThenBy(static summary => summary.OperationName, StringComparer.Ordinal)
+                .Take(Math.Max(1, maxTopOperations))
+        ];
+
+        Pkcs11TelemetryFailureHotspot[] failureHotspots =
+        [
+            .. items
+                .Where(static item => !IsSuccess(item))
+                .GroupBy(static item => new FailureHotspotKey(item.OperationName, item.DeviceName, GetFailureSignature(item)))
+                .Select(group => new Pkcs11TelemetryFailureHotspot(
+                    group.Key.OperationName,
+                    group.Key.DeviceName,
+                    group.Key.FailureSignature,
+                    group.Count(),
+                    group.Max(static item => item.TimestampUtc),
+                    group.Max(static item => item.DurationMilliseconds)))
+                .OrderByDescending(static hotspot => hotspot.Count)
+                .ThenByDescending(static hotspot => hotspot.LatestTimestampUtc)
+                .ThenByDescending(static hotspot => hotspot.MaxDurationMilliseconds)
+                .ThenBy(static hotspot => hotspot.OperationName, StringComparer.Ordinal)
+                .ThenBy(static hotspot => hotspot.DeviceName, StringComparer.Ordinal)
+                .Take(Math.Max(1, maxFailureHotspots))
+        ];
+
+        Pkcs11TelemetryOperationSummary? hottestOperation = topOperations.FirstOrDefault();
+        return new(
+            TotalCount: items.Count,
+            NonSuccessCount: nonSuccessCount,
+            SlowCount: slowCount,
+            FailureRate: items.Count == 0 ? 0 : nonSuccessCount / (double)items.Count,
+            SlowRate: items.Count == 0 ? 0 : slowCount / (double)items.Count,
+            P95DurationMilliseconds: CalculatePercentile(orderedDurations, 0.95),
+            MaxDurationMilliseconds: orderedDurations[^1],
+            HottestOperationName: hottestOperation?.OperationName,
+            HottestOperationCount: hottestOperation?.TotalCount ?? 0,
+            Trend: BuildTrend(items, nowUtc, trendBucketCount),
+            TopOperations: topOperations,
+            FailureHotspots: failureHotspots);
+    }
+
+    private static Pkcs11TelemetryTrendBucket[] BuildTrend(
+        IReadOnlyList<AdminPkcs11TelemetryEntry> items,
+        DateTimeOffset nowUtc,
+        int requestedBucketCount)
+    {
+        int bucketCount = Math.Max(3, requestedBucketCount);
+        DateTimeOffset newest = items.Max(static item => item.TimestampUtc);
+        DateTimeOffset oldest = items.Min(static item => item.TimestampUtc);
+        DateTimeOffset end = newest;
+        DateTimeOffset start = oldest;
+
+        if (end - start < TimeSpan.FromMinutes(1))
+        {
+            start = end.AddMinutes(-1);
+        }
+
+        TimeSpan span = end - start;
+        long bucketTicks = Math.Max(1, span.Ticks / bucketCount);
+        int[] totals = new int[bucketCount];
+        int[] nonSuccessCounts = new int[bucketCount];
+
+        foreach (AdminPkcs11TelemetryEntry item in items)
+        {
+            long offsetTicks = Math.Max(0, item.TimestampUtc.Ticks - start.Ticks);
+            int index = (int)Math.Min(bucketCount - 1, offsetTicks / bucketTicks);
+            totals[index]++;
+            if (!IsSuccess(item))
+            {
+                nonSuccessCounts[index]++;
+            }
+        }
+
+        Pkcs11TelemetryTrendBucket[] buckets = new Pkcs11TelemetryTrendBucket[bucketCount];
+        for (int i = 0; i < bucketCount; i++)
+        {
+            DateTimeOffset bucketEnd = i == bucketCount - 1
+                ? end
+                : start.AddTicks(bucketTicks * (i + 1));
+            buckets[i] = new(
+                Label: FormatTrendLabel(bucketEnd, span),
+                TotalCount: totals[i],
+                NonSuccessCount: nonSuccessCounts[i]);
+        }
+
+        return buckets;
+    }
+
+    private static string FormatTrendLabel(DateTimeOffset bucketEnd, TimeSpan span)
+        => span <= TimeSpan.FromHours(24)
+            ? bucketEnd.ToLocalTime().ToString("HH:mm")
+            : span <= TimeSpan.FromDays(7)
+                ? bucketEnd.ToLocalTime().ToString("MM-dd HH:mm")
+                : bucketEnd.ToLocalTime().ToString("yyyy-MM-dd");
+
+    private static double CalculatePercentile(IReadOnlyList<double> orderedValues, double percentile)
+    {
+        if (orderedValues.Count == 0)
+        {
+            return 0;
+        }
+
+        if (orderedValues.Count == 1)
+        {
+            return orderedValues[0];
+        }
+
+        double position = (orderedValues.Count - 1) * percentile;
+        int lowerIndex = (int)Math.Floor(position);
+        int upperIndex = (int)Math.Ceiling(position);
+        if (lowerIndex == upperIndex)
+        {
+            return orderedValues[lowerIndex];
+        }
+
+        double lower = orderedValues[lowerIndex];
+        double upper = orderedValues[upperIndex];
+        double weight = position - lowerIndex;
+        return lower + ((upper - lower) * weight);
+    }
+
+    private static bool IsSuccess(AdminPkcs11TelemetryEntry item)
+        => string.Equals(item.Status, "Succeeded", StringComparison.Ordinal);
+
+    private static string GetFailureSignature(AdminPkcs11TelemetryEntry item)
+        => !string.IsNullOrWhiteSpace(item.ReturnValue)
+            ? item.ReturnValue
+            : !string.IsNullOrWhiteSpace(item.ExceptionType)
+                ? item.ExceptionType
+                : item.Status;
+
+    private sealed record FailureHotspotKey(string OperationName, string DeviceName, string FailureSignature);
+}
+
+public sealed record Pkcs11TelemetryTrendBucket(
+    string Label,
+    int TotalCount,
+    int NonSuccessCount);
+
+public sealed record Pkcs11TelemetryOperationSummary(
+    string OperationName,
+    int TotalCount,
+    int NonSuccessCount,
+    double AverageDurationMilliseconds,
+    double MaxDurationMilliseconds,
+    IReadOnlyList<string> Devices);
+
+public sealed record Pkcs11TelemetryFailureHotspot(
+    string OperationName,
+    string DeviceName,
+    string FailureSignature,
+    int Count,
+    DateTimeOffset LatestTimestampUtc,
+    double MaxDurationMilliseconds);

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryView.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11TelemetryView.cs
@@ -13,6 +13,7 @@ public static class Pkcs11TelemetryView
         string? slotFilter,
         string? operationFilter,
         string? mechanismFilter,
+        double? minDurationMilliseconds,
         string statusFilter,
         string timeRangeFilter,
         DateTimeOffset nowUtc)
@@ -24,6 +25,7 @@ public static class Pkcs11TelemetryView
                 SlotFilter: slotFilter,
                 OperationFilter: operationFilter,
                 MechanismFilter: mechanismFilter,
+                MinDurationMilliseconds: minDurationMilliseconds,
                 StatusFilter: statusFilter,
                 TimeRangeFilter: timeRangeFilter),
             nowUtc);

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
@@ -17,6 +17,7 @@
             <span class="page-tag">Mechanism correlation</span>
             <span class="page-tag">Retention aware</span>
             <span class="page-tag">Audit trace links</span>
+            <span class="page-tag">Ops summaries</span>
         </div>
     </div>
     <div class="page-hero-side">
@@ -35,7 +36,7 @@
 
 <div class="alert alert-info">
     <div class="fw-semibold">Safe telemetry surface</div>
-    <div class="small">Search and filter the redacted PKCS#11 event stream by device, slot, operation, mechanism, status, actor trace, and recent time window. Use <a href="audit">Audit Logs</a> when you need actor/action traceability; this page now links back into matching audit traces when request/session correlation is available.</div>
+    <div class="small">Search and filter the redacted PKCS#11 event stream by device, slot, operation, mechanism, slow-call threshold, status, actor trace, and recent time window. Use <a href="audit">Audit Logs</a> when you need actor/action traceability; this page now links back into matching audit traces when request/session correlation is available.</div>
 </div>
 
 @if (_storageStatus is not null)
@@ -46,70 +47,85 @@
     </div>
 }
 
+@{
+    IReadOnlyList<AdminPkcs11TelemetryEntry> filteredEntries = FilteredEntries;
+    Pkcs11TelemetryInsights insights = Pkcs11TelemetryInsights.Build(filteredEntries, DateTimeOffset.UtcNow, _slowOperationThresholdMilliseconds);
+}
+
 <div class="row g-3 mb-3">
-    <div class="col-xl-3 col-md-4 col-sm-6">
+    <div class="col-xl-2 col-md-4 col-sm-6">
         <div class="card shadow-sm h-100 metric-card">
             <div class="card-body">
-                <div class="metric-label">Loaded events</div>
+                <div class="metric-label">Loaded window</div>
                 <div class="display-6 metric-meta">@_entries.Count</div>
+                <div class="small metric-note">Newest events pulled from retained storage.</div>
             </div>
         </div>
     </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
+    <div class="col-xl-2 col-md-4 col-sm-6">
         <div class="card shadow-sm h-100 metric-card">
             <div class="card-body">
-                <div class="metric-label">Filtered events</div>
-                <div class="display-6 metric-meta">@FilteredEntries.Count</div>
+                <div class="metric-label">Current view</div>
+                <div class="display-6 metric-meta">@filteredEntries.Count</div>
+                <div class="small metric-note">Events after the current operator filters.</div>
             </div>
         </div>
     </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
+    <div class="col-xl-2 col-md-4 col-sm-6">
         <div class="card shadow-sm h-100 metric-card">
             <div class="card-body">
-                <div class="metric-label">Non-success</div>
-                <div class="display-6 metric-meta">@FilteredEntries.Count(entry => !Pkcs11TelemetryView.IsSuccess(entry))</div>
+                <div class="metric-label">Failure rate</div>
+                <div class="display-6 metric-meta">@FormatPercentage(insights.FailureRate)</div>
+                <div class="small metric-note">@insights.NonSuccessCount non-success event(s).</div>
             </div>
         </div>
     </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
+    <div class="col-xl-2 col-md-4 col-sm-6">
         <div class="card shadow-sm h-100 metric-card">
             <div class="card-body">
-                <div class="metric-label">Devices in window</div>
-                <div class="display-6 metric-meta">@AvailableDevices.Count</div>
+                <div class="metric-label">Slow ops</div>
+                <div class="display-6 metric-meta">@insights.SlowCount</div>
+                <div class="small metric-note">@FormatPercentage(insights.SlowRate) at or above @_slowOperationThresholdMilliseconds.ToString("0", CultureInfo.InvariantCulture) ms.</div>
             </div>
         </div>
     </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
+    <div class="col-xl-2 col-md-4 col-sm-6">
         <div class="card shadow-sm h-100 metric-card">
             <div class="card-body">
-                <div class="metric-label">Retained files</div>
-                <div class="display-6 metric-meta">@(_storageStatus?.RetainedFileCount ?? 0)</div>
+                <div class="metric-label">P95 latency</div>
+                <div class="display-6 metric-meta">@FormatDuration(insights.P95DurationMilliseconds)</div>
+                <div class="small metric-note">Worst-case in view: @FormatDuration(insights.MaxDurationMilliseconds).</div>
             </div>
         </div>
     </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
+    <div class="col-xl-2 col-md-4 col-sm-6">
         <div class="card shadow-sm h-100 metric-card">
             <div class="card-body">
-                <div class="metric-label">Retained size</div>
-                <div class="display-6 metric-meta">@FormatBytes(_storageStatus?.RetainedBytes ?? 0)</div>
+                <div class="metric-label">Hottest operation</div>
+                <div class="display-6 metric-meta telemetry-metric-text">@(string.IsNullOrWhiteSpace(insights.HottestOperationName) ? "—" : insights.HottestOperationName)</div>
+                <div class="small metric-note">@insights.HottestOperationCount call(s) in the current view.</div>
             </div>
         </div>
     </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
-        <div class="card shadow-sm h-100 metric-card">
-            <div class="card-body">
-                <div class="metric-label">Archive files</div>
-                <div class="display-6 metric-meta">@(_storageStatus?.ArchivedFileCount ?? 0)</div>
+</div>
+
+<div class="card shadow-sm mb-4 feature-card">
+    <div class="card-body d-flex flex-column gap-3">
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-3">
+            <div>
+                <div class="metric-label">Operator focus</div>
+                <h2 class="h5 mb-1">Jump straight to likely problem slices</h2>
+                <div class="small text-muted">These shortcuts combine the existing filters into investigation-friendly presets so you can move from “there is noise” to “what exactly is failing or slow?” with one click.</div>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+                <button class="btn btn-outline-danger btn-sm" @onclick="FocusFailures" data-testid="telemetry-quick-failures">Focus failures</button>
+                <button class="btn btn-outline-warning btn-sm" @onclick="FocusReturnedFalse">Returned false</button>
+                <button class="btn btn-outline-primary btn-sm" @onclick="FocusSlowOperations" data-testid="telemetry-quick-slow">Slow ops &gt;= @_slowOperationThresholdMilliseconds.ToString("0", CultureInfo.InvariantCulture) ms</button>
+                <button class="btn btn-outline-secondary btn-sm" @onclick="FocusLastHour" data-testid="telemetry-quick-last-hour">Last hour</button>
+                <button class="btn btn-outline-dark btn-sm" @onclick="ResetFilters" data-testid="telemetry-clear-filters">Clear focus</button>
             </div>
         </div>
-    </div>
-    <div class="col-xl-3 col-md-4 col-sm-6">
-        <div class="card shadow-sm h-100 metric-card">
-            <div class="card-body">
-                <div class="metric-label">Export cap</div>
-                <div class="display-6 metric-meta">@(_storageStatus?.ExportMaxEntries ?? 0)</div>
-            </div>
-        </div>
+        <div class="small text-muted">Current focus: @BuildFocusSummary()</div>
     </div>
 </div>
 
@@ -120,7 +136,7 @@
         </div>
         <div class="col-xl-3 col-lg-4 col-md-6">
             <a class="btn btn-outline-secondary" href="@BuildExportHref()" data-testid="telemetry-export">Download filtered JSON</a>
-            <div class="form-text">Exports only the redacted retained stream and respects the server-side export cap.</div>
+            <div class="form-text">Exports only the redacted retained stream, respects the server-side export cap, and carries the slow-call filter into the export query.</div>
         </div>
         <div class="col-xl-4 col-lg-5 col-md-6">
             <label class="form-label">Search</label>
@@ -146,6 +162,18 @@
                 }
             </select>
         </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Slot</label>
+            <input class="form-control" @bind="_slotFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="decimal or hex" />
+        </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Mechanism</label>
+            <input class="form-control" @bind="_mechanismFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="0x1082 or 4226" />
+        </div>
+        <div class="col-xl-2 col-lg-3 col-md-6">
+            <label class="form-label">Min duration (ms)</label>
+            <input class="form-control" @bind="_minDurationFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" inputmode="decimal" placeholder="250" data-testid="telemetry-min-duration" />
+        </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Status</label>
             <select class="form-select" @bind="_statusFilter" @bind:after="OnFiltersChanged">
@@ -155,14 +183,6 @@
                 <option value="returned-false">Returned false</option>
                 <option value="failed">Failed</option>
             </select>
-        </div>
-        <div class="col-xl-2 col-lg-3 col-md-6">
-            <label class="form-label">Slot</label>
-            <input class="form-control" @bind="_slotFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="decimal or hex" />
-        </div>
-        <div class="col-xl-2 col-lg-3 col-md-6">
-            <label class="form-label">Mechanism</label>
-            <input class="form-control" @bind="_mechanismFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="0x1082 or 4226" />
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Time range</label>
@@ -190,15 +210,157 @@
 {
     <div class="empty-state">No PKCS#11 telemetry has been captured yet.</div>
 }
-else if (FilteredEntries.Count == 0)
+else if (filteredEntries.Count == 0)
 {
     <div class="empty-state">No PKCS#11 telemetry matched the current filters.</div>
 }
 else
 {
+    <div class="row g-3 mb-4">
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100 feature-card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+                        <div>
+                            <div class="metric-label">Trend</div>
+                            <h2 class="h5 mb-1">Recent activity shape</h2>
+                            <div class="small text-muted">Each bucket shows total activity in the current view; the red segment highlights non-success volume.</div>
+                        </div>
+                        <span class="table-pill">@filteredEntries.Count event(s)</span>
+                    </div>
+                    <div class="telemetry-trend" data-testid="telemetry-trend">
+                        @foreach (Pkcs11TelemetryTrendBucket bucket in insights.Trend)
+                        {
+                            <div class="telemetry-trend-column">
+                                <div class="telemetry-trend-bar @(bucket.TotalCount == 0 ? "telemetry-trend-bar-empty" : string.Empty)" style="@BuildTrendBarStyle(bucket, insights.Trend)">
+                                    @if (bucket.NonSuccessCount > 0)
+                                    {
+                                        <div class="telemetry-trend-bar-fail" style="@BuildTrendFailureStyle(bucket)"></div>
+                                    }
+                                </div>
+                                <div class="telemetry-trend-count">@bucket.TotalCount</div>
+                                <div class="small text-muted">@bucket.Label</div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100 feature-card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+                        <div>
+                            <div class="metric-label">Top operations</div>
+                            <h2 class="h5 mb-1">Where the console is spending time</h2>
+                            <div class="small text-muted">Volume plus non-success count helps distinguish noisy-but-healthy calls from the paths that actually need attention.</div>
+                        </div>
+                        <span class="table-pill">Top @insights.TopOperations.Length</span>
+                    </div>
+
+                    @if (insights.TopOperations.Length == 0)
+                    {
+                        <div class="empty-state small">No operation summary is available for the current view.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive table-shell">
+                            <table class="table table-striped align-middle mb-0" data-testid="telemetry-top-operations">
+                                <thead>
+                                    <tr>
+                                        <th>Operation</th>
+                                        <th>Calls</th>
+                                        <th>Non-success</th>
+                                        <th>Avg / max</th>
+                                        <th>Focus</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (Pkcs11TelemetryOperationSummary summary in insights.TopOperations)
+                                    {
+                                        <tr>
+                                            <td>
+                                                <div class="fw-semibold">@summary.OperationName</div>
+                                                <div class="small text-muted">@string.Join(", ", summary.Devices)</div>
+                                            </td>
+                                            <td><span class="table-pill table-pill-code">@summary.TotalCount</span></td>
+                                            <td><span class="table-pill @(summary.NonSuccessCount > 0 ? "telemetry-pill-danger" : string.Empty)">@summary.NonSuccessCount</span></td>
+                                            <td>
+                                                <div>@FormatDuration(summary.AverageDurationMilliseconds)</div>
+                                                <div class="small text-muted">max @FormatDuration(summary.MaxDurationMilliseconds)</div>
+                                            </td>
+                                            <td>
+                                                <button class="btn btn-outline-secondary btn-sm" @onclick="() => FocusOperation(summary.OperationName)" data-testid="telemetry-top-operation-focus">Focus</button>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        <div class="col-xl-4">
+            <div class="card shadow-sm h-100 feature-card">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+                        <div>
+                            <div class="metric-label">Failure hotspots</div>
+                            <h2 class="h5 mb-1">What is failing, where, and how</h2>
+                            <div class="small text-muted">Grouped by operation, device, and failure signature so operators can jump into the exact noisy slice instead of reading the raw table first.</div>
+                        </div>
+                        <span class="table-pill @(insights.FailureHotspots.Length > 0 ? "telemetry-pill-danger" : string.Empty)">@insights.FailureHotspots.Length hotspot(s)</span>
+                    </div>
+
+                    @if (insights.FailureHotspots.Length == 0)
+                    {
+                        <div class="empty-state small">No failure hotspot is visible in the current view.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive table-shell">
+                            <table class="table table-striped align-middle mb-0" data-testid="telemetry-failure-hotspots">
+                                <thead>
+                                    <tr>
+                                        <th>Failure slice</th>
+                                        <th>Count</th>
+                                        <th>Latest</th>
+                                        <th>Focus</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (Pkcs11TelemetryFailureHotspot hotspot in insights.FailureHotspots)
+                                    {
+                                        <tr>
+                                            <td>
+                                                <div class="fw-semibold">@hotspot.OperationName</div>
+                                                <div class="small text-muted">@hotspot.DeviceName • @hotspot.FailureSignature</div>
+                                            </td>
+                                            <td>
+                                                <div><span class="table-pill telemetry-pill-danger">@hotspot.Count</span></div>
+                                                <div class="small text-muted">max @FormatDuration(hotspot.MaxDurationMilliseconds)</div>
+                                            </td>
+                                            <td>
+                                                <span class="table-pill table-pill-code">@hotspot.LatestTimestampUtc.ToLocalTime().ToString("MM-dd HH:mm:ss")</span>
+                                            </td>
+                                            <td>
+                                                <button class="btn btn-outline-danger btn-sm" @onclick="() => FocusHotspot(hotspot)" data-testid="telemetry-hotspot-focus">Investigate</button>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
         <div class="small text-muted">
-            Showing @CurrentRangeStart-@CurrentRangeEnd of @FilteredEntries.Count filtered event(s) from the latest @_entries.Count loaded item(s).
+            Showing @CurrentRangeStart-@CurrentRangeEnd of @filteredEntries.Count filtered event(s) from the latest @_entries.Count loaded item(s).
         </div>
         <div class="small text-muted">Page @CurrentPageIndex of @TotalPages</div>
     </div>
@@ -238,7 +400,7 @@ else
                         <td>
                             <span class="badge @Pkcs11TelemetryView.GetStatusBadgeClass(entry)">@entry.Status</span>
                         </td>
-                        <td><span class="table-pill table-pill-code">@entry.DurationMilliseconds.ToString("F2") ms</span></td>
+                        <td><span class="table-pill table-pill-code">@FormatDuration(entry.DurationMilliseconds)</span></td>
                         <td>
                             <div class="d-flex flex-wrap gap-1 mb-1">
                                 @if (!string.IsNullOrWhiteSpace(entry.ReturnValue))
@@ -308,6 +470,7 @@ else
 
 @code {
     private const int _loadWindowSize = 500;
+    private const double _slowOperationThresholdMilliseconds = 250;
 
     private IReadOnlyList<AdminPkcs11TelemetryEntry> _entries = [];
     private AdminPkcs11TelemetryStorageStatus? _storageStatus;
@@ -316,6 +479,7 @@ else
     private string _slotFilter = string.Empty;
     private string _operationFilter = string.Empty;
     private string _mechanismFilter = string.Empty;
+    private string _minDurationFilter = string.Empty;
     private string _statusFilter = "all";
     private string _timeRangeFilter = "24h";
     private int _pageSize = 25;
@@ -333,6 +497,11 @@ else
         .OrderBy(operation => operation, StringComparer.Ordinal)
         .ToArray();
 
+    private double? MinDurationMilliseconds
+        => double.TryParse(_minDurationFilter, NumberStyles.Float, CultureInfo.InvariantCulture, out double value) && value > 0
+            ? value
+            : null;
+
     private IReadOnlyList<AdminPkcs11TelemetryEntry> FilteredEntries => Pkcs11TelemetryView.Apply(
         _entries,
         _searchText,
@@ -340,6 +509,7 @@ else
         _slotFilter,
         _operationFilter,
         _mechanismFilter,
+        MinDurationMilliseconds,
         _statusFilter,
         _timeRangeFilter,
         DateTimeOffset.UtcNow);
@@ -386,6 +556,65 @@ else
         return Task.CompletedTask;
     }
 
+    private Task FocusFailures()
+    {
+        _statusFilter = "non-success";
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task FocusReturnedFalse()
+    {
+        _statusFilter = "returned-false";
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task FocusSlowOperations()
+    {
+        _minDurationFilter = _slowOperationThresholdMilliseconds.ToString("0", CultureInfo.InvariantCulture);
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task FocusLastHour()
+    {
+        _timeRangeFilter = "1h";
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task FocusOperation(string operationName)
+    {
+        _operationFilter = operationName;
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task FocusHotspot(Pkcs11TelemetryFailureHotspot hotspot)
+    {
+        _operationFilter = hotspot.OperationName;
+        _deviceFilter = hotspot.DeviceName;
+        _searchText = hotspot.FailureSignature;
+        _statusFilter = "non-success";
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
+    private Task ResetFilters()
+    {
+        _searchText = string.Empty;
+        _deviceFilter = string.Empty;
+        _slotFilter = string.Empty;
+        _operationFilter = string.Empty;
+        _mechanismFilter = string.Empty;
+        _minDurationFilter = string.Empty;
+        _statusFilter = "all";
+        _timeRangeFilter = "24h";
+        _pageIndex = 1;
+        return Task.CompletedTask;
+    }
+
     private void PreviousPage()
     {
         if (_pageIndex > 1)
@@ -427,6 +656,7 @@ else
             ["slot"] = string.IsNullOrWhiteSpace(_slotFilter) ? null : _slotFilter,
             ["operation"] = string.IsNullOrWhiteSpace(_operationFilter) ? null : _operationFilter,
             ["mechanism"] = string.IsNullOrWhiteSpace(_mechanismFilter) ? null : _mechanismFilter,
+            ["minDurationMs"] = MinDurationMilliseconds?.ToString(CultureInfo.InvariantCulture),
             ["status"] = string.IsNullOrWhiteSpace(_statusFilter) ? null : _statusFilter,
             ["timeRange"] = string.IsNullOrWhiteSpace(_timeRangeFilter) ? null : _timeRangeFilter
         };
@@ -434,6 +664,63 @@ else
         return Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
             "/telemetry/export",
             query.Where(pair => !string.IsNullOrWhiteSpace(pair.Value)).ToDictionary(pair => pair.Key, pair => pair.Value));
+    }
+
+    private string BuildFocusSummary()
+    {
+        List<string> parts = [];
+        if (!string.IsNullOrWhiteSpace(_deviceFilter))
+        {
+            parts.Add($"device={_deviceFilter}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_operationFilter))
+        {
+            parts.Add($"operation={_operationFilter}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_slotFilter))
+        {
+            parts.Add($"slot={_slotFilter}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_mechanismFilter))
+        {
+            parts.Add($"mechanism={_mechanismFilter}");
+        }
+
+        if (MinDurationMilliseconds.HasValue)
+        {
+            parts.Add($"min-duration={FormatDuration(MinDurationMilliseconds.Value)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_searchText))
+        {
+            parts.Add($"search='{_searchText}'");
+        }
+
+        if (!string.Equals(_statusFilter, "all", StringComparison.Ordinal))
+        {
+            parts.Add($"status={_statusFilter}");
+        }
+
+        parts.Add($"time={_timeRangeFilter}");
+        return string.Join(" • ", parts);
+    }
+
+    private static string BuildTrendBarStyle(Pkcs11TelemetryTrendBucket bucket, IReadOnlyList<Pkcs11TelemetryTrendBucket> trend)
+    {
+        int maxCount = Math.Max(1, trend.Max(static point => point.TotalCount));
+        double height = 24 + ((bucket.TotalCount / (double)maxCount) * 112);
+        return FormattableString.Invariant($"height:{height:0.#}px");
+    }
+
+    private static string BuildTrendFailureStyle(Pkcs11TelemetryTrendBucket bucket)
+    {
+        double percentage = bucket.TotalCount == 0
+            ? 0
+            : (bucket.NonSuccessCount / (double)bucket.TotalCount) * 100;
+        return FormattableString.Invariant($"height:{percentage:0.#}%");
     }
 
     private static string FormatBytes(long bytes)
@@ -454,4 +741,12 @@ else
 
         return $"{value:0.#} {units[unitIndex]}";
     }
+
+    private static string FormatPercentage(double value)
+        => value <= 0
+            ? "0%"
+            : $"{value * 100:0.#}%";
+
+    private static string FormatDuration(double milliseconds)
+        => $"{milliseconds:0.##} ms";
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Configuration/TelemetryEndpoints.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Configuration/TelemetryEndpoints.cs
@@ -16,6 +16,7 @@ public static class TelemetryEndpoints
         [FromQuery(Name = "slot")] string? slotFilter,
         [FromQuery(Name = "operation")] string? operationFilter,
         [FromQuery(Name = "mechanism")] string? mechanismFilter,
+        [FromQuery(Name = "minDurationMs")] double? minDurationMilliseconds,
         [FromQuery(Name = "status")] string? statusFilter,
         [FromQuery(Name = "timeRange")] string? timeRangeFilter,
         CancellationToken cancellationToken)
@@ -28,6 +29,7 @@ public static class TelemetryEndpoints
                 SlotFilter: slotFilter,
                 OperationFilter: operationFilter,
                 MechanismFilter: mechanismFilter,
+                MinDurationMilliseconds: minDurationMilliseconds,
                 StatusFilter: statusFilter ?? "all",
                 TimeRangeFilter: timeRangeFilter ?? "all"),
             cancellationToken);

--- a/src/Pkcs11Wrapper.Admin.Web/wwwroot/app.css
+++ b/src/Pkcs11Wrapper.Admin.Web/wwwroot/app.css
@@ -586,6 +586,64 @@ textarea::placeholder {
     font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
+.telemetry-pill-danger {
+    border-color: rgba(220, 38, 38, 0.24);
+    background: rgba(254, 242, 242, 0.95);
+    color: #991b1b;
+}
+
+.telemetry-metric-text {
+    font-size: clamp(1.35rem, 1rem + 0.55vw, 2.1rem);
+    line-height: 1.15;
+    word-break: break-word;
+}
+
+.telemetry-trend {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(4.5rem, 1fr));
+    gap: 0.85rem;
+    align-items: end;
+    min-height: 12rem;
+}
+
+.telemetry-trend-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: end;
+    gap: 0.35rem;
+    text-align: center;
+}
+
+.telemetry-trend-bar {
+    position: relative;
+    width: 100%;
+    min-height: 1.5rem;
+    border-radius: 0.95rem 0.95rem 0.65rem 0.65rem;
+    border: 1px solid rgba(37, 99, 235, 0.18);
+    background: linear-gradient(180deg, rgba(59, 130, 246, 0.96) 0%, rgba(37, 99, 235, 0.78) 100%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    overflow: hidden;
+}
+
+.telemetry-trend-bar-empty {
+    border-style: dashed;
+    border-color: rgba(148, 163, 184, 0.45);
+    background: linear-gradient(180deg, rgba(226, 232, 240, 0.6) 0%, rgba(203, 213, 225, 0.42) 100%);
+}
+
+.telemetry-trend-bar-fail {
+    position: absolute;
+    inset: auto 0 0 0;
+    background: linear-gradient(180deg, rgba(248, 113, 113, 0.96) 0%, rgba(220, 38, 38, 0.88) 100%);
+}
+
+.telemetry-trend-count {
+    font-size: 0.82rem;
+    font-weight: 800;
+    color: #0f172a;
+}
+
 .capability-text {
     color: #475569;
     line-height: 1.6;

--- a/tests/Pkcs11Wrapper.Admin.E2E/Program.cs
+++ b/tests/Pkcs11Wrapper.Admin.E2E/Program.cs
@@ -194,16 +194,20 @@ internal static class AdminRuntimeE2E
 
     private static async Task ExerciseTelemetryAsync(IPage page, TestConfig config, List<string> eventLog)
     {
-        eventLog.Add("Telemetry: refreshing and filtering event stream");
+        eventLog.Add("Telemetry: refreshing, filtering, and checking operator summaries");
         await NavigateToAsync(page, config.BaseUrl, "/telemetry");
         await page.ClickAsync("[data-testid='telemetry-refresh']");
         await WaitForCountAtLeastAsync(page.Locator("[data-testid='telemetry-table'] tbody tr"), 1, 20000);
+        await WaitForVisibleAsync(page, "[data-testid='telemetry-trend']");
+        await WaitForCountAtLeastAsync(page.Locator("[data-testid='telemetry-top-operations'] tbody tr"), 1, 20000);
         await page.SelectOptionAsync("[data-testid='telemetry-device-filter']", new[] { new SelectOptionValue { Label = config.DeviceName } });
         await page.FillAsync("[data-testid='telemetry-search']", "FindObjects");
-        await page.PressAsync("[data-testid='telemetry-search']", "Tab");
+        await page.FillAsync("[data-testid='telemetry-min-duration']", "0");
+        await page.PressAsync("[data-testid='telemetry-min-duration']", "Tab");
         await WaitForTextAsync(page.Locator("[data-testid='telemetry-table']"), config.DeviceName, 20000);
         await WaitForTextAsync(page.Locator("[data-testid='telemetry-table']"), "FindObjects", 20000);
-        eventLog.Add("Telemetry: verified filtered PKCS#11 event stream");
+        await WaitForTextAsync(page.Locator("[data-testid='telemetry-top-operations']"), "FindObjects", 20000);
+        eventLog.Add("Telemetry: verified filtered PKCS#11 event stream plus operator summary widgets");
     }
 
     private static async Task NavigateToAsync(IPage page, string baseUrl, string expectedPath)

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryInsightsTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryInsightsTests.cs
@@ -1,0 +1,93 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Web.Components.Pages;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class Pkcs11TelemetryInsightsTests
+{
+    [Fact]
+    public void BuildSummarizesFailureRateSlowOpsAndTopOperations()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        AdminPkcs11TelemetryEntry[] items =
+        [
+            CreateEntry("Primary", "SignData", "Succeeded", now.AddMinutes(-12), durationMilliseconds: 22),
+            CreateEntry("Primary", "SignData", "Failed", now.AddMinutes(-10), returnValue: "CKR_PIN_INCORRECT", durationMilliseconds: 520),
+            CreateEntry("Primary", "SignData", "Failed", now.AddMinutes(-8), returnValue: "CKR_PIN_INCORRECT", durationMilliseconds: 410),
+            CreateEntry("Backup", "FindObjects", "Succeeded", now.AddMinutes(-6), durationMilliseconds: 90),
+            CreateEntry("Backup", "FindObjects", "Succeeded", now.AddMinutes(-4), durationMilliseconds: 95),
+            CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-2), durationMilliseconds: 12)
+        ];
+
+        Pkcs11TelemetryInsights insights = Pkcs11TelemetryInsights.Build(items, now, slowOperationThresholdMilliseconds: 250);
+
+        Assert.Equal(6, insights.TotalCount);
+        Assert.Equal(2, insights.NonSuccessCount);
+        Assert.Equal(2, insights.SlowCount);
+        Assert.Equal("SignData", insights.HottestOperationName);
+        Assert.Equal(3, insights.HottestOperationCount);
+        Assert.True(insights.FailureRate > 0.3 && insights.FailureRate < 0.4);
+        Assert.True(insights.P95DurationMilliseconds >= 490);
+
+        Pkcs11TelemetryOperationSummary topOperation = insights.TopOperations[0];
+        Assert.Equal("SignData", topOperation.OperationName);
+        Assert.Equal(3, topOperation.TotalCount);
+        Assert.Equal(2, topOperation.NonSuccessCount);
+        Assert.Contains("Primary", topOperation.Devices);
+
+        Pkcs11TelemetryFailureHotspot hotspot = Assert.Single(insights.FailureHotspots);
+        Assert.Equal("SignData", hotspot.OperationName);
+        Assert.Equal("Primary", hotspot.DeviceName);
+        Assert.Equal("CKR_PIN_INCORRECT", hotspot.FailureSignature);
+        Assert.Equal(2, hotspot.Count);
+    }
+
+    [Fact]
+    public void BuildCreatesTrendBucketsThatAccountForEveryEvent()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        AdminPkcs11TelemetryEntry[] items =
+        [
+            CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-50), durationMilliseconds: 5),
+            CreateEntry("Primary", "Login", "Failed", now.AddMinutes(-40), returnValue: "CKR_PIN_INCORRECT", durationMilliseconds: 35),
+            CreateEntry("Primary", "FindObjects", "Succeeded", now.AddMinutes(-30), durationMilliseconds: 60),
+            CreateEntry("Primary", "SignData", "Succeeded", now.AddMinutes(-20), durationMilliseconds: 85),
+            CreateEntry("Primary", "Verify", "ReturnedFalse", now.AddMinutes(-10), returnValue: "CKR_SIGNATURE_INVALID", durationMilliseconds: 110),
+            CreateEntry("Primary", "Logout", "Succeeded", now.AddMinutes(-2), durationMilliseconds: 8)
+        ];
+
+        Pkcs11TelemetryInsights insights = Pkcs11TelemetryInsights.Build(items, now, slowOperationThresholdMilliseconds: 250, trendBucketCount: 6);
+
+        Assert.Equal(6, insights.Trend.Length);
+        Assert.Equal(items.Length, insights.Trend.Sum(bucket => bucket.TotalCount));
+        Assert.Equal(2, insights.Trend.Sum(bucket => bucket.NonSuccessCount));
+        Assert.Contains(insights.Trend, bucket => bucket.TotalCount > 0 && !string.IsNullOrWhiteSpace(bucket.Label));
+    }
+
+    private static AdminPkcs11TelemetryEntry CreateEntry(
+        string deviceName,
+        string operationName,
+        string status,
+        DateTimeOffset timestampUtc,
+        string? returnValue = null,
+        double durationMilliseconds = 4.2)
+        => new(
+            Guid.NewGuid(),
+            timestampUtc,
+            Guid.NewGuid(),
+            deviceName,
+            operationName,
+            $"C_{operationName}",
+            status,
+            durationMilliseconds,
+            returnValue,
+            1,
+            99,
+            operationName.StartsWith("Sign", StringComparison.Ordinal) ? 0x40UL : null,
+            status == "Failed" ? "Pkcs11Exception" : null,
+            "alice",
+            "cookie",
+            "trace-1",
+            "corr-1",
+            []);
+}

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryViewTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11TelemetryViewTests.cs
@@ -23,6 +23,7 @@ public sealed class Pkcs11TelemetryViewTests
             slotFilter: "2",
             operationFilter: "SignData",
             mechanismFilter: "0x40",
+            minDurationMilliseconds: null,
             statusFilter: "failed",
             timeRangeFilter: "24h",
             nowUtc: now);
@@ -56,10 +57,10 @@ public sealed class Pkcs11TelemetryViewTests
             CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-1), slotId: 3, mechanismType: null)
         ];
 
-        IReadOnlyList<AdminPkcs11TelemetryEntry> byReturnValue = Pkcs11TelemetryView.Apply(items, "pin_incorrect", null, null, null, null, "all", "all", now);
-        IReadOnlyList<AdminPkcs11TelemetryEntry> byFieldName = Pkcs11TelemetryView.Apply(items, "credential.pin", null, null, null, null, "all", "all", now);
-        IReadOnlyList<AdminPkcs11TelemetryEntry> byActor = Pkcs11TelemetryView.Apply(items, "alice", null, null, null, null, "all", "all", now);
-        IReadOnlyList<AdminPkcs11TelemetryEntry> byTrace = Pkcs11TelemetryView.Apply(items, "trace-1", null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byReturnValue = Pkcs11TelemetryView.Apply(items, "pin_incorrect", null, null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byFieldName = Pkcs11TelemetryView.Apply(items, "credential.pin", null, null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byActor = Pkcs11TelemetryView.Apply(items, "alice", null, null, null, null, null, "all", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> byTrace = Pkcs11TelemetryView.Apply(items, "trace-1", null, null, null, null, null, "all", "all", now);
 
         Assert.Single(byReturnValue);
         Assert.Single(byFieldName);
@@ -82,10 +83,27 @@ public sealed class Pkcs11TelemetryViewTests
             CreateEntry("Primary", "SignData", "Failed", now.AddMinutes(-1), slotId: 1, mechanismType: 0x40)
         ];
 
-        IReadOnlyList<AdminPkcs11TelemetryEntry> filtered = Pkcs11TelemetryView.Apply(items, null, null, null, null, null, "non-success", "all", now);
+        IReadOnlyList<AdminPkcs11TelemetryEntry> filtered = Pkcs11TelemetryView.Apply(items, null, null, null, null, null, null, "non-success", "all", now);
 
         Assert.Equal(2, filtered.Count);
         Assert.DoesNotContain(filtered, item => item.Status == "Succeeded");
+    }
+
+    [Fact]
+    public void ApplyFiltersByMinimumDuration()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        AdminPkcs11TelemetryEntry[] items =
+        [
+            CreateEntry("Primary", "OpenSession", "Succeeded", now.AddMinutes(-3), slotId: 1, mechanismType: null, durationMilliseconds: 4.2),
+            CreateEntry("Primary", "FindObjects", "Succeeded", now.AddMinutes(-2), slotId: 1, mechanismType: null, durationMilliseconds: 250),
+            CreateEntry("Primary", "SignData", "Failed", now.AddMinutes(-1), slotId: 1, mechanismType: 0x40, durationMilliseconds: 851.3)
+        ];
+
+        IReadOnlyList<AdminPkcs11TelemetryEntry> filtered = Pkcs11TelemetryView.Apply(items, null, null, null, null, null, 250, "all", "all", now);
+
+        Assert.Equal(2, filtered.Count);
+        Assert.DoesNotContain(filtered, item => item.OperationName == "OpenSession");
     }
 
     [Fact]
@@ -108,7 +126,8 @@ public sealed class Pkcs11TelemetryViewTests
         string? actor = null,
         string? sessionId = null,
         string? correlationId = null,
-        AdminPkcs11TelemetryField[]? fields = null)
+        AdminPkcs11TelemetryField[]? fields = null,
+        double durationMilliseconds = 4.2)
         => new(
             Guid.NewGuid(),
             timestampUtc,
@@ -117,7 +136,7 @@ public sealed class Pkcs11TelemetryViewTests
             operationName,
             $"C_{operationName}",
             status,
-            4.2,
+            durationMilliseconds,
             returnValue,
             slotId,
             99,


### PR DESCRIPTION
## Summary
Enhance telemetry operations UX in the admin panel.

## Included work
- operator-focused telemetry summary cards and insights
- one-click focus shortcuts for failures, slow ops, returned-false and last-hour views
- minimum duration filter wired through query/export paths
- recent activity trends, top operations, and failure hotspot panels
- docs, unit tests, and E2E assertions updated

## Notes
- the goal is to make `/telemetry` feel like an operator console rather than a raw log dump
- broader admin E2E remains somewhat flaky, but the code/tests for this issue are green

## Closes
Closes #83
