### PR TITLE
Harden admin and Crypto API security defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ For the intended boundary/runtime model, scale-out expectations, state-sharing r
 
 - [docs/crypto-api-deployment.md](docs/crypto-api-deployment.md)
 - [docs/crypto-api-host.md](docs/crypto-api-host.md)
+- [docs/security-review-issue-112.md](docs/security-review-issue-112.md)
 
 ### 2c) Build and run the container image
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -234,6 +234,7 @@ Admin panel, core wrapper'ın içine gömülmek yerine **kütüphanenin üstünd
 - [docs/benchmarks.md](docs/benchmarks.md) - benchmark kapsamı, tekrar çalıştırma akışı, periyodik takip modeli
 - [docs/benchmarks/latest-linux-softhsm.md](docs/benchmarks/latest-linux-softhsm.md) - güncel commitlenmiş Linux benchmark baseline'ı
 - [docs/crypto-api-host.md](docs/crypto-api-host.md) - stateless Crypto API host sınırı, çalışma modeli, konfigürasyon ve mevcut iskelet endpoint'leri
+- [docs/security-review-issue-112.md](docs/security-review-issue-112.md) - issue #112 için ürün yüzeyi güvenlik incelemesi, yapılan sertleştirmeler ve açık kalan sınırlar
 - [docs/admin-ops-recovery.md](docs/admin-ops-recovery.md) - lokal admin-panel operasyon ve recovery rehberi
 - [docs/vendor-regression.md](docs/vendor-regression.md) - vendor uyumluluk profili ve env sözleşmesi
 - [docs/luna-integration.md](docs/luna-integration.md) - wrapper, admin panel, smoke ve vendor regression için pratik Thales Luna client/module kurulum rehberi

--- a/deploy/container/crypto-api.env.example
+++ b/deploy/container/crypto-api.env.example
@@ -30,3 +30,8 @@ CryptoApiRuntime__UserPin=ChangeMe
 CryptoApiSharedPersistence__Provider=Sqlite
 CryptoApiSharedPersistence__ConnectionString=Data Source=/var/lib/pkcs11wrapper-cryptoapi/shared-state.db
 CryptoApiSharedPersistence__AutoInitialize=true
+
+# Keep verbose auth/shared-state diagnostics disabled on exposed deployments.
+# Enable only for tightly controlled internal troubleshooting.
+CryptoApiSecurity__ExposeDetailedErrors=false
+CryptoApiSecurity__ExposeSharedStateDetails=false

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -176,10 +176,33 @@ Useful endpoints:
 - `POST /api/v1/operations/verify` using `X-Api-Key-Id` + `X-Api-Key-Secret` with `{ "keyAlias": "payments-signer", "algorithm": "RS256", "payloadBase64": "aGVsbG8=", "signatureBase64": "..." }`
 - `POST /api/v1/operations/random` using `X-Api-Key-Id` + `X-Api-Key-Secret` with `{ "keyAlias": "payments-signer", "length": 32 }`
 
-`/api/v1/shared-state` returns provider/schema/count metadata when the shared store is configured and available.
+`/api/v1/shared-state` returns a reduced public summary by default. Detailed connection-target and count metadata stay hidden unless you explicitly enable `CryptoApiSecurity:ExposeSharedStateDetails`.
 `/api/v1/auth/self` validates the hashed shared secret, enforces disabled / revoked / expired state, updates last-used metadata, and returns the authenticated client context that future crypto operations can reuse.
 `POST /api/v1/operations/authorize` remains the low-level alias/policy check.
 `POST /api/v1/operations/sign`, `verify`, and `random` reuse that same authentication + authorization model and keep the public contract stable and customer-facing: callers provide alias names, high-level algorithms such as `RS256` / `PS256` / `ES256` / `HS256`, and base64 payloads instead of raw PKCS#11 device/slot/handle details.
