### PR TITLE
Improve Crypto API PKCS#11 session reuse

### DIFF
--- a/src/Pkcs11Wrapper.CryptoApi/Configuration/CryptoApiRuntimeOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Configuration/CryptoApiRuntimeOptions.cs
@@ -8,5 +8,7 @@ public sealed class CryptoApiRuntimeOptions
 
     public string? UserPin { get; set; }
 
+    public int MaxRetainedSessionsPerSlot { get; set; } = 16;
+
     public bool DisableHttpsRedirection { get; set; }
 }

--- a/src/Pkcs11Wrapper.CryptoApi/Operations/CryptoApiCustomerOperationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Operations/CryptoApiCustomerOperationService.cs
@@ -1,7 +1,6 @@
+using System.Runtime.CompilerServices;
 using System.Text;
-using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
-using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.Native;
 
@@ -31,14 +30,14 @@ public sealed record CryptoApiRandomOperationResult(
     DateTimeOffset CompletedAtUtc);
 
 public sealed class CryptoApiPkcs11CustomerOperationService(
-    IOptions<CryptoApiRuntimeOptions> runtimeOptions,
     CryptoApiPkcs11Runtime pkcs11Runtime,
     TimeProvider timeProvider) : ICryptoApiCustomerOperationService
 {
     private const int MaxPayloadBytes = 1024 * 1024;
     private const int MaxRandomLength = 4096;
-    private const nuint CkrFunctionFailed = 0x00000006u;
-    private const nuint CkrUserAlreadyLoggedIn = 0x00000100u;
+    private static readonly nuint CkrObjectHandleInvalid = 0x00000082u;
+    private static readonly nuint CkrSessionHandleInvalid = 0x000000B3u;
+    private readonly ConditionalWeakTable<Pkcs11Session, SessionKeyHandleCache> _sessionKeyHandleCaches = new();
 
     public CryptoApiSignOperationResult Sign(CryptoApiAuthorizedKeyOperation authorization, string? algorithm, string? payloadBase64)
     {
@@ -46,14 +45,22 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
 
         SignatureAlgorithmProfile profile = SignatureAlgorithmProfile.Parse(algorithm);
         byte[] payload = ParseRequiredBase64(payloadBase64, nameof(payloadBase64), MaxPayloadBytes);
+        Pkcs11SlotId slotId = ResolveRequiredSlotId(authorization);
 
-        Pkcs11Module module = pkcs11Runtime.GetInitializedModule();
-        using Pkcs11Session session = OpenCompatibleSession(module, ResolveRequiredSlotId(authorization));
-        LoginIfConfigured(session);
+        using CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease = pkcs11Runtime.RentSession(slotId);
+        Pkcs11Session session = sessionLease.Session;
+        ResolvedKeyLocator locator = ResolveRequiredLocator(authorization);
+        KeyHandleCacheKey cacheKey = CreateCacheKey(locator, profile, forSign: true);
 
-        Pkcs11ObjectHandle keyHandle = ResolveRequiredKeyHandle(session, authorization, profile, forSign: true);
-        Pkcs11Mechanism mechanism = profile.CreateMechanism();
-        byte[] signature = SignWithRetry(session, keyHandle, mechanism, payload);
+        byte[] signature = ExecuteWithKeyHandleRecovery(
+            sessionLease,
+            cacheKey,
+            () =>
+            {
+                Pkcs11ObjectHandle keyHandle = ResolveRequiredKeyHandle(session, authorization, locator, profile, forSign: true);
+                Pkcs11Mechanism mechanism = profile.CreateMechanism();
+                return SignWithRetry(session, keyHandle, mechanism, payload);
+            });
 
         return new CryptoApiSignOperationResult(profile.Name, signature, timeProvider.GetUtcNow());
     }
@@ -65,14 +72,22 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         SignatureAlgorithmProfile profile = SignatureAlgorithmProfile.Parse(algorithm);
         byte[] payload = ParseRequiredBase64(payloadBase64, nameof(payloadBase64), MaxPayloadBytes);
         byte[] signature = ParseRequiredBase64(signatureBase64, nameof(signatureBase64), MaxPayloadBytes);
+        Pkcs11SlotId slotId = ResolveRequiredSlotId(authorization);
 
-        Pkcs11Module module = pkcs11Runtime.GetInitializedModule();
-        using Pkcs11Session session = OpenCompatibleSession(module, ResolveRequiredSlotId(authorization));
-        LoginIfConfigured(session);
+        using CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease = pkcs11Runtime.RentSession(slotId);
+        Pkcs11Session session = sessionLease.Session;
+        ResolvedKeyLocator locator = ResolveRequiredLocator(authorization);
+        KeyHandleCacheKey cacheKey = CreateCacheKey(locator, profile, forSign: false);
 
-        Pkcs11ObjectHandle keyHandle = ResolveRequiredKeyHandle(session, authorization, profile, forSign: false);
-        Pkcs11Mechanism mechanism = profile.CreateMechanism();
-        bool verified = session.Verify(keyHandle, mechanism, payload, signature);
+        bool verified = ExecuteWithKeyHandleRecovery(
+            sessionLease,
+            cacheKey,
+            () =>
+            {
+                Pkcs11ObjectHandle keyHandle = ResolveRequiredKeyHandle(session, authorization, locator, profile, forSign: false);
+                Pkcs11Mechanism mechanism = profile.CreateMechanism();
+                return session.Verify(keyHandle, mechanism, payload, signature);
+            });
 
         return new CryptoApiVerifyOperationResult(profile.Name, verified, timeProvider.GetUtcNow());
     }
