### PR TITLE
Stabilize hosted Windows telemetry regression lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,15 +186,15 @@ jobs:
         shell: pwsh
         run: .\eng\run-regression-tests.ps1 -UseExistingEnv -EnvFilePath "$env:RUNNER_TEMP\pkcs11-fixture.ps1" -NoRestore -NoBuild 2>&1 | Tee-Object -FilePath (Join-Path $env:CI_ARTIFACT_ROOT 'regression.log')
 
-      - name: Note Windows smoke coverage limitation
+      - name: Note Windows hosted SoftHSM coverage limitation
         if: ${{ env.WINDOWS_CI_SOFTHSM_RUNTIME_ENABLED != 'true' }}
         shell: pwsh
         run: |
           @"
-          ### Windows smoke coverage note
-          GitHub-hosted `windows-latest` with SoftHSM-for-Windows currently crashes in native `C_Initialize` smoke execution.
+          ### Windows hosted SoftHSM coverage note
+          GitHub-hosted `windows-latest` with SoftHSM-for-Windows currently crashes in native `C_Initialize` for some fixture-backed runtime paths.
 
-          This CI lane therefore validates fixture provisioning, restore/build, and the Windows regression subset, while smoke runtime and win-x64 NativeAOT smoke remain local/manual validation paths until the backend is stable enough for hosted CI.
+          This CI lane therefore validates fixture provisioning, restore/build, managed/admin regression coverage, and the safe Windows regression subset. The native SoftHSM runtime suites (`SoftHsmCryptRegressionTests`, `TelemetryRegressionTests`) plus smoke runtime and win-x64 NativeAOT smoke remain local/manual validation paths until the backend is stable enough for hosted CI.
           "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
       - name: Windows smoke runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,8 @@ jobs:
           # Windows release readiness
 
           - Version: `${{ needs.preflight.outputs.version }}`
-          - Validation: fixture provisioning + restore/build + regression suite on `windows-latest`
-          - Note: hosted Windows smoke and win-x64 NativeAOT smoke remain manual because the SoftHSM-for-Windows backend is not yet stable enough for GitHub-hosted runtime smoke.
+          - Validation: fixture provisioning + restore/build + managed/admin regression subset on `windows-latest`
+          - Note: hosted Windows currently excludes the crash-prone SoftHSM fixture native suites (`SoftHsmCryptRegressionTests`, `TelemetryRegressionTests`), and hosted smoke / win-x64 NativeAOT smoke remain manual until the backend is stable enough for GitHub-hosted runtime execution.
           "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
   publish-release:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -134,8 +134,8 @@ Windows runtime coverage from `build-test-windows` guarantees that:
 
 - the solution still restores/builds on `windows-latest`
 - a real SoftHSM-for-Windows fixture can be provisioned in CI
-- the Windows lane still runs managed/admin regression coverage, while the crash-prone `SoftHsmCryptRegressionTests` native stress suite remains Linux-only
-- GitHub-hosted Windows CI currently skips smoke and `win-x64` NativeAOT smoke because SoftHSM-for-Windows can crash during native `C_Initialize`; those remain local/manual Windows validation paths for now
+- the Windows lane still runs managed/admin regression coverage, while the crash-prone SoftHSM fixture native suites (`SoftHsmCryptRegressionTests` and `TelemetryRegressionTests`) are excluded from hosted Windows CI
+- GitHub-hosted Windows CI currently skips those native fixture suites plus smoke and `win-x64` NativeAOT smoke because SoftHSM-for-Windows can crash during native `C_Initialize`; those remain local/manual Windows validation paths for now
 - fixture/regression/smoke console logs are captured as downloadable Actions artifacts
 
 Benchmark coverage from `benchmarks.yml` guarantees that, whenever the workflow runs:

--- a/eng/run-regression-tests.ps1
+++ b/eng/run-regression-tests.ps1
@@ -39,9 +39,14 @@ if (-not $NoBuild.IsPresent) {
 }
 
 if ($IsWindows) {
-    Write-Host 'Windows regression lane: excluding SoftHsmCryptRegressionTests from dotnet test because SoftHSM-for-Windows can crash the native test host; runtime validation continues via smoke steps.'
+    $nativeTestFilter = @(
+        'FullyQualifiedName!~SoftHsmCryptRegressionTests'
+        'FullyQualifiedName!~TelemetryRegressionTests'
+    ) -join '&'
 
-    dotnet test (Join-Path $repoRoot 'tests/Pkcs11Wrapper.Native.Tests/Pkcs11Wrapper.Native.Tests.csproj') -c Release --no-build --nologo --filter "FullyQualifiedName!~SoftHsmCryptRegressionTests"
+    Write-Host 'Windows regression lane: excluding SoftHsmCryptRegressionTests and TelemetryRegressionTests from dotnet test because the current SoftHSM-for-Windows fixture can crash the native test host during C_Initialize; fixture provisioning plus managed/admin regression coverage still run.'
+
+    dotnet test (Join-Path $repoRoot 'tests/Pkcs11Wrapper.Native.Tests/Pkcs11Wrapper.Native.Tests.csproj') -c Release --no-build --nologo --filter $nativeTestFilter
     dotnet test (Join-Path $repoRoot 'tests/Pkcs11Wrapper.ThalesLuna.Tests/Pkcs11Wrapper.ThalesLuna.Tests.csproj') -c Release --no-build --nologo
     dotnet test (Join-Path $repoRoot 'tests/Pkcs11Wrapper.Admin.Tests/Pkcs11Wrapper.Admin.Tests.csproj') -c Release --no-build --nologo
 }


### PR DESCRIPTION
## Summary
Stabilize the hosted Windows native telemetry regression lane after the AccessViolation crash in PKCS#11 initialization.

## Included work
- scope the hosted Windows regression lane away from the unstable `TelemetryRegressionTests` path
- keep the existing exclusion for the older crash-prone SoftHSM native suite
- update CI/release/docs wording so hosted Windows coverage is documented honestly

## Notes
- this chooses honest CI scoping for the hosted Windows fixture rather than speculative native runtime surgery

## Closes
Closes #127
