### PR TITLE
Add built-in Crypto API rate limiting

### DIFF
--- a/docs/crypto-api-deployment.md
+++ b/docs/crypto-api-deployment.md
@@ -249,6 +249,29 @@ A good pattern is:
 4. observe HSM/session behavior, readiness stability, and latency tails
 5. scale further only when the external PKCS#11 tier proves it can handle the load
 
+## Built-in rate limiting in a scaled-out topology
+
+The Crypto API host now includes a practical first built-in limiter for `/api/v1/auth/self` and the customer-facing `/api/v1/operations/*` POST routes.
+
+That limiter is intentionally:
+
+- **per instance**
+- **partitioned by presented API key id** (with remote-IP fallback when no key id is present)
+- **zero-queue by default**, so rejected traffic gets immediate `429 Too Many Requests`
+
+What that means operationally:
+
+- if you run one API instance, the built-in limiter gives a real local abuse-control baseline
+- if you run many API instances behind a load balancer, the effective fleet-wide budget is roughly the per-instance budget multiplied by the number of healthy instances that can receive the caller's traffic
+- if you need strict tenant/global quotas, keep enforcing them at the ingress/gateway layer rather than trying to treat the current SQLite control-plane store as a hot-path distributed counter system
+
+This is a deliberate trade-off for the current product shape:
+
+- it protects the machine-facing API immediately
+- it does not add shared-state writes on every request
+- it keeps the stateless-HTTP-worker architecture honest
+- it avoids overselling SQLite as a distributed rate-limit backend
+
 ## Current routing/alias expectations
 
 Today, alias records in shared state can carry:

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -42,6 +42,7 @@ The current slice is still deliberately small, but now includes the first practi
 - customer-facing random endpoint at `/api/v1/operations/random`
 - shared-state descriptor endpoint at `/api/v1/shared-state`
 - authenticated self-introspection endpoint at `/api/v1/auth/self`
+- built-in customer-endpoint rate limiting with predictable `429 Too Many Requests` + `Retry-After` responses
 - liveness endpoint at `/health/live`
 - readiness endpoint at `/health/ready`
 - readiness check that attempts to load the configured PKCS#11 module via `Pkcs11Module.Load(...)`
@@ -145,6 +146,10 @@ Notes:
 - `CryptoApiSharedPersistence:Provider` currently supports only `Sqlite`.
 - `CryptoApiSharedPersistence:ConnectionString` enables the shared state store. If omitted, the host still runs, but `/api/v1/shared-state` reports that shared persistence is not configured.
 - `CryptoApiSharedPersistence:AutoInitialize=true` creates the schema on startup/first use.
+- `CryptoApiRateLimiting` adds built-in limits for `/api/v1/auth/self` and the customer-facing `/api/v1/operations/*` POST routes.
+- The first slice is intentionally **instance-local**, not shared across the fleet. A caller can consume up to the configured budget on each Crypto API instance behind the load balancer.
+- Partitioning is keyed by the presented `X-Api-Key-Id` header when present, with remote-IP fallback when no key id is available.
+- Rejections do not queue by default; the host immediately returns `429 Too Many Requests` and includes `Retry-After` plus a problem-details body so machine clients can back off deterministically.
 - The admin panel can point at the same `CryptoApiSharedPersistence` section to stay on the same shared control-plane data model used for clients, aliases, policies, and bindings.
 
 For the full operator deployment model, see [docs/crypto-api-deployment.md](docs/crypto-api-deployment.md).
@@ -181,6 +186,35 @@ Useful endpoints:
 `POST /api/v1/operations/authorize` remains the low-level alias/policy check.
 `POST /api/v1/operations/sign`, `verify`, and `random` reuse that same authentication + authorization model and keep the public contract stable and customer-facing: callers provide alias names, high-level algorithms such as `RS256` / `PS256` / `ES256` / `HS256`, and base64 payloads instead of raw PKCS#11 device/slot/handle details.
 