@@ -83,12 +98,11 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(length, MaxRandomLength);
 
-        Pkcs11Module module = pkcs11Runtime.GetInitializedModule();
-        using Pkcs11Session session = OpenCompatibleSession(module, ResolveRequiredSlotId(authorization));
-        LoginIfConfigured(session);
+        Pkcs11SlotId slotId = ResolveRequiredSlotId(authorization);
+        using CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease = pkcs11Runtime.RentSession(slotId);
 
         byte[] buffer = new byte[length];
-        session.GenerateRandom(buffer);
+        sessionLease.Session.GenerateRandom(buffer);
         return new CryptoApiRandomOperationResult(buffer, timeProvider.GetUtcNow());
     }
 
@@ -103,41 +117,7 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         return new Pkcs11SlotId((nuint)slotId.Value);
     }
 
-    private void LoginIfConfigured(Pkcs11Session session)
-    {
-        string userPin = runtimeOptions.Value.UserPin?.Trim() ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(userPin))
-        {
-            return;
-        }
-
-        byte[] pinUtf8 = Encoding.UTF8.GetBytes(userPin);
-        try
-        {
-            session.Login(Pkcs11UserType.User, pinUtf8);
-        }
-        catch (Pkcs11Exception ex) when ((nuint)ex.RawResult == CkrUserAlreadyLoggedIn)
-        {
-        }
-    }
-
-    private static Pkcs11Session OpenCompatibleSession(Pkcs11Module module, Pkcs11SlotId slotId)
-    {
-        try
-        {
-            return module.OpenSession(slotId, readWrite: false);
-        }
-        catch (Pkcs11Exception ex) when ((nuint)ex.RawResult == CkrFunctionFailed)
-        {
-            return module.OpenSession(slotId, readWrite: true);
-        }
-    }
-
-    private static Pkcs11ObjectHandle ResolveRequiredKeyHandle(
-        Pkcs11Session session,
-        CryptoApiAuthorizedKeyOperation authorization,
-        SignatureAlgorithmProfile profile,
-        bool forSign)
+    private static ResolvedKeyLocator ResolveRequiredLocator(CryptoApiAuthorizedKeyOperation authorization)
     {
         byte[] objectId = ParseOptionalHex(authorization.ResolvedRoute.ObjectIdHex);
         byte[] objectLabel = string.IsNullOrWhiteSpace(authorization.ResolvedRoute.ObjectLabel)
@@ -149,12 +129,55 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
             throw new CryptoApiOperationConfigurationException($"Key alias '{authorization.AliasName}' does not define a PKCS#11 object locator.");
         }
 
