### PR TITLE
Fix admin E2E shared persistence setup

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -113,7 +113,7 @@ Admin runtime E2E coverage from `admin-runtime-e2e` guarantees that:
 
 - the Blazor admin host still boots in CI against an isolated temporary storage root instead of repo-local mutable `App_Data`
 - a deterministic bootstrap admin credential can be injected for automation without changing the default local first-run behavior
-- critical authenticated admin flows still work end-to-end: login, device profile creation + connection test, slot inventory load, keys/object browse + detail open, PKCS#11 Lab execution, and telemetry viewing/filtering
+- critical authenticated admin flows still work end-to-end: login, device profile creation + connection test, slot inventory load, keys/object browse + detail open, Crypto API Access client/key/policy/alias management, PKCS#11 Lab execution, and telemetry viewing/filtering
 - browser traces, screenshots, and runtime logs are captured as downloadable artifacts to make failures diagnosable instead of opaque
 
 Native AOT coverage from `eng/run-smoke-aot.sh` guarantees that:

--- a/eng/run-admin-e2e.sh
+++ b/eng/run-admin-e2e.sh
@@ -12,6 +12,7 @@ no_build=false
 fixture_root=""
 fixture_env=""
 admin_data_root=""
+crypto_api_shared_db=""
 server_pid=""
 server_running=false
 
@@ -154,6 +155,7 @@ fi
 "${playwright_command[@]}" "${playwright_install_args[@]}" 2>&1 | tee "$artifact_root/playwright-install.log"
 
 admin_data_root="$(mktemp -d -t pkcs11wrapper-admin-storage-XXXXXX)"
+crypto_api_shared_db="$admin_data_root/crypto-api-shared.db"
 admin_user="ci-admin"
 admin_password="AdminE2E!Pass123"
 admin_device_name="CI Seeded SoftHSM"
@@ -195,6 +197,9 @@ export AdminStorage__DataRoot="$admin_data_root"
 export LocalAdminBootstrap__UserName="$admin_user"
 export LocalAdminBootstrap__Password="$admin_password"
 export LocalAdminLoginThrottle__MaxFailures="100"
+export CryptoApiSharedPersistence__Provider="Sqlite"
+export CryptoApiSharedPersistence__ConnectionString="Data Source=$crypto_api_shared_db"
+export CryptoApiSharedPersistence__AutoInitialize="true"
 
 (
   cd "$repo_root"


### PR DESCRIPTION
## Summary
Fix the admin runtime E2E CI setup by providing isolated Crypto API shared persistence during the test run.

## Included work
- configure a per-run SQLite shared-state database in `eng/run-admin-e2e.sh`
- pass the necessary Crypto API shared persistence settings into the admin host
- keep the setup isolated under the temporary admin data root so cleanup removes it automatically
- update CI docs to reflect the existing Crypto API Access control-plane coverage

## Closes
Closes #121