+### Built-in rate limiting behavior
+
+The host now ships a practical first built-in rate-limiting slice for customer-facing routes:
+
+- `/api/v1/auth/self`
+  - default budget: **60 requests / minute / presented API key id**
+- `/api/v1/operations/authorize`
+- `/api/v1/operations/sign`
+- `/api/v1/operations/verify`
+- `/api/v1/operations/random`
+  - default budget: **600 requests / minute / presented API key id / instance**
+
+Why this shape:
+
+- it protects the public Crypto API surface without introducing shared counter writes into the SQLite control-plane path
+- it keeps the API instances stateless and horizontally replaceable
+- it gives machine callers deterministic backoff behavior instead of silent slowdowns or long server-side queues
+
+Important caveats:
+
+- the limiter is **not cluster-global**; multiple API instances mean multiple per-instance budgets
+- the limiter runs before full authentication/authorization, so the presented key id is the practical partition key
+- upstream ingress/gateway policy should still enforce fleet-wide quotas, body-size limits, and abuse controls
+
+Rejected requests return:
+
+- HTTP `429 Too Many Requests`
+- `Retry-After` response header when the limiter can compute it
+- an `application/problem+json` body with machine-friendly scope / mode metadata
 
 ### Crypto API security defaults
 

--- a/docs/security-review-issue-112.md
+++ b/docs/security-review-issue-112.md
@@ -97,8 +97,8 @@ These are **not** fixed by this issue and should remain explicit in docs/roadmap
 2. **Login throttling is still in-memory per process.**
    It helps against casual brute force but resets on process restart and is not shared across multiple admin instances.
 
-3. **Crypto API rate limiting is still not built in.**
-   Upstream gateways/load balancers should still enforce request-rate, body-size, and abuse controls.
+3. **Crypto API rate limiting is now built in, but it is intentionally instance-local.**
+   The host now enforces per-instance customer-endpoint rate limits keyed by presented API key id (with remote-IP fallback when no key id is present), and 429 responses include `Retry-After` plus problem-details metadata. Upstream gateways/load balancers should still enforce fleet-wide request-rate, body-size, and abuse controls.
 
 4. **SQLite is still the shared control-plane backend.**
    That remains acceptable only for the documented conservative deployment model with trustworthy file-locking/WAL semantics.
@@ -113,6 +113,6 @@ These are **not** fixed by this issue and should remain explicit in docs/roadmap
 
 Validation should include at least:
 
-- targeted Crypto API route tests for generic error behavior and sanitized shared-state output
+- targeted Crypto API route tests for generic error behavior, sanitized shared-state output, and 429 / `Retry-After` rate-limit behavior
 - admin integration tests proving hardening headers are present and tokenless login POSTs fail
 - normal repo build/test validation for the touched projects

--- a/src/Pkcs11Wrapper.CryptoApi/Configuration/CryptoApiRateLimitingOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Configuration/CryptoApiRateLimitingOptions.cs
@@ -1,0 +1,42 @@
+namespace Pkcs11Wrapper.CryptoApi.Configuration;
+
+public sealed class CryptoApiRateLimitingOptions
+{
+    public const string SectionName = "CryptoApiRateLimiting";
+
+    public bool Enabled { get; set; } = true;
+
+    public CryptoApiSlidingWindowRateLimitOptions Authentication { get; set; } = new()
+    {
+        PermitLimit = 60,
+        WindowSeconds = 60,
+        SegmentsPerWindow = 6,
+        QueueLimit = 0
+    };
+
+    public CryptoApiSlidingWindowRateLimitOptions Operations { get; set; } = new()
+    {
+        PermitLimit = 600,
+        WindowSeconds = 60,
+        SegmentsPerWindow = 6,
+        QueueLimit = 0
+    };
+
+    public static bool IsValid(CryptoApiSlidingWindowRateLimitOptions? options)
+        => options is not null
+            && options.PermitLimit > 0
+            && options.WindowSeconds > 0
+            && options.SegmentsPerWindow > 0
+            && options.QueueLimit >= 0;
+}
+
+public sealed class CryptoApiSlidingWindowRateLimitOptions
+{
+    public int PermitLimit { get; set; }
+
+    public int WindowSeconds { get; set; }
+
+    public int SegmentsPerWindow { get; set; }
+
+    public int QueueLimit { get; set; }
+}

--- a/src/Pkcs11Wrapper.CryptoApi/Endpoints/CryptoApiRouteBuilderExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Endpoints/CryptoApiRouteBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Pkcs11Wrapper.Native;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Operations;
+using Pkcs11Wrapper.CryptoApi.RateLimiting;
 using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