-        KeyResolutionAttempt result;
-        if (objectId.Length != 0)
+        return new ResolvedKeyLocator(
+            ObjectId: objectId,
+            ObjectIdHex: objectId.Length == 0 ? null : Convert.ToHexString(objectId),
+            ObjectLabel: objectLabel,
+            ObjectLabelText: objectLabel.Length == 0 ? null : authorization.ResolvedRoute.ObjectLabel?.Trim());
+    }
+
+    private T ExecuteWithKeyHandleRecovery<T>(
+        CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease,
+        KeyHandleCacheKey cacheKey,
+        Func<T> operation)
+    {
+        try
         {
-            result = TryResolveKeyHandle(session, objectId, label: null, profile, forSign);
+            return operation();
+        }
+        catch (Pkcs11Exception ex) when ((nuint)ex.RawResult == CkrObjectHandleInvalid)
+        {
+            GetOrCreateSessionKeyHandleCache(sessionLease.Session).Invalidate(cacheKey);
+            return operation();
+        }
+        catch (Pkcs11Exception ex) when ((nuint)ex.RawResult == CkrSessionHandleInvalid)
+        {
+            sessionLease.MarkBroken();
+            throw new CryptoApiOperationExecutionException("The PKCS#11 session became invalid during execution. Retry the request.", ex);
+        }
+    }
+
+    private Pkcs11ObjectHandle ResolveRequiredKeyHandle(
+        Pkcs11Session session,
+        CryptoApiAuthorizedKeyOperation authorization,
+        ResolvedKeyLocator locator,
+        SignatureAlgorithmProfile profile,
+        bool forSign)
+    {
+        KeyHandleCacheKey cacheKey = CreateCacheKey(locator, profile, forSign);
+        SessionKeyHandleCache cache = GetOrCreateSessionKeyHandleCache(session);
+        if (cache.TryGetValue(cacheKey, out Pkcs11ObjectHandle cachedHandle))
+        {
+            return cachedHandle;
+        }
+
+        KeyResolutionAttempt result;
+        if (locator.ObjectId.Length != 0)
+        {
+            result = TryResolveKeyHandle(session, locator.ObjectId, label: null, profile, forSign);
             if (result.Handle is not null)
             {
+                cache.Set(cacheKey, result.Handle.Value);
                 return result.Handle.Value;
             }
 
@@ -164,11 +187,12 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
             }
         }
 
-        if (objectLabel.Length != 0)
+        if (locator.ObjectLabel.Length != 0)
         {
-            result = TryResolveKeyHandle(session, id: null, objectLabel, profile, forSign);
+            result = TryResolveKeyHandle(session, id: null, locator.ObjectLabel, profile, forSign);
             if (result.Handle is not null)
             {
+                cache.Set(cacheKey, result.Handle.Value);
                 return result.Handle.Value;
             }
 
@@ -180,6 +204,17 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
 
         throw new CryptoApiOperationExecutionException($"Key alias '{authorization.AliasName}' could not be resolved to a PKCS#11 object for {(forSign ? "signing" : "verification")}.");
     }