+
+
+### Crypto API security defaults
+
+The host now defaults to a safer public diagnostic posture:
+
+```json
+"CryptoApiSecurity": {
+  "ExposeDetailedErrors": false,
+  "ExposeSharedStateDetails": false
+}
+```
+
+That means:
+
+- auth failures return generic rejection text by default
+- alias/policy authorization failures return generic access-denied text by default
+- `/api/v1/shared-state` omits the SQLite path/connection target and record counts by default
+
+For private/internal troubleshooting, operators can opt back into the verbose behavior with:
+
+- `CryptoApiSecurity__ExposeDetailedErrors=true`
+- `CryptoApiSecurity__ExposeSharedStateDetails=true`
 
 ## Intentionally out of scope for this issue
 

--- a/docs/security-review-issue-112.md
+++ b/docs/security-review-issue-112.md
@@ -1,0 +1,118 @@
+# Security review and hardening notes for issue #112
+
+This note captures the focused product-surface security pass completed for issue #112.
+It is intentionally about the shipped **admin dashboard + Crypto API product boundary**, not host hardening.
+
+## Review scope
+
+Reviewed surfaces:
+
+- admin dashboard authentication and session handling
+- customer-facing Crypto API authentication and alias/policy authorization
+- API key handling and public error behavior
+- shared SQLite-backed control-plane persistence exposure
+- exposed HTTP endpoints and container/operator-facing defaults
+- operator-facing docs for the above behavior
+
+## Concrete gaps identified
+
+### 1. Public Crypto API diagnostics leaked more than necessary
+
+The customer-facing host exposed:
+
+- detailed API-key authentication failure reasons (`not found`, `revoked`, `expired`, etc.)
+- detailed key-alias authorization failure reasons (`alias not found`, policy mismatch, invalid stored policy document)
+- shared-state metadata including SQLite connection target/path and record counts
+
+That was useful for private debugging, but too chatty as a default internet-facing or semi-exposed API surface.
+It increased enumeration and deployment-fingerprint leakage without being required for normal clients.
+
+### 2. Admin login/logout endpoints needed explicit request verification
+
+The admin dashboard already rendered antiforgery tokens in forms, but the `/account/login` and `/account/logout` minimal endpoints were manually reading forms and did not explicitly validate the antiforgery token at the endpoint boundary.
+
+### 3. Admin HTTP responses were missing a few low-cost browser hardening defaults
+
+The admin UI did not consistently emit response headers that reduce common browser-side attack surface:
+
+- clickjacking protection
+- MIME sniffing suppression
+- referrer suppression
+- cache suppression on especially sensitive auth/export routes
+
+### 4. Admin auth cookie defaults could be tightened
+
+Cookie auth was functional, but the configuration did not explicitly lock in:
+
+- `HttpOnly`
+- `SameSite=Lax`
+- request-aware secure cookie policy
+- bounded session lifetime
+
+## Fixes applied
+
+### Crypto API
+
+Added `CryptoApiSecurity` configuration with secure-by-default behavior:
+
+```json
+"CryptoApiSecurity": {
+  "ExposeDetailedErrors": false,
+  "ExposeSharedStateDetails": false
+}
+```
+
+Default behavior now:
+
+- authentication failures return a generic rejection message
+- authorization failures return a generic access-denied message
+- `/api/v1/shared-state` returns a reduced public document without connection target or record counts
+
+Private/internal operators can still opt back into the previous verbose diagnostics by setting:
+
+- `CryptoApiSecurity__ExposeDetailedErrors=true`
+- `CryptoApiSecurity__ExposeSharedStateDetails=true`
+
+### Admin dashboard
+
+Hardened the local-cookie auth surface by:
+
+- explicitly validating antiforgery tokens on login/logout POST endpoints
+- returning a clean `400` problem response when the token is missing/invalid
+- setting cookie auth defaults to `HttpOnly`, `SameSite=Lax`, and an 8-hour session lifetime
+- adding response hardening headers:
+  - `X-Frame-Options: DENY`
+  - `X-Content-Type-Options: nosniff`
+  - `Referrer-Policy: no-referrer`
+  - `Permissions-Policy: camera=(), geolocation=(), microphone=()`
+- disabling caching on login/account/export routes
+
+## Remaining risks and honest boundaries
+
+These are **not** fixed by this issue and should remain explicit in docs/roadmap discussions:
+
+1. **Local admin auth is still local-user/cookie based.**
+   There is still no MFA, external IdP, SSO, hardware-backed admin auth, or centralized session revocation.
+
+2. **Login throttling is still in-memory per process.**
+   It helps against casual brute force but resets on process restart and is not shared across multiple admin instances.
+
+3. **Crypto API rate limiting is still not built in.**
+   Upstream gateways/load balancers should still enforce request-rate, body-size, and abuse controls.
+
+4. **SQLite is still the shared control-plane backend.**
+   That remains acceptable only for the documented conservative deployment model with trustworthy file-locking/WAL semantics.
+
+5. **Security headers are intentionally conservative.**
+   A strict CSP was not added in this pass because the current interactive admin UI would need CSP-specific tuning/testing rather than a guessy header that could break the product.
+
+6. **No active Swagger/OpenAPI generator was found in the current tree.**
+   If a Swagger/OpenAPI surface is added later, it should be treated as another public attack surface and gated appropriately rather than assumed safe by default.
+
+## Validation expectation for this issue
+
+Validation should include at least:
+
+- targeted Crypto API route tests for generic error behavior and sanitized shared-state output
+- admin integration tests proving hardening headers are present and tokenless login POSTs fail
+- normal repo build/test validation for the touched projects

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -30,7 +30,11 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     {
         options.LoginPath = "/login";
         options.AccessDeniedPath = "/forbidden";
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SameSite = SameSiteMode.Lax;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
         options.SlidingExpiration = true;
+        options.ExpireTimeSpan = TimeSpan.FromHours(8);
     });
 
 builder.Services.AddAuthorizationBuilder()