@@ -10,11 +11,19 @@ namespace Pkcs11Wrapper.CryptoApi.Endpoints;
 
 public static class CryptoApiRouteBuilderExtensions
 {
-    public static IEndpointRouteBuilder MapCryptoApiRoutes(this IEndpointRouteBuilder endpoints, CryptoApiHostOptions hostOptions, CryptoApiSecurityOptions securityOptions)
+    public static IEndpointRouteBuilder MapCryptoApiRoutes(this IEndpointRouteBuilder endpoints, CryptoApiHostOptions hostOptions, CryptoApiSecurityOptions securityOptions, CryptoApiRateLimitingOptions rateLimitingOptions)
     {
         string apiBasePath = CryptoApiHostDefaults.NormalizeBasePath(hostOptions.ApiBasePath);
         RouteGroupBuilder group = endpoints.MapGroup(apiBasePath)
             .WithTags("Crypto API");
+
+        RouteGroupBuilder authGroup = group.MapGroup("/auth")
+            .RequireRateLimiting(CryptoApiRateLimitingExtensions.AuthenticationPolicyName)
+            .WithCryptoApiRateLimitScope("customer-authentication", rateLimitingOptions.Authentication.WindowSeconds);
+
+        RouteGroupBuilder operationExecutionGroup = group.MapGroup("/operations")
+            .RequireRateLimiting(CryptoApiRateLimitingExtensions.OperationsPolicyName)
+            .WithCryptoApiRateLimitScope("customer-operations", rateLimitingOptions.Operations.WindowSeconds);
 
         group.MapGet("/", static (CryptoApiRuntimeDescriptorProvider descriptorProvider) =>
         {
@@ -24,7 +33,7 @@ public static class CryptoApiRouteBuilderExtensions
                 descriptor.InstanceId,
                 descriptor.ApiBasePath,
                 descriptor.DeploymentModel,
-                "Machine-facing host for customer-facing sign/verify/random workflows backed by shared API-key auth, alias routing, and policy checks. No local operator UI or per-node auth/policy files.",
+                "Machine-facing host for customer-facing sign/verify/random workflows backed by shared API-key auth, alias routing, policy checks, and per-instance built-in rate limiting. No local operator UI or per-node auth/policy files.",
                 descriptor.CurrentSurface,
                 descriptor.SharedPersistenceConfigured,
                 descriptor.SharedPersistenceProvider,
@@ -48,7 +57,7 @@ public static class CryptoApiRouteBuilderExtensions
             return TypedResults.Ok(new CryptoApiOperationSurfaceDocument(
                 descriptor.ServiceName,
                 descriptor.ApiBasePath,
-                "Customer-facing v1 sign/verify/random routes are live and reuse the shared API-key, alias-routing, and policy-enforcement model.",
+                "Customer-facing v1 sign/verify/random routes are live and reuse the shared API-key, alias-routing, and policy-enforcement model plus per-instance rate limiting with 429 + Retry-After responses.",
                 ["sign", "verify", "random"],
                 ["key metadata lookup", "encrypt", "decrypt", "wrap", "unwrap"],
                 ["POST /operations/authorize", "POST /operations/sign", "POST /operations/verify", "POST /operations/random"]));
@@ -65,7 +74,7 @@ public static class CryptoApiRouteBuilderExtensions
                     statusCode: StatusCodes.Status503ServiceUnavailable);
         });
 
-        group.MapGet("/auth/self", async Task<IResult> (HttpContext httpContext, CryptoApiClientAuthenticationService authenticationService, CancellationToken cancellationToken) =>
+        authGroup.MapGet("/self", async Task<IResult> (HttpContext httpContext, CryptoApiClientAuthenticationService authenticationService, CancellationToken cancellationToken) =>
         {
             AuthenticationAttempt authentication = await AuthenticateAsync(httpContext, authenticationService, securityOptions, cancellationToken);
             if (authentication.Error is not null)
@@ -77,7 +86,7 @@ public static class CryptoApiRouteBuilderExtensions
             return Results.Ok(ToAuthenticatedClientDocument(client));
         });
 
-        group.MapPost("/operations/authorize", async Task<IResult> (
+        operationExecutionGroup.MapPost("/authorize", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiAuthorizeKeyOperationRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -111,7 +120,7 @@ public static class CryptoApiRouteBuilderExtensions
                     .ToArray()));
         });
 
-        group.MapPost("/operations/sign", async Task<IResult> (
+        operationExecutionGroup.MapPost("/sign", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiSignRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -151,7 +160,7 @@ public static class CryptoApiRouteBuilderExtensions
             }
         });
 
-        group.MapPost("/operations/verify", async Task<IResult> (
+        operationExecutionGroup.MapPost("/verify", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiVerifyRequest request,
             CryptoApiClientAuthenticationService authenticationService,
@@ -190,7 +199,7 @@ public static class CryptoApiRouteBuilderExtensions
             }
         });
 
-        group.MapPost("/operations/random", async Task<IResult> (
+        operationExecutionGroup.MapPost("/random", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiRandomRequest request,
             CryptoApiClientAuthenticationService authenticationService,

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Clients;
@@ -6,6 +7,7 @@ using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Endpoints;
 using Pkcs11Wrapper.CryptoApi.Health;
 using Pkcs11Wrapper.CryptoApi.Operations;
+using Pkcs11Wrapper.CryptoApi.RateLimiting;
 using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
@@ -36,6 +38,16 @@ builder.Services.AddOptions<CryptoApiRuntimeOptions>()
 builder.Services.AddOptions<CryptoApiSecurityOptions>()
     .Bind(builder.Configuration.GetSection(CryptoApiSecurityOptions.SectionName));
 
+builder.Services.AddOptions<CryptoApiRateLimitingOptions>()
+    .Bind(builder.Configuration.GetSection(CryptoApiRateLimitingOptions.SectionName))
+    .Validate(
+        static options => CryptoApiRateLimitingOptions.IsValid(options.Authentication),
+        "Crypto API authentication rate limiting must define positive permit/window/segment values and a non-negative queue limit.")
+    .Validate(
+        static options => CryptoApiRateLimitingOptions.IsValid(options.Operations),
+        "Crypto API operation rate limiting must define positive permit/window/segment values and a non-negative queue limit.")
+    .ValidateOnStart();
+
 builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
     .Bind(builder.Configuration.GetSection(CryptoApiSharedPersistenceOptions.SectionName))
     .PostConfigure(static options =>
@@ -58,6 +70,10 @@ builder.Services.AddSingleton<CryptoApiKeyAccessManagementService>();
 builder.Services.AddSingleton<CryptoApiKeyOperationAuthorizationService>();
 builder.Services.AddSingleton<ICryptoApiCustomerOperationService, CryptoApiPkcs11CustomerOperationService>();
 builder.Services.AddSingleton<ICryptoApiSharedStateStore, SqliteCryptoApiSharedStateStore>();
+
+builder.Services.AddSingleton<IConfigureOptions<RateLimiterOptions>, ConfigureCryptoApiRateLimiterOptions>();
+builder.Services.AddRateLimiter(_ => { });
+
 builder.Services.AddHealthChecks()
     .AddCheck<CryptoApiModuleReadinessHealthCheck>("pkcs11-module", tags: ["ready"])
     .AddCheck<CryptoApiSharedStateHealthCheck>("shared-persistence", tags: ["ready"]);
@@ -66,6 +82,7 @@ WebApplication app = builder.Build();
 CryptoApiHostOptions hostOptions = app.Services.GetRequiredService<IOptions<CryptoApiHostOptions>>().Value;
 CryptoApiRuntimeOptions runtimeOptions = app.Services.GetRequiredService<IOptions<CryptoApiRuntimeOptions>>().Value;
 CryptoApiSecurityOptions securityOptions = app.Services.GetRequiredService<IOptions<CryptoApiSecurityOptions>>().Value;
+CryptoApiRateLimitingOptions rateLimitingOptions = app.Services.GetRequiredService<IOptions<CryptoApiRateLimitingOptions>>().Value;
 CryptoApiSharedPersistenceOptions sharedPersistenceOptions = app.Services.GetRequiredService<IOptions<CryptoApiSharedPersistenceOptions>>().Value;
 
 if (!app.Environment.IsDevelopment())
@@ -78,6 +95,8 @@ if (!runtimeOptions.DisableHttpsRedirection)
 {
     app.UseHttpsRedirection();
 }
+
+app.UseRateLimiter();
 
 if (!string.IsNullOrWhiteSpace(sharedPersistenceOptions.ConnectionString) && sharedPersistenceOptions.AutoInitialize)
 {
@@ -114,7 +133,7 @@ app.MapHealthChecks(CryptoApiHostDefaults.HealthReadyPath, new HealthCheckOption
     Predicate = static registration => registration.Tags.Contains("ready", StringComparer.Ordinal),
     ResponseWriter = CryptoApiHealthResponseWriter.WriteAsync
 });
-app.MapCryptoApiRoutes(hostOptions, securityOptions);
+app.MapCryptoApiRoutes(hostOptions, securityOptions, rateLimitingOptions);
 
 app.Run();
 

--- a/src/Pkcs11Wrapper.CryptoApi/RateLimiting/ConfigureCryptoApiRateLimiterOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/RateLimiting/ConfigureCryptoApiRateLimiterOptions.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+
+namespace Pkcs11Wrapper.CryptoApi.RateLimiting;
+
+internal sealed class ConfigureCryptoApiRateLimiterOptions(
+    IOptions<CryptoApiRateLimitingOptions> settings) : IConfigureOptions<RateLimiterOptions>
+{
+    public void Configure(RateLimiterOptions options)
+        => options.ConfigureCryptoApiPolicies(settings.Value);
+}

--- a/src/Pkcs11Wrapper.CryptoApi/RateLimiting/CryptoApiRateLimitingExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/RateLimiting/CryptoApiRateLimitingExtensions.cs
@@ -1,0 +1,122 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+
+namespace Pkcs11Wrapper.CryptoApi.RateLimiting;
+
+public static class CryptoApiRateLimitingExtensions
+{
+    public const string AuthenticationPolicyName = "crypto-api-authentication";
+    public const string OperationsPolicyName = "crypto-api-operations";
+    public const string InstanceLocalMode = "instance-local";
+
+    public static RateLimiterOptions ConfigureCryptoApiPolicies(this RateLimiterOptions options, CryptoApiRateLimitingOptions settings)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        options.OnRejected = static async (context, cancellationToken) =>
+        {
+            CryptoApiRateLimitScopeMetadata metadata = context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<CryptoApiRateLimitScopeMetadata>()
+                ?? new CryptoApiRateLimitScopeMetadata("customer-api", 1L);
+
+            Dictionary<string, object?> extensions = new(StringComparer.Ordinal)
+            {
+                ["scope"] = metadata.Scope,
+                ["mode"] = InstanceLocalMode
+            };
+
+            long retryAfterSeconds = Math.Max(1L, metadata.RetryAfterSeconds);
+            if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfter))
+            {
+                retryAfterSeconds = Math.Max(1L, (long)Math.Ceiling(retryAfter.TotalSeconds));
+            }
+
+            context.HttpContext.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+            extensions["retryAfterSeconds"] = retryAfterSeconds;
+
+            IResult result = Results.Problem(
+                title: "Rate limit exceeded.",
+                detail: "The built-in Crypto API rate limiter rejected the request. Wait for the retry interval and try again.",
+                statusCode: StatusCodes.Status429TooManyRequests,
+                extensions: extensions);
+
+            await result.ExecuteAsync(context.HttpContext);
+        };
+
+        options.AddPolicy(AuthenticationPolicyName, httpContext => CreateSlidingWindowPartition(httpContext, settings.Enabled, settings.Authentication));
+        options.AddPolicy(OperationsPolicyName, httpContext => CreateSlidingWindowPartition(httpContext, settings.Enabled, settings.Operations));
+
+        return options;
+    }
+
+    public static TBuilder WithCryptoApiRateLimitScope<TBuilder>(this TBuilder builder, string scope, long retryAfterSeconds)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(retryAfterSeconds);
+
+        builder.WithMetadata(new CryptoApiRateLimitScopeMetadata(scope.Trim(), retryAfterSeconds));
+        return builder;
+    }
+
+    private static RateLimitPartition<string> CreateSlidingWindowPartition(
+        HttpContext httpContext,
+        bool enabled,
+        CryptoApiSlidingWindowRateLimitOptions settings)
+    {
+        string partitionKey = ResolvePartitionKey(httpContext);
+        if (!enabled)
+        {
+            return RateLimitPartition.GetNoLimiter(partitionKey);
+        }
+
+        return RateLimitPartition.GetSlidingWindowLimiter(
+            partitionKey,
+            _ => new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = settings.PermitLimit,
+                Window = TimeSpan.FromSeconds(settings.WindowSeconds),
+                SegmentsPerWindow = settings.SegmentsPerWindow,
+                QueueLimit = settings.QueueLimit,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                AutoReplenishment = true
+            });
+    }
+
+    private static string ResolvePartitionKey(HttpContext httpContext)
+    {
+        string? presentedKeyId = httpContext.Request.Headers[CryptoApiAuthenticationDefaults.ApiKeyIdHeaderName].ToString();
+        if (!string.IsNullOrWhiteSpace(presentedKeyId))
+        {
+            return $"api-key:{NormalizePartitionToken(presentedKeyId)}";
+        }
+
+        string? remoteIp = httpContext.Connection.RemoteIpAddress?.ToString();
+        if (!string.IsNullOrWhiteSpace(remoteIp))
+        {
+            return $"remote-ip:{remoteIp}";
+        }
+
+        return "anonymous";
+    }
+
+    private static string NormalizePartitionToken(string value)
+    {
+        string trimmed = value.Trim();
+        if (trimmed.Length <= 96 && trimmed.All(static c => !char.IsControl(c)))
+        {
+            return trimmed;
+        }
+
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(trimmed));
+        return Convert.ToHexString(hash);
+    }
+
+    private sealed record CryptoApiRateLimitScopeMetadata(string Scope, long RetryAfterSeconds);
+}

