### PR TITLE
Fix Crypto API PKCS#11 concurrency crash

### DIFF
--- a/src/Pkcs11Wrapper.CryptoApi/Health/CryptoApiModuleReadinessHealthCheck.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Health/CryptoApiModuleReadinessHealthCheck.cs
@@ -1,28 +1,27 @@
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Options;
 using Pkcs11Wrapper;
-using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Operations;
+using Pkcs11Wrapper.CryptoApi.Runtime;
 
 namespace Pkcs11Wrapper.CryptoApi.Health;
 
-public sealed class CryptoApiModuleReadinessHealthCheck(IOptions<CryptoApiRuntimeOptions> options) : IHealthCheck
+public sealed class CryptoApiModuleReadinessHealthCheck(CryptoApiPkcs11Runtime runtime) : IHealthCheck
 {
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        string modulePath = options.Value.ModulePath?.Trim() ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(modulePath))
-        {
-            return Task.FromResult(HealthCheckResult.Unhealthy("Crypto API module path is not configured."));
-        }
-
         try
         {
-            using Pkcs11Module module = Pkcs11Module.Load(modulePath);
-            return Task.FromResult(HealthCheckResult.Healthy("Configured PKCS#11 module can be loaded."));
+            Pkcs11Module module = runtime.GetInitializedModule();
+            _ = module.GetInfo();
+            return Task.FromResult(HealthCheckResult.Healthy("Configured PKCS#11 module is initialized and ready."));
+        }
+        catch (CryptoApiOperationConfigurationException ex)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(ex.Message, ex));
         }
         catch (Exception ex)
         {
-            return Task.FromResult(HealthCheckResult.Unhealthy("Configured PKCS#11 module could not be loaded.", ex));
+            return Task.FromResult(HealthCheckResult.Unhealthy("Configured PKCS#11 module could not be initialized.", ex));
         }
     }
 }

--- a/src/Pkcs11Wrapper.CryptoApi/Operations/CryptoApiCustomerOperationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Operations/CryptoApiCustomerOperationService.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.CryptoApi.Operations;
@@ -31,6 +32,7 @@ public sealed record CryptoApiRandomOperationResult(
 
 public sealed class CryptoApiPkcs11CustomerOperationService(
     IOptions<CryptoApiRuntimeOptions> runtimeOptions,
+    CryptoApiPkcs11Runtime pkcs11Runtime,
     TimeProvider timeProvider) : ICryptoApiCustomerOperationService
 {
     private const int MaxPayloadBytes = 1024 * 1024;
@@ -45,7 +47,7 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         SignatureAlgorithmProfile profile = SignatureAlgorithmProfile.Parse(algorithm);
         byte[] payload = ParseRequiredBase64(payloadBase64, nameof(payloadBase64), MaxPayloadBytes);
 
-        using Pkcs11Module module = CreateInitializedModule();
+        Pkcs11Module module = pkcs11Runtime.GetInitializedModule();
         using Pkcs11Session session = OpenCompatibleSession(module, ResolveRequiredSlotId(authorization));
         LoginIfConfigured(session);
 
@@ -64,7 +66,7 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         byte[] payload = ParseRequiredBase64(payloadBase64, nameof(payloadBase64), MaxPayloadBytes);
         byte[] signature = ParseRequiredBase64(signatureBase64, nameof(signatureBase64), MaxPayloadBytes);
 
-        using Pkcs11Module module = CreateInitializedModule();
+        Pkcs11Module module = pkcs11Runtime.GetInitializedModule();
         using Pkcs11Session session = OpenCompatibleSession(module, ResolveRequiredSlotId(authorization));
         LoginIfConfigured(session);
 
@@ -81,34 +83,13 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(length, MaxRandomLength);
 
-        using Pkcs11Module module = CreateInitializedModule();
+        Pkcs11Module module = pkcs11Runtime.GetInitializedModule();
         using Pkcs11Session session = OpenCompatibleSession(module, ResolveRequiredSlotId(authorization));
         LoginIfConfigured(session);
 
         byte[] buffer = new byte[length];
         session.GenerateRandom(buffer);
         return new CryptoApiRandomOperationResult(buffer, timeProvider.GetUtcNow());
-    }
-
-    private Pkcs11Module CreateInitializedModule()
-    {
-        string modulePath = runtimeOptions.Value.ModulePath?.Trim() ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(modulePath))
-        {
-            throw new CryptoApiOperationConfigurationException("Crypto API PKCS#11 module path is not configured.");
-        }
-
-        Pkcs11Module module = Pkcs11Module.Load(modulePath);
-        try
-        {
-            module.Initialize();
-            return module;
-        }
-        catch
-        {
-            module.Dispose();
-            throw;
-        }
     }
 
     private static Pkcs11SlotId ResolveRequiredSlotId(CryptoApiAuthorizedKeyOperation authorization)

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -62,6 +62,7 @@ builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
 
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<CryptoApiRuntimeDescriptorProvider>();
+builder.Services.AddSingleton<CryptoApiPkcs11Runtime>();
 builder.Services.AddSingleton<CryptoApiClientSecretGenerator>();
 builder.Services.AddSingleton<CryptoApiClientSecretHasher>();
 builder.Services.AddSingleton<CryptoApiClientManagementService>();

