### PR TITLE
Fix crash-safe temp promotion on Windows

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Infrastructure/CrashSafeFileStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/CrashSafeFileStore.cs
@@ -85,6 +85,9 @@ public static class CrashSafeFileStore
     public static string GetBackupPath(string path)
         => $"{path}.bak";
 
+    public static void PromoteTempFile(string destinationPath, string tempPath)
+        => PromoteTempFile(destinationPath, tempPath, onBeforeMove: null);
+
     private static FileStream CreateWriteThroughStream(string path)
         => new(
             path,
@@ -94,16 +97,32 @@ public static class CrashSafeFileStore
             64 * 1024,
             FileOptions.Asynchronous | FileOptions.WriteThrough);
 
-    private static void PromoteTempFile(string destinationPath, string tempPath)
+    internal static void PromoteTempFile(string destinationPath, string tempPath, Action? onBeforeMove)
     {
         string backupPath = GetBackupPath(destinationPath);
         if (File.Exists(destinationPath))
         {
-            File.Replace(tempPath, destinationPath, backupPath, ignoreMetadataErrors: true);
+            try
+            {
+                File.Replace(tempPath, destinationPath, backupPath, ignoreMetadataErrors: true);
+                return;
+            }
+            catch (FileNotFoundException) when (!File.Exists(destinationPath))
+            {
+                // Another writer/process removed the destination after our existence check.
+                // Fall through to the create path below and keep the temp payload intact.
+            }
         }
-        else
+
+        onBeforeMove?.Invoke();
+
+        try
         {
             File.Move(tempPath, destinationPath);
+        }
+        catch (IOException) when (File.Exists(destinationPath))
+        {
+            File.Replace(tempPath, destinationPath, backupPath, ignoreMetadataErrors: true);
         }
     }
 

--- a/src/Pkcs11Wrapper.Admin.Infrastructure/Properties/AssemblyInfo.cs
+++ b/src/Pkcs11Wrapper.Admin.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Pkcs11Wrapper.Admin.Tests")]

--- a/src/Pkcs11Wrapper.Admin.Web/Lab/Pkcs11LabTemplateStore.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Lab/Pkcs11LabTemplateStore.cs
@@ -161,14 +161,7 @@ public sealed class Pkcs11LabTemplateStore(IOptions<AdminStorageOptions> options
                 stream.Flush(flushToDisk: true);
             }
 
-            if (File.Exists(TemplateFilePath))
-            {
-                File.Replace(tempPath, TemplateFilePath, CrashSafeFileStore.GetBackupPath(TemplateFilePath), ignoreMetadataErrors: true);
-            }
-            else
-            {
-                File.Move(tempPath, TemplateFilePath);
-            }
+            CrashSafeFileStore.PromoteTempFile(TemplateFilePath, tempPath);
         }
         finally
         {

--- a/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/JsonStoresTests.cs
@@ -60,6 +60,31 @@ public sealed class JsonStoresTests
     }
 
     [Fact]
+    public void CrashSafeFileStorePromoteTempFileFallsBackToReplaceWhenDestinationAppearsBeforeMove()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            string path = Path.Combine(root, "race.json");
+            string tempPath = $"{path}.tmp-{Guid.NewGuid():N}";
+            File.WriteAllText(tempPath, "new");
+
+            CrashSafeFileStore.PromoteTempFile(
+                path,
+                tempPath,
+                onBeforeMove: () => File.WriteAllText(path, "old"));
+
+            Assert.Equal("new", File.ReadAllText(path));
+            Assert.Equal("old", File.ReadAllText(CrashSafeFileStore.GetBackupPath(path)));
+            Assert.False(File.Exists(tempPath));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task JsonDeviceProfileStoreReportsCorruptionWithBackupPath()
     {
         string root = CreateTempDirectory();


### PR DESCRIPTION
## Summary
Fix crash-safe temp-file promotion so Windows does not fail when the destination appears during promotion.

## Included work
- harden `CrashSafeFileStore` temp promotion against the Windows file-exists race
- preserve crash-safe rewrite behavior and backup semantics
- reuse the hardened helper in `Pkcs11LabTemplateStore`
- add deterministic regression coverage for the exact destination-appears race

## Notes
- this addresses the Windows CI admin-test failure seen in `AdminOpenApiIntegrationTests`

## Closes
Closes #125