+
+    private SessionKeyHandleCache GetOrCreateSessionKeyHandleCache(Pkcs11Session session)
+        => _sessionKeyHandleCaches.GetValue(session, static _ => new SessionKeyHandleCache());
+
+    private static KeyHandleCacheKey CreateCacheKey(ResolvedKeyLocator locator, SignatureAlgorithmProfile profile, bool forSign)
+        => new(
+            locator.ObjectIdHex,
+            locator.ObjectLabelText,
+            profile.KeyType,
+            forSign ? profile.SignObjectClass : profile.VerifyObjectClass,
+            forSign);
 
     private static KeyResolutionAttempt TryResolveKeyHandle(
         Pkcs11Session session,
@@ -277,6 +312,33 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         {
             throw new CryptoApiOperationConfigurationException($"Configured object ID hex '{value}' is not valid.", ex);
         }
+    }
+
+    private readonly record struct ResolvedKeyLocator(
+        byte[] ObjectId,
+        string? ObjectIdHex,
+        byte[] ObjectLabel,
+        string? ObjectLabelText);
+
+    private readonly record struct KeyHandleCacheKey(
+        string? ObjectIdHex,
+        string? ObjectLabel,
+        Pkcs11KeyType KeyType,
+        Pkcs11ObjectClass ObjectClass,
+        bool ForSign);
+
+    private sealed class SessionKeyHandleCache
+    {
+        private readonly Dictionary<KeyHandleCacheKey, Pkcs11ObjectHandle> _handles = new();
+
+        public bool TryGetValue(KeyHandleCacheKey key, out Pkcs11ObjectHandle handle)
+            => _handles.TryGetValue(key, out handle);
+
+        public void Set(KeyHandleCacheKey key, Pkcs11ObjectHandle handle)
+            => _handles[key] = handle;
+
+        public void Invalidate(KeyHandleCacheKey key)
+            => _handles.Remove(key);
     }
 
     private readonly record struct KeyResolutionAttempt(Pkcs11ObjectHandle? Handle, bool Ambiguous);

--- a/src/Pkcs11Wrapper.CryptoApi/Runtime/CryptoApiPkcs11Runtime.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Runtime/CryptoApiPkcs11Runtime.cs
@@ -1,13 +1,19 @@
+using System.Collections.Concurrent;
+using System.Text;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Operations;
+using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.CryptoApi.Runtime;
 
 public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> runtimeOptions) : IDisposable
 {
+    private static readonly nuint CkrFunctionFailed = 0x00000006u;
+    private static readonly nuint CkrUserAlreadyLoggedIn = 0x00000100u;
     private readonly object _sync = new();
+    private readonly ConcurrentDictionary<Pkcs11SlotId, SlotSessionPool> _sessionPools = new();
     private Pkcs11Module? _module;
     private bool _disposed;
 
@@ -20,10 +26,7 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
 
         lock (_sync)
         {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(CryptoApiPkcs11Runtime));
-            }
+            ThrowIfDisposed();
 
             if (_module is not null)
             {
@@ -51,6 +54,19 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
         }
     }
 
+    internal CryptoApiPooledSessionLease RentSession(Pkcs11SlotId slotId)
+    {
+        ThrowIfDisposed();
+
+        SlotSessionPool pool = _sessionPools.GetOrAdd(slotId, static _ => new SlotSessionPool());
+        if (pool.TryRent(out Pkcs11Session? existingSession) && existingSession is not null)
+        {
+            return new CryptoApiPooledSessionLease(this, slotId, existingSession);
+        }
+
+        return new CryptoApiPooledSessionLease(this, slotId, CreateAuthenticatedSession(slotId));
+    }
+
     public void Dispose()
     {
         lock (_sync)
@@ -61,8 +77,167 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
             }
 
             _disposed = true;
+        }
+
+        foreach ((_, SlotSessionPool pool) in _sessionPools)
+        {
+            pool.Dispose();
+        }
+
+        _sessionPools.Clear();
+
+        lock (_sync)
+        {
             _module?.Dispose();
             _module = null;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(CryptoApiPkcs11Runtime));