--- a/src/Pkcs11Wrapper.CryptoApi/Runtime/CryptoApiPkcs11Runtime.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Runtime/CryptoApiPkcs11Runtime.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Operations;
+
+namespace Pkcs11Wrapper.CryptoApi.Runtime;
+
+public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> runtimeOptions) : IDisposable
+{
+    private readonly object _sync = new();
+    private Pkcs11Module? _module;
+    private bool _disposed;
+
+    public Pkcs11Module GetInitializedModule()
+    {
+        if (_module is not null)
+        {
+            return _module;
+        }
+
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(CryptoApiPkcs11Runtime));
+            }
+
+            if (_module is not null)
+            {
+                return _module;
+            }
+
+            string modulePath = runtimeOptions.Value.ModulePath?.Trim() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(modulePath))
+            {
+                throw new CryptoApiOperationConfigurationException("Crypto API PKCS#11 module path is not configured.");
+            }
+
+            Pkcs11Module module = Pkcs11Module.Load(modulePath);
+            try
+            {
+                module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+                _module = module;
+                return module;
+            }
+            catch
+            {
+                module.Dispose();
+                throw;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _module?.Dispose();
+            _module = null;
+        }
+    }
+}

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
@@ -72,6 +72,51 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
         Assert.Contains(random, static value => value != 0);
     }
 
+    [Fact]
+    public async Task ConcurrentSignAndRandomRequestsRemainStableAgainstSoftHsm()
+    {
+        if (!SoftHsmTestContext.IsSupported())
+        {
+            return;
+        }
+
+        await using SoftHsmTestContext context = await SoftHsmTestContext.CreateAsync();
+        if (!context.CanExecuteInProcess)
+        {
+            return;
+        }
+
+        await using WebApplicationFactory<Program> factory = CreateFactory(context);
+
+        SeededAccess access = await SeedAuthorizedAccessAsync(factory, context);
+
+        HttpClient httpClient = factory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+        string payloadBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("concurrent customer-facing crypto api"));
+        Task<OperationResponse>[] tasks = Enumerable.Range(0, 48)
+            .Select(index => index % 2 == 0
+                ? PostOperationAsync(
+                    httpClient,
+                    "/api/v1/operations/sign",
+                    $"{{\"keyAlias\":\"{context.AliasName}\",\"algorithm\":\"RS256\",\"payloadBase64\":\"{payloadBase64}\"}}")
+                : PostOperationAsync(
+                    httpClient,
+                    "/api/v1/operations/random",
+                    $"{{\"keyAlias\":\"{context.AliasName}\",\"length\":32}}"))
+            .ToArray();
+
+        OperationResponse[] responses = await Task.WhenAll(tasks);
+
+        Assert.All(responses, response =>
+            Assert.True(
+                response.StatusCode == HttpStatusCode.OK,
+                $"{response.Path} failed with {(int)response.StatusCode}: {response.Body}"));
+        Assert.Contains(responses, response => string.Equals(response.Path, "/api/v1/operations/sign", StringComparison.Ordinal));
+        Assert.Contains(responses, response => string.Equals(response.Path, "/api/v1/operations/random", StringComparison.Ordinal));
+    }
+
     private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, SoftHsmTestContext context)
     {
         using IServiceScope scope = factory.Services.CreateScope();
@@ -124,11 +169,20 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
     private static StringContent CreateJsonContent(string json)
         => new(json, Encoding.UTF8, "application/json");
 
+    private static async Task<OperationResponse> PostOperationAsync(HttpClient httpClient, string path, string json)
+    {
+        using HttpResponseMessage response = await httpClient.PostAsync(path, CreateJsonContent(json));
+        string body = await response.Content.ReadAsStringAsync();
+        return new OperationResponse(path, response.StatusCode, body);
+    }
+
     private sealed record SeededAccess(
         CryptoApiManagedClient Client,
         CryptoApiCreatedClientKey Key,
         CryptoApiManagedKeyAlias Alias,
         CryptoApiManagedPolicy Policy);
+
+    private sealed record OperationResponse(string Path, HttpStatusCode StatusCode, string Body);
 
     private sealed class SoftHsmTestContext : IAsyncDisposable
     {

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiHealthCheckTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiHealthCheckTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Health;
+using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
 namespace Pkcs11Wrapper.CryptoApi.Tests;
@@ -16,7 +17,8 @@ public sealed class CryptoApiHealthCheckTests
         HealthCheckResult result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
 
         Assert.Equal(HealthStatus.Unhealthy, result.Status);
-        Assert.Equal("Crypto API module path is not configured.", result.Description);
+        Assert.Equal("Crypto API PKCS#11 module path is not configured.", result.Description);
+        Assert.NotNull(result.Exception);
     }
 
     [Fact]
@@ -28,7 +30,7 @@ public sealed class CryptoApiHealthCheckTests
         HealthCheckResult result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
 
         Assert.Equal(HealthStatus.Unhealthy, result.Status);
-        Assert.Equal("Configured PKCS#11 module could not be loaded.", result.Description);
+        Assert.Equal("Configured PKCS#11 module could not be initialized.", result.Description);
         Assert.NotNull(result.Exception);
     }
 
@@ -45,5 +47,5 @@ public sealed class CryptoApiHealthCheckTests
     }
 
     private static CryptoApiModuleReadinessHealthCheck CreateHealthCheck(string? modulePath)
-        => new(Options.Create(new CryptoApiRuntimeOptions { ModulePath = modulePath }));
+        => new(new CryptoApiPkcs11Runtime(Options.Create(new CryptoApiRuntimeOptions { ModulePath = modulePath })));
 }


### PR DESCRIPTION
## Summary
Fix the Crypto API concurrency crash under concurrent SoftHSM-backed traffic and stabilize the PKCS#11 module lifecycle.

## Included work
- replace per-request PKCS#11 module load/init/finalize with a process-wide shared runtime
- keep requests opening/closing their own sessions against the shared initialized module
- align readiness checks with the same shared runtime
- add concurrent SoftHSM integration coverage
- re-validate throughput after the crash fix

## Follow-up
- throughput now scales past the crash point, but the next bottleneck is per-request session/login/key-discovery overhead tracked separately in #131

## Closes
Closes #130