@@ -125,6 +129,7 @@ if (!runtimeOptions.DisableHttpsRedirection)
     app.UseHttpsRedirection();
 }
 
+app.UseAdminSecurityResponseHeaders();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseAntiforgery();
@@ -149,3 +154,5 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
 app.Run();
+
+public partial class Program;

--- a/src/Pkcs11Wrapper.Admin.Web/Security/AccountEndpoints.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Security/AccountEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Pkcs11Wrapper.Admin.Application.Models;
@@ -9,6 +10,12 @@ public static class AccountEndpoints
 {
     public static async Task<IResult> LoginAsync(HttpContext context, LocalAdminLoginService loginService)
     {
+        IResult? antiforgeryFailure = await ValidateAntiforgeryAsync(context);
+        if (antiforgeryFailure is not null)
+        {
+            return antiforgeryFailure;
+        }
+
         IFormCollection form = await context.Request.ReadFormAsync();
         string username = form["username"].ToString();
         string password = form["password"].ToString();
@@ -33,9 +40,33 @@ public static class AccountEndpoints
 
     public static async Task<IResult> LogoutAsync(HttpContext context, LocalAdminLoginService loginService)
     {
+        IResult? antiforgeryFailure = await ValidateAntiforgeryAsync(context);
+        if (antiforgeryFailure is not null)
+        {
+            return antiforgeryFailure;
+        }
+
         string? userName = context.User.Identity?.Name;
         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         await loginService.WriteLogoutAsync(userName, context.RequestAborted);
         return Results.LocalRedirect("/login");
+    }
+
+    private static async Task<IResult?> ValidateAntiforgeryAsync(HttpContext context)
+    {
+        IAntiforgery antiforgery = context.RequestServices.GetRequiredService<IAntiforgery>();
+
+        try
+        {
+            await antiforgery.ValidateRequestAsync(context);
+            return null;
+        }
+        catch (AntiforgeryValidationException)
+        {
+            return Results.Problem(
+                title: "Request verification failed.",
+                detail: "The admin request is missing a valid antiforgery token.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
     }
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Security/AdminSecurityResponseHeadersExtensions.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Security/AdminSecurityResponseHeadersExtensions.cs
@@ -1,0 +1,38 @@
+namespace Pkcs11Wrapper.Admin.Web.Security;
+
+public static class AdminSecurityResponseHeadersExtensions
+{
+    public static IApplicationBuilder UseAdminSecurityResponseHeaders(this IApplicationBuilder app)
+        => app.Use(async (context, next) =>
+        {
+            bool disableCaching = IsSensitivePath(context.Request.Path);
+
+            context.Response.OnStarting(static state =>
+            {
+                (HttpContext httpContext, bool noStore) = ((HttpContext, bool))state;
+                IHeaderDictionary headers = httpContext.Response.Headers;
+
+                headers["X-Frame-Options"] = "DENY";
+                headers["X-Content-Type-Options"] = "nosniff";
+                headers["Referrer-Policy"] = "no-referrer";
+                headers["Permissions-Policy"] = "camera=(), geolocation=(), microphone=()";
+
+                if (noStore)
+                {
+                    headers["Cache-Control"] = "no-store, max-age=0";
+                    headers["Pragma"] = "no-cache";
+                    headers["Expires"] = "0";
+                }
+
+                return Task.CompletedTask;
+            }, (context, disableCaching));
+
+            await next();
+        });
+
+    private static bool IsSensitivePath(PathString path)
+        => path.StartsWithSegments("/login", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWithSegments("/account", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWithSegments("/configuration/export", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWithSegments("/telemetry/export", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Pkcs11Wrapper.CryptoApi/Configuration/CryptoApiSecurityOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Configuration/CryptoApiSecurityOptions.cs
@@ -1,0 +1,10 @@
+namespace Pkcs11Wrapper.CryptoApi.Configuration;
+
+public sealed class CryptoApiSecurityOptions
+{
+    public const string SectionName = "CryptoApiSecurity";
+
+    public bool ExposeDetailedErrors { get; set; }
+
+    public bool ExposeSharedStateDetails { get; set; }
+}

--- a/src/Pkcs11Wrapper.CryptoApi/Endpoints/CryptoApiRouteBuilderExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Endpoints/CryptoApiRouteBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace Pkcs11Wrapper.CryptoApi.Endpoints;
 
 public static class CryptoApiRouteBuilderExtensions
 {
-    public static IEndpointRouteBuilder MapCryptoApiRoutes(this IEndpointRouteBuilder endpoints, CryptoApiHostOptions hostOptions)
+    public static IEndpointRouteBuilder MapCryptoApiRoutes(this IEndpointRouteBuilder endpoints, CryptoApiHostOptions hostOptions, CryptoApiSecurityOptions securityOptions)
     {
         string apiBasePath = CryptoApiHostDefaults.NormalizeBasePath(hostOptions.ApiBasePath);
         RouteGroupBuilder group = endpoints.MapGroup(apiBasePath)
@@ -54,20 +54,20 @@ public static class CryptoApiRouteBuilderExtensions
                 ["POST /operations/authorize", "POST /operations/sign", "POST /operations/verify", "POST /operations/random"]));
         });
 
-        group.MapGet("/shared-state", static async Task<IResult> (ICryptoApiSharedStateStore sharedStateStore, CancellationToken cancellationToken) =>
+        group.MapGet("/shared-state", async Task<IResult> (ICryptoApiSharedStateStore sharedStateStore, CancellationToken cancellationToken) =>
         {
             CryptoApiSharedStateStatus status = await sharedStateStore.GetStatusAsync(cancellationToken);
             return status.Configured
-                ? Results.Ok(status)
+                ? Results.Ok(securityOptions.ExposeSharedStateDetails ? status : ToPublicSharedStateDocument(status))
                 : Results.Problem(
                     title: "Shared persistence is not configured.",
                     detail: "Configure CryptoApiSharedPersistence:ConnectionString to enable shared API client/key, alias, and policy state.",
                     statusCode: StatusCodes.Status503ServiceUnavailable);
         });
 
-        group.MapGet("/auth/self", static async Task<IResult> (HttpContext httpContext, CryptoApiClientAuthenticationService authenticationService, CancellationToken cancellationToken) =>
+        group.MapGet("/auth/self", async Task<IResult> (HttpContext httpContext, CryptoApiClientAuthenticationService authenticationService, CancellationToken cancellationToken) =>
         {
-            AuthenticationAttempt authentication = await AuthenticateAsync(httpContext, authenticationService, cancellationToken);
+            AuthenticationAttempt authentication = await AuthenticateAsync(httpContext, authenticationService, securityOptions, cancellationToken);
             if (authentication.Error is not null)
             {
                 return authentication.Error;
@@ -77,7 +77,7 @@ public static class CryptoApiRouteBuilderExtensions
             return Results.Ok(ToAuthenticatedClientDocument(client));
         });
 
-        group.MapPost("/operations/authorize", static async Task<IResult> (
+        group.MapPost("/operations/authorize", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiAuthorizeKeyOperationRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -90,6 +90,7 @@ public static class CryptoApiRouteBuilderExtensions
                 request.Operation,
                 authenticationService,
                 authorizationService,
+                securityOptions,
                 cancellationToken);
 
             if (authorization.Error is not null)
@@ -110,7 +111,7 @@ public static class CryptoApiRouteBuilderExtensions
                     .ToArray()));
         });
 
-        group.MapPost("/operations/sign", static async Task<IResult> (
+        group.MapPost("/operations/sign", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiSignRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -124,6 +125,7 @@ public static class CryptoApiRouteBuilderExtensions
                 "sign",
                 authenticationService,
                 authorizationService,
+                securityOptions,
                 cancellationToken);
 
             if (authorization.Error is not null)
@@ -149,7 +151,7 @@ public static class CryptoApiRouteBuilderExtensions
             }
         });
 
-        group.MapPost("/operations/verify", static async Task<IResult> (
+        group.MapPost("/operations/verify", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiVerifyRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -163,6 +165,7 @@ public static class CryptoApiRouteBuilderExtensions
                 "verify",
                 authenticationService,
                 authorizationService,
+                securityOptions,
                 cancellationToken);
 
             if (authorization.Error is not null)
@@ -187,7 +190,7 @@ public static class CryptoApiRouteBuilderExtensions
             }
         });
 
-        group.MapPost("/operations/random", static async Task<IResult> (
+        group.MapPost("/operations/random", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiRandomRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -201,6 +204,7 @@ public static class CryptoApiRouteBuilderExtensions
                 "random",
                 authenticationService,
                 authorizationService,
+                securityOptions,
                 cancellationToken);
 
             if (authorization.Error is not null)
@@ -231,6 +235,7 @@ public static class CryptoApiRouteBuilderExtensions
     private static async Task<AuthenticationAttempt> AuthenticateAsync(
         HttpContext httpContext,
         CryptoApiClientAuthenticationService authenticationService,
+        CryptoApiSecurityOptions securityOptions,
         CancellationToken cancellationToken)
     {
         string? keyIdentifier = httpContext.Request.Headers[CryptoApiAuthenticationDefaults.ApiKeyIdHeaderName].ToString();
@@ -242,7 +247,9 @@ public static class CryptoApiRouteBuilderExtensions
                 null,
                 Results.Problem(
                     title: "API key authentication failed.",
-                    detail: result.FailureReason,
+                    detail: securityOptions.ExposeDetailedErrors
+                        ? result.FailureReason
+                        : "The provided API credentials were rejected.",
                     statusCode: StatusCodes.Status401Unauthorized));
         }
 
@@ -255,9 +262,10 @@ public static class CryptoApiRouteBuilderExtensions
         string? operation,
         CryptoApiClientAuthenticationService authenticationService,
         CryptoApiKeyOperationAuthorizationService authorizationService,
+        CryptoApiSecurityOptions securityOptions,
         CancellationToken cancellationToken)
     {
-        AuthenticationAttempt authentication = await AuthenticateAsync(httpContext, authenticationService, cancellationToken);
+        AuthenticationAttempt authentication = await AuthenticateAsync(httpContext, authenticationService, securityOptions, cancellationToken);
         if (authentication.Error is not null)
         {
             return new AuthorizationAttempt(null, authentication.Error);
@@ -277,7 +285,9 @@ public static class CryptoApiRouteBuilderExtensions
                     null,
                     Results.Problem(
                         title: "Key alias authorization failed.",
-                        detail: authorization.FailureReason,
+                        detail: securityOptions.ExposeDetailedErrors
+                            ? authorization.FailureReason
+                            : "The caller is not allowed to use the requested key alias or operation.",
                         statusCode: StatusCodes.Status403Forbidden));
             }
 
@@ -304,6 +314,13 @@ public static class CryptoApiRouteBuilderExtensions
             InvalidOperationException ex => Results.Problem(title: title, detail: ex.Message, statusCode: StatusCodes.Status422UnprocessableEntity),
             _ => Results.Problem(title: title, detail: "The Crypto API host could not complete the request.", statusCode: StatusCodes.Status500InternalServerError)
         };
+
+    private static CryptoApiPublicSharedStateDocument ToPublicSharedStateDocument(CryptoApiSharedStateStatus status)
+        => new(
+            status.Configured,
+            status.Provider,
+            status.SchemaVersion,
+            status.SharedReadyAreas);
 
     private static CryptoApiAuthenticatedClientDocument ToAuthenticatedClientDocument(CryptoApiAuthenticatedClient client)
         => new(
@@ -343,6 +360,12 @@ public static class CryptoApiRouteBuilderExtensions
         IReadOnlyList<string> CurrentOperations,
         IReadOnlyList<string> PlannedOperations,
         IReadOnlyList<string> CurrentEndpoints);
+
+    private sealed record CryptoApiPublicSharedStateDocument(
+        bool Configured,
+        string Provider,
+        int SchemaVersion,
+        IReadOnlyList<string> SharedReadyAreas);
 
     private sealed record CryptoApiAuthenticatedClientDocument(
         Guid ClientId,

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -33,6 +33,9 @@ builder.Services.AddOptions<CryptoApiRuntimeOptions>()
         options.UserPin = options.UserPin?.Trim();
     });
 
+builder.Services.AddOptions<CryptoApiSecurityOptions>()
+    .Bind(builder.Configuration.GetSection(CryptoApiSecurityOptions.SectionName));
+
 builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
     .Bind(builder.Configuration.GetSection(CryptoApiSharedPersistenceOptions.SectionName))
     .PostConfigure(static options =>
@@ -62,6 +65,7 @@ builder.Services.AddHealthChecks()
 WebApplication app = builder.Build();
 CryptoApiHostOptions hostOptions = app.Services.GetRequiredService<IOptions<CryptoApiHostOptions>>().Value;
 CryptoApiRuntimeOptions runtimeOptions = app.Services.GetRequiredService<IOptions<CryptoApiRuntimeOptions>>().Value;
+CryptoApiSecurityOptions securityOptions = app.Services.GetRequiredService<IOptions<CryptoApiSecurityOptions>>().Value;
 CryptoApiSharedPersistenceOptions sharedPersistenceOptions = app.Services.GetRequiredService<IOptions<CryptoApiSharedPersistenceOptions>>().Value;
 
 if (!app.Environment.IsDevelopment())
@@ -110,7 +114,7 @@ app.MapHealthChecks(CryptoApiHostDefaults.HealthReadyPath, new HealthCheckOption
     Predicate = static registration => registration.Tags.Contains("ready", StringComparer.Ordinal),
     ResponseWriter = CryptoApiHealthResponseWriter.WriteAsync
 });
-app.MapCryptoApiRoutes(hostOptions);
+app.MapCryptoApiRoutes(hostOptions, securityOptions);
 
 app.Run();
 

--- a/src/Pkcs11Wrapper.CryptoApi/appsettings.json
+++ b/src/Pkcs11Wrapper.CryptoApi/appsettings.json
@@ -15,6 +15,10 @@
     "ModulePath": "",
     "UserPin": ""
   },
+  "CryptoApiSecurity": {
+    "ExposeDetailedErrors": false,
+    "ExposeSharedStateDetails": false
+  },
   "CryptoApiSharedPersistence": {
     "Provider": "Sqlite",
     "ConnectionString": "",

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminSecurityIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminSecurityIntegrationTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Pkcs11Wrapper.Admin.Web.Components;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class AdminSecurityIntegrationTests
+{
+    [Fact]
+    public async Task LoginPageIncludesResponseHardeningHeaders()
+    {
+        string rootPath = CreateTempDirectory();
+        await using WebApplicationFactory<App> factory = CreateFactory(rootPath);
+
+        try
+        {
+            using HttpClient client = factory.CreateClient();
+            using HttpResponseMessage response = await client.GetAsync("/login");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("DENY", GetSingleHeaderValue(response.Headers, "X-Frame-Options"));
+            Assert.Equal("nosniff", GetSingleHeaderValue(response.Headers, "X-Content-Type-Options"));
+            Assert.Equal("no-referrer", GetSingleHeaderValue(response.Headers, "Referrer-Policy"));
+            Assert.Equal("no-store, max-age=0", GetSingleHeaderValue(response.Headers, "Cache-Control"));
+        }
+        finally
+        {
+            DeleteDirectory(rootPath);
+        }
+    }
+
+    [Fact]
+    public async Task LoginRejectsPostWithoutAntiforgeryToken()
+    {
+        string rootPath = CreateTempDirectory();
+        await using WebApplicationFactory<App> factory = CreateFactory(rootPath);
+
+        try
+        {
+            using HttpClient client = factory.CreateClient();
+            using FormUrlEncodedContent content = new([
+                new KeyValuePair<string, string>("username", "admin"),
+                new KeyValuePair<string, string>("password", "wrong-password"),
+                new KeyValuePair<string, string>("returnUrl", "/")
+            ]);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+
+            using HttpResponseMessage response = await client.PostAsync("/account/login", content);
+            string body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("missing a valid antiforgery token", body, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteDirectory(rootPath);
+        }
+    }
+
+    private static WebApplicationFactory<App> CreateFactory(string rootPath)
+        => new WebApplicationFactory<App>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+                {
+                    configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["AdminStorage:DataRoot"] = rootPath,
+                        ["AdminRuntime:DisableHttpsRedirection"] = "true"
+                    });
+                });
+            });
+
+    private static string GetSingleHeaderValue(HttpResponseHeaders headers, string name)
+        => Assert.Single(headers.GetValues(name));
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "pkcs11wrapper-admin-security-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11Wrapper.Admin.Tests.csproj
+++ b/tests/Pkcs11Wrapper.Admin.Tests/Pkcs11Wrapper.Admin.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
@@ -109,7 +109,8 @@ public sealed class CryptoApiRoutesTests
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
             string content = await response.Content.ReadAsStringAsync();
-            Assert.Contains("Requested operation is not allowed for this key alias.", content, StringComparison.Ordinal);
+            Assert.Contains("The caller is not allowed to use the requested key alias or operation.", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("Requested operation is not allowed for this key alias.", content, StringComparison.Ordinal);
         }
         finally
         {
@@ -145,6 +146,103 @@ public sealed class CryptoApiRoutesTests
         }
     }
 