+        }
+    }
+
+    private Pkcs11Session CreateAuthenticatedSession(Pkcs11SlotId slotId)
+    {
+        Pkcs11Module module = GetInitializedModule();
+        Pkcs11Session session = OpenCompatibleSession(module, slotId);
+
+        try
+        {
+            LoginIfConfigured(session);
+            return session;
+        }
+        catch
+        {
+            session.Dispose();
+            throw;
+        }
+    }
+
+    private void ReturnSession(Pkcs11SlotId slotId, Pkcs11Session session, bool broken)
+    {
+        if (_disposed || broken)
+        {
+            session.Dispose();
+            return;
+        }
+
+        SlotSessionPool pool = _sessionPools.GetOrAdd(slotId, static _ => new SlotSessionPool());
+        if (!pool.TryReturn(session, GetMaxRetainedSessionsPerSlot()))
+        {
+            session.Dispose();
+        }
+    }
+
+    private int GetMaxRetainedSessionsPerSlot()
+        => Math.Max(runtimeOptions.Value.MaxRetainedSessionsPerSlot, 0);
+
+    private void LoginIfConfigured(Pkcs11Session session)
+    {
+        string userPin = runtimeOptions.Value.UserPin?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(userPin))
+        {
+            return;
+        }
+
+        byte[] pinUtf8 = Encoding.UTF8.GetBytes(userPin);
+        try
+        {
+            session.Login(Pkcs11UserType.User, pinUtf8);
+        }
+        catch (Pkcs11Exception ex) when ((nuint)ex.RawResult == CkrUserAlreadyLoggedIn)
+        {
+        }
+    }
+
+    private static Pkcs11Session OpenCompatibleSession(Pkcs11Module module, Pkcs11SlotId slotId)
+    {
+        try
+        {
+            return module.OpenSession(slotId, readWrite: false);
+        }
+        catch (Pkcs11Exception ex) when ((nuint)ex.RawResult == CkrFunctionFailed)
+        {
+            return module.OpenSession(slotId, readWrite: true);
+        }
+    }
+
+    internal sealed class CryptoApiPooledSessionLease : IDisposable
+    {
+        private readonly CryptoApiPkcs11Runtime _runtime;
+        private readonly Pkcs11SlotId _slotId;
+        private bool _broken;
+        private bool _disposed;
+
+        public CryptoApiPooledSessionLease(CryptoApiPkcs11Runtime runtime, Pkcs11SlotId slotId, Pkcs11Session session)
+        {
+            _runtime = runtime;
+            _slotId = slotId;
+            Session = session;
+        }
+
+        public Pkcs11Session Session { get; }
+
+        public void MarkBroken() => _broken = true;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _runtime.ReturnSession(_slotId, Session, _broken);
+        }
+    }
+
+    private sealed class SlotSessionPool : IDisposable
+    {
+        private readonly ConcurrentQueue<Pkcs11Session> _idleSessions = new();
+        private int _idleCount;
+
+        public bool TryRent(out Pkcs11Session? session)
+        {
+            while (_idleSessions.TryDequeue(out session))
+            {
+                _ = Interlocked.Decrement(ref _idleCount);
+                return true;
+            }
+
+            session = null;
+            return false;
+        }
+
+        public bool TryReturn(Pkcs11Session session, int maxRetainedSessions)
+        {
+            if (maxRetainedSessions <= 0)
+            {
+                return false;
+            }
+
+            int newIdleCount = Interlocked.Increment(ref _idleCount);
+            if (newIdleCount > maxRetainedSessions)
+            {
+                _ = Interlocked.Decrement(ref _idleCount);
+                return false;
+            }
+
+            _idleSessions.Enqueue(session);
+            return true;
+        }
+
+        public void Dispose()
+        {
+            while (_idleSessions.TryDequeue(out Pkcs11Session? session))
+            {
+                _ = Interlocked.Decrement(ref _idleCount);
+                session.Dispose();
+            }
         }
     }
 }

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Text;
@@ -9,6 +10,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Pkcs11Wrapper;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Runtime;
+using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.CryptoApi.Tests;
 
