### PR TITLE
Fix audit log UTF-8 BOM handling

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Infrastructure/CrashSafeFileStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/CrashSafeFileStore.cs
@@ -6,6 +6,8 @@ namespace Pkcs11Wrapper.Admin.Infrastructure;
 
 public static class CrashSafeFileStore
 {
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
     public static async Task<T?> ReadJsonAsync<T>(string path, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken = default)
     {
         if (!File.Exists(path))
@@ -64,7 +66,7 @@ public static class CrashSafeFileStore
         try
         {
             await using (FileStream stream = CreateWriteThroughStream(tempPath))
-            await using (StreamWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
+            await using (StreamWriter writer = new(stream, Utf8NoBom, leaveOpen: true))
             {
                 await writer.WriteAsync(content.AsMemory(), cancellationToken);
                 await writer.FlushAsync(cancellationToken);

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLineAuditLogStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLineAuditLogStore.cs
@@ -8,6 +8,7 @@ namespace Pkcs11Wrapper.Admin.Infrastructure;
 
 public sealed class JsonLineAuditLogStore(AdminStorageOptions options) : IAuditLogStore
 {
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
     private readonly SemaphoreSlim _mutex = new(1, 1);
     private AuditTailState? _tailState;
 
@@ -24,7 +25,7 @@ public sealed class JsonLineAuditLogStore(AdminStorageOptions options) : IAuditL
             string line = JsonSerializer.Serialize(normalized, AdminJsonContext.Default.AdminAuditLogEntry) + Environment.NewLine;
 
             await using FileStream stream = new(path, FileMode.Append, FileAccess.Write, FileShare.Read, 64 * 1024, FileOptions.Asynchronous | FileOptions.WriteThrough);
-            await using StreamWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+            await using StreamWriter writer = new(stream, Utf8NoBom, leaveOpen: true);
             await writer.WriteAsync(line.AsMemory(), cancellationToken);
             await writer.FlushAsync(cancellationToken);
             await stream.FlushAsync(cancellationToken);
@@ -173,7 +174,7 @@ public sealed class JsonLineAuditLogStore(AdminStorageOptions options) : IAuditL
 
         long position = stream.Length;
         byte[] buffer = new byte[4096];
-        StringBuilder reversed = new();
+        List<byte> reversedLineBytes = [];
         bool skippedTrailingNewline = false;
 
         while (position > 0 && lines.Count < take)
@@ -185,16 +186,16 @@ public sealed class JsonLineAuditLogStore(AdminStorageOptions options) : IAuditL
 
             for (int index = read - 1; index >= 0; index--)
             {
-                char current = (char)buffer[index];
-                if (current == '\n')
+                byte current = buffer[index];
+                if (current == (byte)'\n')
                 {
-                    if (!skippedTrailingNewline && reversed.Length == 0)
+                    if (!skippedTrailingNewline && reversedLineBytes.Count == 0)
                     {
                         skippedTrailingNewline = true;
                         continue;
                     }
 
-                    AddCompletedLine(lines, reversed);
+                    AddCompletedLine(lines, reversedLineBytes);
                     if (lines.Count >= take)
                     {
                         break;
@@ -204,39 +205,44 @@ public sealed class JsonLineAuditLogStore(AdminStorageOptions options) : IAuditL
                 }
                 else
                 {
-                    reversed.Append(current);
+                    reversedLineBytes.Add(current);
                 }
             }
         }
 
-        if (lines.Count < take && reversed.Length > 0)
+        if (lines.Count < take && reversedLineBytes.Count > 0)
         {
-            AddCompletedLine(lines, reversed);
+            AddCompletedLine(lines, reversedLineBytes);
         }
 
         return lines;
     }
 
-    private static void AddCompletedLine(List<string> lines, StringBuilder reversed)
+    private static void AddCompletedLine(List<string> lines, List<byte> reversedLineBytes)
     {
-        if (reversed.Length == 0)
+        if (reversedLineBytes.Count == 0)
         {
             return;
         }
 
-        char[] chars = new char[reversed.Length];
-        for (int i = 0; i < reversed.Length; i++)
+        byte[] bytes = new byte[reversedLineBytes.Count];
+        for (int i = 0; i < reversedLineBytes.Count; i++)
         {
-            chars[i] = reversed[reversed.Length - 1 - i];
+            bytes[i] = reversedLineBytes[reversedLineBytes.Count - 1 - i];
         }
 
-        string line = new string(chars).TrimEnd('\r');
-        reversed.Clear();
+        string line = StripLeadingByteOrderMark(Encoding.UTF8.GetString(bytes)).TrimEnd('\r');
+        reversedLineBytes.Clear();
         if (!string.IsNullOrWhiteSpace(line))
         {
             lines.Add(line);
         }
     }
+
+    private static string StripLeadingByteOrderMark(string line)
+        => line.Length > 0 && line[0] == '\uFEFF'
+            ? line[1..]
+            : line;
 
     private static string ComputeHash(AdminAuditLogEntry entry)
     {

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLinePkcs11TelemetryStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/JsonLinePkcs11TelemetryStore.cs
@@ -7,6 +7,8 @@ namespace Pkcs11Wrapper.Admin.Infrastructure;
 
 public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions storageOptions, AdminPkcs11TelemetryOptions? telemetryOptions = null) : IPkcs11TelemetryStore
 {
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
     private readonly SemaphoreSlim _mutex = new(1, 1);
     private readonly AdminPkcs11TelemetryOptions _telemetryOptions = telemetryOptions ?? new();
 
@@ -24,7 +26,7 @@ public sealed class JsonLinePkcs11TelemetryStore(AdminStorageOptions storageOpti
             await RotateIfNeededForAppendAsync(lineBytes, cancellationToken);
 
             await using FileStream stream = new(path, FileMode.Append, FileAccess.Write, FileShare.Read, 64 * 1024, FileOptions.Asynchronous);
-            await using StreamWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+            await using StreamWriter writer = new(stream, Utf8NoBom, leaveOpen: true);
             await writer.WriteAsync(line.AsMemory(), cancellationToken);
             await writer.FlushAsync(cancellationToken);
 

--- a/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
@@ -154,6 +154,88 @@ public sealed class JsonStoresTests
     }
 
     [Fact]
+    public async Task JsonAuditStoreWritesBomlessUtf8Jsonl()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            AdminStorageOptions options = new() { DataRoot = root };
+            JsonLineAuditLogStore store = new(options);
+            await store.AppendAsync(CreateAudit("fresh-stack", "first-entry", DateTimeOffset.UtcNow));
+
+            byte[] bytes = await File.ReadAllBytesAsync(Path.Combine(root, options.AuditLogFileName));
+
+            Assert.False(StartsWithUtf8Bom(bytes));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task JsonAuditStoreHandlesLegacyBomPrefixedFirstEntryAcrossRestart()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            AdminStorageOptions options = new() { DataRoot = root };
+            JsonLineAuditLogStore initialStore = new(options);
+            await initialStore.AppendAsync(CreateAudit("cihaz-İstanbul", "İlk giriş 🔐", DateTimeOffset.UtcNow.AddMinutes(-1)));
+
+            string path = Path.Combine(root, options.AuditLogFileName);
+            PrependUtf8Bom(path);
+
+            JsonLineAuditLogStore restartedStore = new(options);
+            IReadOnlyList<AdminAuditLogEntry> beforeAppend = await restartedStore.ReadRecentAsync(1);
+            await restartedStore.AppendAsync(CreateAudit("cihaz-Ankara", "İkinci giriş", DateTimeOffset.UtcNow));
+            IReadOnlyList<AdminAuditLogEntry> afterAppend = await restartedStore.ReadRecentAsync(2);
+            AuditIntegrityStatus integrity = await restartedStore.VerifyIntegrityAsync();
+
+            Assert.Single(beforeAppend);
+            Assert.Equal("cihaz-İstanbul", beforeAppend[0].Target);
+            Assert.Equal("İlk giriş 🔐", beforeAppend[0].Details);
+            Assert.Equal(1, beforeAppend[0].Sequence);
+
+            Assert.Equal(2, afterAppend.Count);
+            Assert.Equal("cihaz-Ankara", afterAppend[0].Target);
+            Assert.Equal(2, afterAppend[0].Sequence);
+            Assert.Equal("cihaz-İstanbul", afterAppend[1].Target);
+            Assert.Equal(1, afterAppend[1].Sequence);
+
+            Assert.True(integrity.IsValid);
+            Assert.Equal(2, integrity.CheckedEntries);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task JsonAuditStoreReadRecentPreservesUtf8Content()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            AdminStorageOptions options = new() { DataRoot = root };
+            JsonLineAuditLogStore store = new(options);
+            await store.AppendAsync(CreateAudit("profil-şifre", "Operatör parolayı güncelledi 🔐", DateTimeOffset.UtcNow));
+
+            JsonLineAuditLogStore restartedStore = new(options);
+            IReadOnlyList<AdminAuditLogEntry> logs = await restartedStore.ReadRecentAsync(1);
+
+            Assert.Single(logs);
+            Assert.Equal("profil-şifre", logs[0].Target);
+            Assert.Equal("Operatör parolayı güncelledi 🔐", logs[0].Details);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task JsonPkcs11TelemetryStoreReturnsNewestWindow()
     {
         string root = CreateTempDirectory();
@@ -213,6 +295,28 @@ public sealed class JsonStoresTests
             Directory.Delete(root, recursive: true);
         }
     }
+
+    private static void PrependUtf8Bom(string path)
+    {
+        byte[] payload = File.ReadAllBytes(path);
+        if (StartsWithUtf8Bom(payload))
+        {
+            return;
+        }
+
+        byte[] withBom = new byte[payload.Length + 3];
+        withBom[0] = 0xEF;
+        withBom[1] = 0xBB;
+        withBom[2] = 0xBF;
+        Buffer.BlockCopy(payload, 0, withBom, 3, payload.Length);
+        File.WriteAllBytes(path, withBom);
+    }
+
+    private static bool StartsWithUtf8Bom(byte[] bytes)
+        => bytes.Length >= 3
+            && bytes[0] == 0xEF
+            && bytes[1] == 0xBB
+            && bytes[2] == 0xBF;
 
     private static HsmDeviceProfile CreateProfile(string name)
         => new(Guid.NewGuid(), name, "/tmp/libpkcs11.so", null, null, true, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);


### PR DESCRIPTION
## Summary
Fix the audit log UTF-8 BOM / tail-read corruption bug that breaks dashboard recent-audit reads on fresh stacks.

## Included work
- stop emitting BOM on new JSONL/text writes
- fix reverse tail reading to decode full UTF-8 lines correctly
- tolerate legacy BOM-prefixed audit lines
- add regression coverage for BOM and multibyte UTF-8 content

## Notes
- this fixes the dashboard/audit parse issue found in runtime sweep issue #90
- scope also covers the directly related multibyte UTF-8 corruption risk in the old reverse reader

## Closes
Closes #90
