### PR TITLE
Handle uninitialized SoftHSM slots in admin UI

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Application/Models/HsmSlotSummary.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/HsmSlotSummary.cs
@@ -7,8 +7,20 @@ public sealed record HsmSlotSummary(
     string SlotManufacturer,
     string SlotFlags,
     bool TokenPresent,
+    bool TokenInitialized,
     string? TokenLabel,
     string? TokenModel,
     string? TokenSerialNumber,
     string? TokenFlags,
-    int MechanismCount);
+    int MechanismCount)
+{
+    public bool CanOpenSessions => TokenPresent && TokenInitialized;
+
+    public bool RequiresInitialization => TokenPresent && !TokenInitialized;
+
+    public string SessionOpenUnavailableReason => !TokenPresent
+        ? "No token is present in this slot, so session-based actions are unavailable."
+        : TokenInitialized
+            ? string.Empty
+            : "The slot reports token info, but the token is not initialized yet. Session-based actions stay disabled until initialization completes.";
+}

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -415,6 +415,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
             Pkcs11SlotId slotId = slots[i];
             Pkcs11SlotInfo slotInfo = module.GetSlotInfo(slotId);
             bool hasToken = module.TryGetTokenInfo(slotId, out Pkcs11TokenInfo tokenInfo);
+            bool tokenInitialized = hasToken && tokenInfo.Flags.HasFlag(Pkcs11TokenFlags.TokenInitialized);
             int mechanismCount = 0;
             try
             {
@@ -432,6 +433,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
                 slotInfo.ManufacturerId,
                 slotInfo.Flags.ToString(),
                 hasToken,
+                tokenInitialized,
                 hasToken ? tokenInfo.Label : null,
                 hasToken ? tokenInfo.Model : null,
                 hasToken ? tokenInfo.SerialNumber : null,
@@ -1650,6 +1652,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
     private static SessionOpenResult OpenCompatibleSession(Pkcs11Module module, Pkcs11SlotId slotId, bool readWriteRequested, List<string>? notes = null)
     {
+        EnsureSlotSupportsSessionOpen(module, slotId);
+
         try
         {
             return new(module.OpenSession(slotId, readWriteRequested), readWriteRequested, readWriteRequested, EscalatedToReadWrite: false);
@@ -1658,6 +1662,21 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         {
             notes?.Add("The module rejected a read-only C_OpenSession request with CKR_FUNCTION_FAILED, so the admin layer retried with a read-write session for compatibility.");
             return new(module.OpenSession(slotId, readWrite: true), readWriteRequested, OpenedReadWrite: true, EscalatedToReadWrite: true);
+        }
+    }
+
+    private static void EnsureSlotSupportsSessionOpen(Pkcs11Module module, Pkcs11SlotId slotId)
+    {
+        Pkcs11SlotInfo slotInfo = module.GetSlotInfo(slotId);
+        if (!slotInfo.Flags.HasFlag(Pkcs11SlotFlags.TokenPresent))
+        {
+            throw new InvalidOperationException($"Slot {slotId.Value} has no token present, so session-based actions are unavailable.");
+        }
+
+        if (module.TryGetTokenInfo(slotId, out Pkcs11TokenInfo tokenInfo) &&
+            !tokenInfo.Flags.HasFlag(Pkcs11TokenFlags.TokenInitialized))
+        {
+            throw new InvalidOperationException($"Slot {slotId.Value} reports a token, but it is not initialized yet. Initialize the token before opening sessions or running session-based operations.");
         }
     }
 

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
@@ -83,16 +83,17 @@
         <div class="col-xl-3 col-md-6">
             <div class="card shadow-sm h-100 metric-card">
                 <div class="card-body">
-                    <div class="metric-label">Token present</div>
-                    <div class="display-6 metric-meta">@_slots.Count(slot => slot.TokenPresent)</div>
+                    <div class="metric-label">Session ready</div>
+                    <div class="display-6 metric-meta">@_slots.Count(slot => slot.CanOpenSessions)</div>
                 </div>
             </div>
         </div>
         <div class="col-xl-3 col-md-6">
             <div class="card shadow-sm h-100 metric-card">
                 <div class="card-body">
-                    <div class="metric-label">No token</div>
-                    <div class="display-6 metric-meta">@_slots.Count(slot => !slot.TokenPresent)</div>
+                    <div class="metric-label">Setup required</div>
+                    <div class="display-6 metric-meta">@_slots.Count(slot => slot.RequiresInitialization)</div>
+                    <div class="small metric-note">Token visible, not yet session-usable</div>
                 </div>
             </div>
         </div>
@@ -163,9 +164,21 @@
                             <td>
                                 @if (slot.TokenPresent)
                                 {
-                                    <div class="fw-semibold">@slot.TokenLabel</div>
-                                    <div class="small text-muted">@slot.TokenModel · @slot.TokenSerialNumber</div>
-                                    <span class="badge text-bg-success mt-1">Token present</span>
+                                    <div class="fw-semibold">@GetTokenDisplayLabel(slot)</div>
+                                    @if (HasTokenMetadata(slot))
+                                    {
+                                        <div class="small text-muted">@FormatTokenMetadata(slot)</div>
+                                    }
+
+                                    @if (slot.CanOpenSessions)
+                                    {
+                                        <span class="badge text-bg-success mt-1">Session ready</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge text-bg-warning text-dark mt-1">Setup required</span>
+                                        <div class="small text-muted mt-1">@slot.SessionOpenUnavailableReason</div>
+                                    }
                                 }
                                 else
                                 {
@@ -178,10 +191,10 @@
                             </td>
                             <td><span class="table-pill">@slot.MechanismCount mechanism(s)</span></td>
                             <td class="text-end">
-                                <div class="btn-group btn-group-sm">
-                                    <button class="btn btn-outline-primary" @onclick="() => OpenSessionAsync(slot, false)" disabled="@(!_isOperator)">Open RO</button>
-                                    <button class="btn btn-outline-warning" @onclick="() => OpenSessionAsync(slot, true)" disabled="@(!_isOperator)">Open RW</button>
-                                    <button class="btn btn-outline-danger" @onclick="() => CloseAllAsync(slot)" disabled="@(!_isOperator)">Close All</button>
+                                <div class="btn-group btn-group-sm" title="@GetSlotActionDisabledReason(slot)">
+                                    <button class="btn btn-outline-primary" @onclick="() => OpenSessionAsync(slot, false)" disabled="@(!_isOperator || !slot.CanOpenSessions)">Open RO</button>
+                                    <button class="btn btn-outline-warning" @onclick="() => OpenSessionAsync(slot, true)" disabled="@(!_isOperator || !slot.CanOpenSessions)">Open RW</button>
+                                    <button class="btn btn-outline-danger" @onclick="() => CloseAllAsync(slot)" disabled="@(!_isOperator || !slot.CanOpenSessions)">Close All</button>
                                 </div>
                             </td>
                         </tr>
@@ -309,6 +322,13 @@
 
     private async Task OpenSessionAsync(HsmSlotSummary slot, bool readWrite)
     {
+        if (!slot.CanOpenSessions)
+        {
+            _statusMessage = slot.SessionOpenUnavailableReason;
+            _statusIsError = true;
+            return;
+        }
+
         try
         {
             AdminSessionSnapshot snapshot = await Admin.OpenSessionAsync(slot.DeviceId, slot.SlotId, readWrite, _userPin);
@@ -325,6 +345,13 @@
 
     private async Task CloseAllAsync(HsmSlotSummary slot)
     {
+        if (!slot.CanOpenSessions)
+        {
+            _statusMessage = slot.SessionOpenUnavailableReason;
+            _statusIsError = true;
+            return;
+        }
+
         try
         {
             await Admin.CloseAllSessionsAsync(slot.DeviceId, slot.SlotId);
@@ -393,6 +420,22 @@
             "mechanisms" => slots.OrderByDescending(slot => slot.MechanismCount).ThenBy(slot => slot.SlotId),
             _ => slots.OrderBy(slot => slot.SlotId)
         };
+
+    private static string GetTokenDisplayLabel(HsmSlotSummary slot)
+        => !string.IsNullOrWhiteSpace(slot.TokenLabel)
+            ? slot.TokenLabel
+            : slot.RequiresInitialization
+                ? "Uninitialized token"
+                : "Unnamed token";
+
+    private static bool HasTokenMetadata(HsmSlotSummary slot)
+        => !string.IsNullOrWhiteSpace(slot.TokenModel) || !string.IsNullOrWhiteSpace(slot.TokenSerialNumber);
+
+    private static string FormatTokenMetadata(HsmSlotSummary slot)
+        => string.Join(" · ", new[] { slot.TokenModel, slot.TokenSerialNumber }.Where(value => !string.IsNullOrWhiteSpace(value)));
+
+    private static string? GetSlotActionDisabledReason(HsmSlotSummary slot)
+        => slot.CanOpenSessions ? null : slot.SessionOpenUnavailableReason;
 
     private static bool Contains(string? value, string term)
         => value?.Contains(term, StringComparison.OrdinalIgnoreCase) == true;

--- a/tests/Pkcs11Wrapper.Admin.E2E/Program.cs
+++ b/tests/Pkcs11Wrapper.Admin.E2E/Program.cs
@@ -154,7 +154,31 @@ internal static class AdminRuntimeE2E
         await WaitForVisibleAsync(page, "[data-testid='slots-device']");
         await WaitForTextAsync(page.Locator("[data-testid='slots-device']"), config.DeviceName, 15000);
         await WaitForVisibleAsync(page, "[data-testid='slots-load']");
-        logStep("Slots: page loaded with seeded device context");
+        await page.SelectOptionAsync("[data-testid='slots-device']", new[] { new SelectOptionValue { Label = config.DeviceName } });
+        await page.ClickAsync("[data-testid='slots-load']");
+        await WaitForTextAsync(page.Locator("[data-testid='slots-status']"), "Loaded ", 15000);
+        await WaitForCountAtLeastAsync(page.Locator("[data-testid='slots-table'] tbody tr"), 1, 15000);
+
+        ILocator setupRequiredRows = page.Locator("[data-testid='slots-table'] tbody tr").Filter(new LocatorFilterOptions
+        {
+            Has = page.Locator("span:has-text('Setup required')")
+        });
+
+        await WaitForCountAtLeastAsync(setupRequiredRows, 1, 15000);
+        ILocator setupRequiredRow = setupRequiredRows.First;
+        await WaitForTextAsync(setupRequiredRow, "not initialized", 15000);
+
+        if (!await setupRequiredRow.Locator("button:has-text('Open RO')").IsDisabledAsync())
+        {
+            throw new InvalidOperationException("Expected the Setup required slot to disable the Open RO action.");
+        }
+
+        if (!await setupRequiredRow.Locator("button:has-text('Open RW')").IsDisabledAsync())
+        {
+            throw new InvalidOperationException("Expected the Setup required slot to disable the Open RW action.");
+        }
+
+        logStep("Slots: loaded inventory and verified setup-required slots are not directly actionable");
     }
 
     private static async Task ExerciseKeysAsync(IPage page, TestConfig config, List<string> eventLog, Action<string> logStep)

--- a/tests/Pkcs11Wrapper.Admin.Tests/HsmSlotSummaryTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/HsmSlotSummaryTests.cs
@@ -1,0 +1,72 @@
+using Pkcs11Wrapper.Admin.Application.Models;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class HsmSlotSummaryTests
+{
+    [Fact]
+    public void InitializedTokenEnablesSessionActions()
+    {
+        HsmSlotSummary slot = new(
+            Guid.NewGuid(),
+            7,
+            "SoftHSM slot",
+            "SoftHSM project",
+            "TokenPresent",
+            TokenPresent: true,
+            TokenInitialized: true,
+            TokenLabel: "Pkcs11Wrapper CI Token",
+            TokenModel: "SoftHSM v2",
+            TokenSerialNumber: "123456",
+            TokenFlags: "TokenInitialized, UserPinInitialized",
+            MechanismCount: 12);
+
+        Assert.True(slot.CanOpenSessions);
+        Assert.False(slot.RequiresInitialization);
+        Assert.Equal(string.Empty, slot.SessionOpenUnavailableReason);
+    }
+
+    [Fact]
+    public void UninitializedTokenRequiresSetupBeforeSessionActions()
+    {
+        HsmSlotSummary slot = new(
+            Guid.NewGuid(),
+            3,
+            "SoftHSM slot ID 0x3",
+            "SoftHSM project",
+            "TokenPresent",
+            TokenPresent: true,
+            TokenInitialized: false,
+            TokenLabel: string.Empty,
+            TokenModel: "SoftHSM v2",
+            TokenSerialNumber: string.Empty,
+            TokenFlags: "None",
+            MechanismCount: 0);
+
+        Assert.False(slot.CanOpenSessions);
+        Assert.True(slot.RequiresInitialization);
+        Assert.Contains("not initialized", slot.SessionOpenUnavailableReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MissingTokenReportsSessionActionsUnavailable()
+    {
+        HsmSlotSummary slot = new(
+            Guid.NewGuid(),
+            9,
+            "Empty slot",
+            "SoftHSM project",
+            "None",
+            TokenPresent: false,
+            TokenInitialized: false,
+            TokenLabel: null,
+            TokenModel: null,
+            TokenSerialNumber: null,
+            TokenFlags: null,
+            MechanismCount: 0);
+
+        Assert.False(slot.CanOpenSessions);
+        Assert.False(slot.RequiresInitialization);
+        Assert.Contains("no token", slot.SessionOpenUnavailableReason, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Pkcs11Wrapper.Native.Tests/SoftHsmCryptRegressionTests.cs
+++ b/tests/Pkcs11Wrapper.Native.Tests/SoftHsmCryptRegressionTests.cs
@@ -27,6 +27,7 @@ public sealed class SoftHsmCryptRegressionTests
     private const nuint CkrKeyUnwrappable = 0x00000067u;
     private const nuint CkrKeyFunctionNotPermitted = 0x00000068u;
     private const nuint CkrObjectHandleInvalid = 0x00000082u;
+    private const nuint CkrTokenNotRecognized = 0x000000e1u;
 
     [Fact]
     public void InterfaceDiscoveryGracefullyReportsAbsentOnSoftHsm()
@@ -1743,6 +1744,24 @@ public sealed class SoftHsmCryptRegressionTests
 
         using Pkcs11Session replacementSession = activeContext.Module.OpenSession(activeContext.SlotId);
         Assert.Equal(activeContext.SlotId, replacementSession.GetInfo().SlotId);
+    }
+
+    [Fact]
+    public void UninitializedSoftHsmSlotCanAdvertiseTokenPresenceButRejectSessionOpen()
+    {
+        if (!TryCreateProvisioningContext(out ProvisioningContext? context))
+        {
+            return;
+        }
+
+        using ProvisioningContext activeContext = context!;
+        Pkcs11SlotInfo slotInfo = activeContext.Module.GetSlotInfo(activeContext.SlotId);
+        Assert.True(slotInfo.Flags.HasFlag(Pkcs11SlotFlags.TokenPresent));
+        Assert.True(activeContext.Module.TryGetTokenInfo(activeContext.SlotId, out Pkcs11TokenInfo tokenInfo));
+        Assert.False(tokenInfo.Flags.HasFlag(Pkcs11TokenFlags.TokenInitialized));
+
+        Pkcs11Exception exception = Assert.Throws<Pkcs11Exception>(() => activeContext.Module.OpenSession(activeContext.SlotId));
+        Assert.Equal(CkrTokenNotRecognized, exception.Result.Value);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Handle uninitialized SoftHSM slots more honestly in the admin UI.

## Included work
- distinguish session-ready tokens from setup-required/uninitialized tokens
- disable direct session-open actions for slots that advertise token presence but reject session open
- add server-side guard for session-based operations on uninitialized token slots
- add regression coverage across admin/native/E2E paths

## Notes
- fixes the real runtime issue found in issue #91
- keeps the UI from presenting unusable slots as straightforward actionable success cases

## Closes
Closes #91