@@ -117,6 +120,56 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
         Assert.Contains(responses, response => string.Equals(response.Path, "/api/v1/operations/random", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task SequentialRequestsReuseSessionLoginAndKeyLookupAgainstSoftHsm()
+    {
+        if (!SoftHsmTestContext.IsSupported())
+        {
+            return;
+        }
+
+        await using SoftHsmTestContext context = await SoftHsmTestContext.CreateAsync();
+        if (!context.CanExecuteInProcess)
+        {
+            return;
+        }
+
+        await using WebApplicationFactory<Program> factory = CreateFactory(context);
+
+        SeededAccess access = await SeedAuthorizedAccessAsync(factory, context);
+
+        using IServiceScope scope = factory.Services.CreateScope();
+        CryptoApiPkcs11Runtime runtime = scope.ServiceProvider.GetRequiredService<CryptoApiPkcs11Runtime>();
+        CountingTelemetryListener telemetry = new();
+        runtime.GetInitializedModule().TelemetryListener = telemetry;
+
+        HttpClient httpClient = factory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+        string payloadBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("steady-state crypto api"));
+        for (int i = 0; i < 3; i++)
+        {
+            using HttpResponseMessage signResponse = await httpClient.PostAsync(
+                "/api/v1/operations/sign",
+                CreateJsonContent($"{{\"keyAlias\":\"{context.AliasName}\",\"algorithm\":\"RS256\",\"payloadBase64\":\"{payloadBase64}\"}}"));
+            Assert.Equal(HttpStatusCode.OK, signResponse.StatusCode);
+        }
+
+        for (int i = 0; i < 3; i++)
+        {
+            using HttpResponseMessage randomResponse = await httpClient.PostAsync(
+                "/api/v1/operations/random",
+                CreateJsonContent($"{{\"keyAlias\":\"{context.AliasName}\",\"length\":32}}"));
+            Assert.Equal(HttpStatusCode.OK, randomResponse.StatusCode);
+        }
+
+        Assert.Equal(1, telemetry.GetCount("C_OpenSession"));
+        Assert.Equal(1, telemetry.GetCount("C_Login"));
+        Assert.Equal(1, telemetry.GetCount("C_FindObjects"));
+        Assert.Equal(3, telemetry.GetCount("C_GenerateRandom"));
+    }
+
     private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, SoftHsmTestContext context)
     {
         using IServiceScope scope = factory.Services.CreateScope();
@@ -183,6 +236,20 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
         CryptoApiManagedPolicy Policy);
 
     private sealed record OperationResponse(string Path, HttpStatusCode StatusCode, string Body);
+
+    private sealed class CountingTelemetryListener : IPkcs11OperationTelemetryListener
+    {
+        private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.Ordinal);
+
+        public void OnOperationCompleted(in Pkcs11OperationTelemetryEvent operationEvent)
+        {
+            string key = operationEvent.NativeOperationName ?? operationEvent.OperationName;
+            _counts.AddOrUpdate(key, 1, static (_, count) => count + 1);
+        }
+
+        public int GetCount(string operationName)
+            => _counts.TryGetValue(operationName, out int count) ? count : 0;
+    }
 
     private sealed class SoftHsmTestContext : IAsyncDisposable
     {
@@ -372,45 +439,4 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
             return false;
         }
 
-        private static async Task<ProcessResult> RunProcessAsync(string fileName, IReadOnlyList<string> arguments, string configPath)
-        {
-            ProcessStartInfo startInfo = new(fileName)
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            foreach (string argument in arguments)
-            {
-                startInfo.ArgumentList.Add(argument);
-            }
-
-            startInfo.Environment[SoftHsmConfEnvironmentVariable] = configPath;
-
-            using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Could not start '{fileName}'.");
-            string stdout = await process.StandardOutput.ReadToEndAsync();
-            string stderr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            if (process.ExitCode != 0)
-            {
-                throw new InvalidOperationException($"Command '{fileName} {string.Join(' ', arguments)}' failed with exit code {process.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{stdout}{Environment.NewLine}STDERR:{Environment.NewLine}{stderr}");
-            }
-
-            return new ProcessResult(stdout, stderr);
-        }
-
-        private static void DeleteDatabaseArtifacts(string databasePath)
-        {
-            string walPath = databasePath + "-wal";
-            string shmPath = databasePath + "-shm";
-
-            if (File.Exists(databasePath)) File.Delete(databasePath);
-            if (File.Exists(walPath)) File.Delete(walPath);
-            if (File.Exists(shmPath)) File.Delete(shmPath);
-        }
-
-        private sealed record ProcessResult(string StandardOutput, string StandardError);
-    }
-}
+        private static async Task<ProcessResult> RunP


### PR DESCRIPTION
Improve steady-state Crypto API performance by reusing PKCS#11 sessions and per-session key resolution work. Follow-up performance ceiling remains tracked in #133. Closes #131.