+    [Fact]
+    public async Task SharedStateEndpointHidesConnectionTargetAndCountsByDefault()
+    {
+        string databasePath = CreateDatabasePath();
+        await using WebApplicationFactory<Program> factory = CreateFactory(databasePath);
+        try
+        {
+            using HttpClient httpClient = factory.CreateClient();
+            using HttpResponseMessage response = await httpClient.GetAsync("/api/v1/shared-state");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            using JsonDocument json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            JsonElement root = json.RootElement;
+            Assert.True(root.GetProperty("configured").GetBoolean());
+            Assert.Equal("Sqlite", root.GetProperty("provider").GetString());
+            Assert.True(root.TryGetProperty("schemaVersion", out _));
+            Assert.True(root.TryGetProperty("sharedReadyAreas", out _));
+            Assert.False(root.TryGetProperty("connectionTarget", out _));
+            Assert.False(root.TryGetProperty("apiClientCount", out _));
+            Assert.False(root.TryGetProperty("apiClientKeyCount", out _));
+            Assert.False(root.TryGetProperty("keyAliasCount", out _));
+            Assert.False(root.TryGetProperty("policyCount", out _));
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task AuthEndpointsUseGenericFailureDetailsByDefault()
+    {
+        string databasePath = CreateDatabasePath();
+        await using WebApplicationFactory<Program> factory = CreateFactory(databasePath);
+        try
+        {
+            using HttpClient httpClient = factory.CreateClient();
+
+            using HttpResponseMessage authResponse = await httpClient.GetAsync("/api/v1/auth/self");
+            string authContent = await authResponse.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.Unauthorized, authResponse.StatusCode);
+            Assert.Contains("The provided API credentials were rejected.", authContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("API key id and secret are required.", authContent, StringComparison.Ordinal);
+
+            SeededAccess access = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer");
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+            using HttpResponseMessage authorizationResponse = await httpClient.PostAsync(
+                "/api/v1/operations/authorize",
+                CreateJsonContent("{\"keyAlias\":\"missing-alias\",\"operation\":\"sign\"}"));
+
+            string authorizationContent = await authorizationResponse.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.Forbidden, authorizationResponse.StatusCode);
+            Assert.Contains("The caller is not allowed to use the requested key alias or operation.", authorizationContent, StringComparison.Ordinal);
+            Assert.DoesNotContain("Requested key alias was not found.", authorizationContent, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task SecurityOptionsCanRestoreDetailedDiagnosticsForPrivateDeployments()
+    {
+        string databasePath = CreateDatabasePath();
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            databasePath,
+            null,
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiSecurity:ExposeDetailedErrors"] = "true",
+                ["CryptoApiSecurity:ExposeSharedStateDetails"] = "true"
+            });
+
+        try
+        {
+            using HttpClient httpClient = factory.CreateClient();
+
+            using HttpResponseMessage sharedStateResponse = await httpClient.GetAsync("/api/v1/shared-state");
+            string sharedStateContent = await sharedStateResponse.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.OK, sharedStateResponse.StatusCode);
+            Assert.Contains("connectionTarget", sharedStateContent, StringComparison.Ordinal);
+            Assert.Contains("apiClientCount", sharedStateContent, StringComparison.Ordinal);
+
+            using HttpResponseMessage authResponse = await httpClient.GetAsync("/api/v1/auth/self");
+            string authContent = await authResponse.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.Unauthorized, authResponse.StatusCode);
+            Assert.Contains("API key id and secret are required.", authContent, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
     private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, IReadOnlyCollection<string> allowedOperations, string aliasName)
     {
         using IServiceScope scope = factory.Services.CreateScope();
@@ -173,14 +271,14 @@ public sealed class CryptoApiRoutesTests
         return new SeededAccess(client, key, alias, policy);
     }
 
-    private static WebApplicationFactory<Program> CreateFactory(string databasePath, Action<IServiceCollection>? configureServices = null)
+    private static WebApplicationFactory<Program> CreateFactory(string databasePath, Action<IServiceCollection>? configureServices = null, IReadOnlyDictionary<string, string?>? additionalConfiguration = null)
         => new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
                 builder.UseEnvironment("Development");
                 builder.ConfigureAppConfiguration((_, configurationBuilder) =>
                 {
-                    configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    Dictionary<string, string?> configuration = new()
                     {
                         ["CryptoApiHost:ServiceName"] = "Pkcs11Wrapper.CryptoApi.Tests",
                         ["CryptoApiHost:ApiBasePath"] = "/api/v1",
@@ -188,7 +286,17 @@ public sealed class CryptoApiRoutesTests
                         ["CryptoApiSharedPersistence:Provider"] = "Sqlite",
                         ["CryptoApiSharedPersistence:ConnectionString"] = $"Data Source={databasePath}",
                         ["CryptoApiSharedPersistence:AutoInitialize"] = "true"
-                    });
+                    };
+
+                    if (additionalConfiguration is not null)
+                    {
+                        foreach ((string key, string? value) in additionalConfiguration)
+                        {
+                            configuration[key] = value;
+                        }
+                    }
+
+                    configurationBuilder.AddInMemoryCollection(configuration);
                 });
 
                 if (configureServices is not null)


### PR DESCRIPTION
## Summary
Harden the current admin and Crypto API product surface based on a focused security review.

## Included work
- reduce customer-facing diagnostic leakage in the Crypto API
- harden admin login/logout with antiforgery validation
- tighten cookie auth defaults and browser security headers
- disable caching on sensitive auth/export routes
- update docs with the current security posture and remaining boundaries

## Notes
- scoped to practical product hardening, not host hardening
- keeps remaining risks documented honestly where they are not yet addressed

## Closes
Closes #112