--- a/src/Pkcs11Wrapper.CryptoApi/appsettings.json
+++ b/src/Pkcs11Wrapper.CryptoApi/appsettings.json
@@ -19,6 +19,21 @@
     "ExposeDetailedErrors": false,
     "ExposeSharedStateDetails": false
   },
+  "CryptoApiRateLimiting": {
+    "Enabled": true,
+    "Authentication": {
+      "PermitLimit": 60,
+      "WindowSeconds": 60,
+      "SegmentsPerWindow": 6,
+      "QueueLimit": 0
+    },
+    "Operations": {
+      "PermitLimit": 600,
+      "WindowSeconds": 60,
+      "SegmentsPerWindow": 6,
+      "QueueLimit": 0
+    }
+  },
   "CryptoApiSharedPersistence": {
     "Provider": "Sqlite",
     "ConnectionString": "",

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
@@ -243,7 +243,103 @@ public sealed class CryptoApiRoutesTests
         }
     }
 
-    private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, IReadOnlyCollection<string> allowedOperations, string aliasName)
+    [Fact]
+    public async Task AuthEndpointReturnsRateLimitProblemDetailsAndRetryAfterHeader()
+    {
+        string databasePath = CreateDatabasePath();
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            databasePath,
+            null,
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiRateLimiting:Authentication:PermitLimit"] = "1",
+                ["CryptoApiRateLimiting:Authentication:WindowSeconds"] = "60",
+                ["CryptoApiRateLimiting:Authentication:SegmentsPerWindow"] = "6",
+                ["CryptoApiRateLimiting:Authentication:QueueLimit"] = "0"
+            });
+
+        try
+        {
+            using HttpClient httpClient = factory.CreateClient();
+
+            using HttpResponseMessage firstResponse = await httpClient.GetAsync("/api/v1/auth/self");
+            Assert.Equal(HttpStatusCode.Unauthorized, firstResponse.StatusCode);
+
+            using HttpResponseMessage secondResponse = await httpClient.GetAsync("/api/v1/auth/self");
+            string content = await secondResponse.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.TooManyRequests, secondResponse.StatusCode);
+            Assert.Equal("application/problem+json", secondResponse.Content.Headers.ContentType?.MediaType);
+            Assert.True(secondResponse.Headers.TryGetValues("Retry-After", out IEnumerable<string>? retryAfterValues));
+            Assert.NotEmpty(retryAfterValues);
+            Assert.Contains("Rate limit exceeded.", content, StringComparison.Ordinal);
+            Assert.Contains("customer-authentication", content, StringComparison.Ordinal);
+            Assert.Contains("instance-local", content, StringComparison.Ordinal);
+            Assert.Contains("retryAfterSeconds", content, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task OperationRateLimitsArePartitionedByPresentedApiKeyId()
+    {
+        string databasePath = CreateDatabasePath();
+        FakeCustomerOperationService fakeOperations = new();
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            databasePath,
+            services => services.AddSingleton<ICryptoApiCustomerOperationService>(fakeOperations),
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiRateLimiting:Operations:PermitLimit"] = "1",
+                ["CryptoApiRateLimiting:Operations:WindowSeconds"] = "60",
+                ["CryptoApiRateLimiting:Operations:SegmentsPerWindow"] = "6",
+                ["CryptoApiRateLimiting:Operations:QueueLimit"] = "0"
+            });
+
+        try
+        {
+            SeededAccess firstAccess = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer", policyName: $"gateway-sign-{Guid.NewGuid():N}");
+            SeededAccess secondAccess = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer-2", policyName: $"gateway-sign-{Guid.NewGuid():N}");
+
+            using HttpClient firstClient = factory.CreateClient();
+            firstClient.DefaultRequestHeaders.Add("X-Api-Key-Id", firstAccess.Key.KeyIdentifier);
+            firstClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", firstAccess.Key.Secret);
+
+            using HttpResponseMessage firstAllowed = await firstClient.PostAsync(
+                "/api/v1/operations/sign",
+                CreateJsonContent("{\"keyAlias\":\"payments-signer\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
+            Assert.Equal(HttpStatusCode.OK, firstAllowed.StatusCode);
+
+            using HttpResponseMessage firstRejected = await firstClient.PostAsync(
+                "/api/v1/operations/sign",
+                CreateJsonContent("{\"keyAlias\":\"payments-signer\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
+            string rejectedContent = await firstRejected.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.TooManyRequests, firstRejected.StatusCode);
+            Assert.Contains("customer-operations", rejectedContent, StringComparison.Ordinal);
+
+            using HttpClient secondClient = factory.CreateClient();
+            secondClient.DefaultRequestHeaders.Add("X-Api-Key-Id", secondAccess.Key.KeyIdentifier);
+            secondClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", secondAccess.Key.Secret);
+
+            using HttpResponseMessage secondAllowed = await secondClient.PostAsync(
+                "/api/v1/operations/sign",
+                CreateJsonContent("{\"keyAlias\":\"payments-signer-2\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
+
+            Assert.Equal(HttpStatusCode.OK, secondAllowed.StatusCode);
+            Assert.Equal(2, fakeOperations.Calls.Count);
+            Assert.Equal("payments-signer", fakeOperations.Calls[0].AliasName);
+            Assert.Equal("payments-signer-2", fakeOperations.Calls[1].AliasName);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, IReadOnlyCollection<string> allowedOperations, string aliasName, string? policyName = null)
     {
         using IServiceScope scope = factory.Services.CreateScope();
         CryptoApiClientManagementService clientManagement = scope.ServiceProvider.GetRequiredService<CryptoApiClientManagementService>();
@@ -256,7 +352,7 @@ public sealed class CryptoApiRoutesTests
             Notes: null));
         CryptoApiCreatedClientKey key = await clientManagement.CreateClientKeyAsync(new CreateCryptoApiClientKeyRequest(client.ClientId, "primary", null));
         CryptoApiManagedPolicy policy = await accessManagement.CreatePolicyAsync(new CreateCryptoApiPolicyRequest(
-            PolicyName: $"gateway-{string.Join('-', allowedOperations)}",
+            PolicyName: policyName ?? $"gateway-{string.Join('-', allowedOperations)}",
             Description: null,
             AllowedOperations: allowedOperations));
         CryptoApiManagedKeyAlias alias = await accessManagement.CreateKeyAliasAsync(new CreateCryptoApiKeyAliasRequest(


### PR DESCRIPTION
## Summary
Add built-in Crypto API rate limiting and practical client usage protection for the customer-facing surface.

## Included work
- add instance-local rate limiting for auth and customer-facing operation endpoints
- partition primarily by presented API key id, with remote IP fallback
- return predictable 429/problem-details responses with Retry-After
- add configurable defaults and document the fleet-wide caveat honestly
- add route coverage for rate-limit behavior

## Closes
Closes #119
