### PR TITLE
Improve Crypto API auth/shared-state request-path throughput

### DIFF
--- a/docs/crypto-api-deployment.md
+++ b/docs/crypto-api-deployment.md
@@ -117,6 +117,10 @@ When both point at the same `CryptoApiSharedPersistence:ConnectionString`, they 
 - binding relationships
 - usage metadata such as `last_used_at_utc`
 
+Each API node may still keep a **small local request-path cache** for successful auth + authorization decisions.
+That cache is intentionally node-local and disposable; correctness still comes from the shared database because cache keys are tied to a shared auth-state revision that advances when clients, keys, aliases, policies, or bindings change.
+`last_used_at_utc` remains shared metadata, but the host now writes it on a short throttled interval instead of once per successful request.
+
 ### Not shared
 
 The following stay admin-local and should **not** be treated as Crypto API shared state:

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -69,6 +69,15 @@ The host is still designed around a **stateless request pipeline**:
 
 That means the API host stays stateless from the instance point of view even though shared durable data now exists for the state that would otherwise break under scale-out.
 
+Steady-state request execution is now intentionally **two-tiered**:
+
+- the source of truth for auth, alias, and policy state remains the shared persistence store
+- each API node keeps a small bounded in-memory cache for successful auth and authorization decisions
+- cache entries are keyed by a lightweight shared-state auth revision so admin changes still invalidate warm entries across nodes without forcing full snapshot reloads on every request
+- `last_used_at_utc` updates are throttled to a short interval per key instead of writing synchronously on every successful request
+
+This keeps the instance stateless in the deployment sense while removing avoidable per-request PBKDF2, full-snapshot, and SQLite write overhead from the hot path.
+
 ## Shared persistence approach
 
 The first persistence provider is intentionally pragmatic: **SQLite via a shared database file**.

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyAccessModels.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyAccessModels.cs
@@ -93,6 +93,12 @@ public sealed record CryptoApiKeyOperationAuthorizationResult(
     string? FailureReason,
     CryptoApiAuthorizedKeyOperation? Authorization);
 
+public sealed record CryptoApiRequestAuthorizationResult(
+    bool Succeeded,
+    int? FailureStatusCode,
+    string? FailureReason,
+    CryptoApiAuthorizedKeyOperation? Authorization);
+
 internal static class CryptoApiOperationPolicyDocumentCodec
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyOperationAuthorizationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyOperationAuthorizationService.cs
@@ -1,13 +1,101 @@
 using System.Text.Json;
+using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
 namespace Pkcs11Wrapper.CryptoApi.Access;
 
-public sealed class CryptoApiKeyOperationAuthorizationService(
-    ICryptoApiSharedStateStore sharedStateStore,
-    TimeProvider timeProvider)
+public sealed class CryptoApiKeyOperationAuthorizationService
 {
+    private readonly ICryptoApiSharedStateStore _sharedStateStore;
+    private readonly TimeProvider _timeProvider;
+    private readonly CryptoApiClientSecretHasher _secretHasher;
+    private readonly CryptoApiRequestPathCache _requestPathCache;
+
+    public CryptoApiKeyOperationAuthorizationService(
+        ICryptoApiSharedStateStore sharedStateStore,
+        TimeProvider timeProvider,
+        CryptoApiClientSecretHasher? secretHasher = null,
+        CryptoApiRequestPathCache? requestPathCache = null)
+    {
+        _sharedStateStore = sharedStateStore;
+        _timeProvider = timeProvider;
+        _secretHasher = secretHasher ?? new CryptoApiClientSecretHasher();
+        _requestPathCache = requestPathCache ?? new CryptoApiRequestPathCache(timeProvider);
+    }
+
+    public async Task<CryptoApiRequestAuthorizationResult> AuthorizeRequestAsync(
+        string? keyIdentifier,
+        string? secret,
+        string? aliasName,
+        string? operation,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(keyIdentifier) || string.IsNullOrWhiteSpace(secret))
+        {
+            return AuthenticationFailed("API key id and secret are required.");
+        }
+
+        string normalizedKeyIdentifier = keyIdentifier.Trim();
+        string normalizedSecret = secret.Trim();
+        string normalizedAliasName = NormalizeAliasName(aliasName, nameof(aliasName));
+        string normalizedOperation = CryptoApiOperationPolicyDocumentCodec.NormalizeOperation(operation, nameof(operation));
+
+        long authStateRevision = await _sharedStateStore.GetAuthStateRevisionAsync(cancellationToken);
+        if (authStateRevision <= 0)
+        {
+            return AuthenticationFailed("Shared persistence is not configured.");
+        }
+
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        string secretFingerprint = _requestPathCache.CreateSecretFingerprint(normalizedSecret);
+        CryptoApiSharedStateSnapshot? snapshot = null;
+        CryptoApiAuthenticatedClient authenticatedClient;
+
+        if (_requestPathCache.TryGetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now, out CryptoApiAuthenticatedClient cachedClient))
+        {
+            authenticatedClient = cachedClient;
+        }
+        else
+        {
+            snapshot = await _sharedStateStore.GetSnapshotAsync(cancellationToken);
+            AuthenticatedClientAuthenticationResult authentication = AuthenticateClientFromSnapshot(snapshot, normalizedKeyIdentifier, normalizedSecret, now);
+            if (!authentication.Succeeded || authentication.Template is null)
+            {
+                return AuthenticationFailed(authentication.FailureReason ?? "The provided API credentials were rejected.");
+            }
+
+            authenticatedClient = authentication.Template.Client;
+            await RefreshLastUsedIfNeededAsync(authStateRevision, authentication.Template.Key, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+            _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
+        }
+
+        await RefreshLastUsedIfNeededAsync(authStateRevision, authenticatedClient.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+
+        if (_requestPathCache.TryGetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, normalizedAliasName, normalizedOperation, authenticatedClient, now, out CryptoApiAuthorizedKeyOperation cachedAuthorization))
+        {
+            return new CryptoApiRequestAuthorizationResult(
+                Succeeded: true,
+                FailureStatusCode: null,
+                FailureReason: null,
+                Authorization: cachedAuthorization);
+        }
+
+        snapshot ??= await _sharedStateStore.GetSnapshotAsync(cancellationToken);
+        CryptoApiKeyOperationAuthorizationResult authorization = AuthorizeFromSnapshot(snapshot, authenticatedClient, normalizedAliasName, normalizedOperation);
+        if (!authorization.Succeeded || authorization.Authorization is null)
+        {
+            return AuthorizationFailed(authorization.FailureReason ?? "The caller is not allowed to use the requested key alias or operation.");
+        }
+
+        _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, authorization.Authorization);
+        return new CryptoApiRequestAuthorizationResult(
+            Succeeded: true,
+            FailureStatusCode: null,
+            FailureReason: null,
+            Authorization: authorization.Authorization);
+    }
+
     public async Task<CryptoApiKeyOperationAuthorizationResult> AuthorizeAsync(
         CryptoApiAuthenticatedClient authenticatedClient,
         string? aliasName,
@@ -19,13 +107,138 @@ public sealed class CryptoApiKeyOperationAuthorizationService(
         string normalizedAliasName = NormalizeAliasName(aliasName, nameof(aliasName));
         string normalizedOperation = CryptoApiOperationPolicyDocumentCodec.NormalizeOperation(operation, nameof(operation));
 
-        CryptoApiSharedStateStatus status = await sharedStateStore.GetStatusAsync(cancellationToken);
-        if (!status.Configured)
+        long authStateRevision = await _sharedStateStore.GetAuthStateRevisionAsync(cancellationToken);
+        if (authStateRevision <= 0)
         {
             return Failed("Shared persistence is not configured.");
         }
 
-        CryptoApiSharedStateSnapshot snapshot = await sharedStateStore.GetSnapshotAsync(cancellationToken);
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        if (_requestPathCache.TryGetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, normalizedAliasName, normalizedOperation, authenticatedClient, now, out CryptoApiAuthorizedKeyOperation cachedAuthorization))
+        {
+            return new CryptoApiKeyOperationAuthorizationResult(
+                Succeeded: true,
+                FailureReason: null,
+                Authorization: cachedAuthorization);
+        }
+
+        CryptoApiSharedStateSnapshot snapshot = await _sharedStateStore.GetSnapshotAsync(cancellationToken);
+        CryptoApiKeyOperationAuthorizationResult authorization = AuthorizeFromSnapshot(snapshot, authenticatedClient, normalizedAliasName, normalizedOperation);
+        if (authorization.Succeeded && authorization.Authorization is not null)
+        {
+            _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, authorization.Authorization);
+        }
+
+        return authorization;
+    }
+    private AuthenticatedClientAuthenticationResult AuthenticateClientFromSnapshot(
+        CryptoApiSharedStateSnapshot snapshot,
+        string normalizedKeyIdentifier,
+        string normalizedSecret,
+        DateTimeOffset now)
+    {
+        CryptoApiClientKeyRecord? key = snapshot.ClientKeys.FirstOrDefault(candidate => string.Equals(candidate.KeyIdentifier, normalizedKeyIdentifier, StringComparison.Ordinal));
+        if (key is null)
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "API key was not found.", null);
+        }
+
+        CryptoApiClientRecord? client = snapshot.Clients.FirstOrDefault(candidate => candidate.ClientId == key.ClientId);
+        if (client is null)
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "Owning API client was not found.", null);
+        }
+
+        if (!client.IsEnabled)
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "API client is disabled.", null);
+        }
+
+        if (key.RevokedAtUtc is not null)
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "API key has been revoked.", null);
+        }
+
+        if (!key.IsEnabled)
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "API key is disabled.", null);
+        }
+
+        if (key.ExpiresAtUtc is DateTimeOffset expiresAtUtc && expiresAtUtc <= now)
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "API key has expired.", null);
+        }
+
+        if (!_secretHasher.VerifySecret(normalizedSecret, key.SecretHash))
+        {
+            return new AuthenticatedClientAuthenticationResult(false, "API key secret is invalid.", null);
+        }
+
+        Guid[] boundPolicyIds = snapshot.ClientPolicyBindings
+            .Where(binding => binding.ClientId == client.ClientId)
+            .Select(binding => binding.PolicyId)
+            .Distinct()
+            .OrderBy(id => id)
+            .ToArray();
+
+        return new AuthenticatedClientAuthenticationResult(
+            true,
+            null,
+            new AuthenticatedClientTemplate(
+                new CryptoApiAuthenticatedClient(
+                ClientId: client.ClientId,
+                ClientName: client.ClientName,
+                DisplayName: client.DisplayName,
+                ApplicationType: client.ApplicationType,
+                AuthenticationMode: client.AuthenticationMode,
+                ClientKeyId: key.ClientKeyId,
+                KeyIdentifier: key.KeyIdentifier,
+                CredentialType: key.CredentialType,
+                AuthenticatedAtUtc: now,
+                ExpiresAtUtc: key.ExpiresAtUtc,
+                BoundPolicyIds: boundPolicyIds),
+                key));
+    }
+
+    private async Task RefreshLastUsedIfNeededAsync(
+        long authStateRevision,
+        CryptoApiClientKeyRecord key,
+        string normalizedKeyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        if (key.LastUsedAtUtc is DateTimeOffset lastUsedAtUtc && now - lastUsedAtUtc < _requestPathCache.LastUsedWriteInterval)
+        {
+            return;
+        }
+
+        await RefreshLastUsedIfNeededAsync(authStateRevision, key.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+    }
+
+    private async Task RefreshLastUsedIfNeededAsync(
+        long authStateRevision,
+        Guid clientKeyId,
+        string normalizedKeyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        if (!_requestPathCache.ShouldRefreshLastUsed(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now))
+        {
+            return;
+        }
+
+        _ = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, _requestPathCache.LastUsedWriteInterval, cancellationToken);
+        _requestPathCache.RecordLastUsedRefresh(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
+    }
+
+    private CryptoApiKeyOperationAuthorizationResult AuthorizeFromSnapshot(
+        CryptoApiSharedStateSnapshot snapshot,
+        CryptoApiAuthenticatedClient authenticatedClient,
+        string normalizedAliasName,
+        string normalizedOperation)
+    {
         CryptoApiClientRecord? client = snapshot.Clients.FirstOrDefault(candidate => candidate.ClientId == authenticatedClient.ClientId);
         if (client is null || !client.IsEnabled)
         {
@@ -102,8 +315,22 @@ public sealed class CryptoApiKeyOperationAuthorizationService(
                     ObjectLabel: alias.ObjectLabel,
                     ObjectIdHex: alias.ObjectIdHex),
                 MatchedPolicies: matchedPolicies.OrderBy(policy => policy.PolicyName, StringComparer.OrdinalIgnoreCase).ToArray(),
-                AuthorizedAtUtc: timeProvider.GetUtcNow()));
+                AuthorizedAtUtc: _timeProvider.GetUtcNow()));
     }
+
+    private static CryptoApiRequestAuthorizationResult AuthenticationFailed(string reason)
+        => new(
+            Succeeded: false,
+            FailureStatusCode: 401,
+            FailureReason: reason,
+            Authorization: null);
+
+    private static CryptoApiRequestAuthorizationResult AuthorizationFailed(string reason)
+        => new(
+            Succeeded: false,
+            FailureStatusCode: 403,
+            FailureReason: reason,
+            Authorization: null);
 
     private static CryptoApiKeyOperationAuthorizationResult Failed(string reason)
         => new(
@@ -127,4 +354,13 @@ public sealed class CryptoApiKeyOperationAuthorizationService(
 
         return normalized;
     }
+
+    private sealed record AuthenticatedClientTemplate(
+        CryptoApiAuthenticatedClient Client,
+        CryptoApiClientKeyRecord Key);
+
+    private sealed record AuthenticatedClientAuthenticationResult(
+        bool Succeeded,
+        string? FailureReason,
+        AuthenticatedClientTemplate? Template);
 }

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/CryptoApiRequestPathCache.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/CryptoApiRequestPathCache.cs
@@ -1,0 +1,193 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+
+namespace Pkcs11Wrapper.CryptoApi.Caching;
+
+public sealed class CryptoApiRequestPathCache : IDisposable
+{
+    private readonly CryptoApiRequestPathCachingOptions _options;
+    private readonly MemoryCache _authenticationCache;
+    private readonly MemoryCache _authorizationCache;
+
+    public CryptoApiRequestPathCache(TimeProvider timeProvider)
+        : this(timeProvider, new CryptoApiRequestPathCachingOptions())
+    {
+    }
+
+    public CryptoApiRequestPathCache(TimeProvider timeProvider, CryptoApiRequestPathCachingOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _authenticationCache = new MemoryCache(new MemoryCacheOptions { SizeLimit = Math.Max(1, options.AuthenticationEntryLimit) });
+        _authorizationCache = new MemoryCache(new MemoryCacheOptions { SizeLimit = Math.Max(1, options.AuthorizationEntryLimit) });
+    }
+
+    public bool Enabled
+        => _options.Enabled;
+
+    public TimeSpan LastUsedWriteInterval
+        => _options.LastUsedWriteInterval;
+
+    public string CreateSecretFingerprint(string normalizedSecret)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(normalizedSecret);
+
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedSecret));
+        return Convert.ToHexString(hash);
+    }
+
+    public bool TryGetAuthenticatedClient(long authStateRevision, string keyIdentifier, string secretFingerprint, DateTimeOffset now, out CryptoApiAuthenticatedClient authenticatedClient)
+    {
+        authenticatedClient = null!;
+
+        if (!Enabled)
+        {
+            return false;
+        }
+
+        if (!_authenticationCache.TryGetValue(new AuthenticationCacheKey(authStateRevision, keyIdentifier, secretFingerprint), out AuthenticationCacheEntry? entry)
+            || entry is null)
+        {
+            return false;
+        }
+
+        if (entry.Template.ExpiresAtUtc is DateTimeOffset expiresAtUtc && expiresAtUtc <= now)
+        {
+            return false;
+        }
+
+        authenticatedClient = entry.Template with { AuthenticatedAtUtc = now };
+        return true;
+    }
+
+    public void SetAuthenticatedClient(long authStateRevision, string keyIdentifier, string secretFingerprint, CryptoApiAuthenticatedClient authenticatedClient, DateTimeOffset lastUsedRecordedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(authenticatedClient);
+
+        if (!Enabled)
+        {
+            return;
+        }
+
+        _authenticationCache.Set(
+            new AuthenticationCacheKey(authStateRevision, keyIdentifier, secretFingerprint),
+            new AuthenticationCacheEntry(authenticatedClient, lastUsedRecordedAtUtc),
+            new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = _options.EntryTtl,
+                Size = 1
+            });
+    }
+
+    public bool ShouldRefreshLastUsed(long authStateRevision, string keyIdentifier, string secretFingerprint, DateTimeOffset now)
+    {
+        if (!Enabled)
+        {
+            return true;
+        }
+
+        if (!_authenticationCache.TryGetValue(new AuthenticationCacheKey(authStateRevision, keyIdentifier, secretFingerprint), out AuthenticationCacheEntry? entry)
+            || entry is null)
+        {
+            return true;
+        }
+
+        return now - entry.LastUsedRecordedAtUtc >= _options.LastUsedWriteInterval;
+    }
+
+    public void RecordLastUsedRefresh(long authStateRevision, string keyIdentifier, string secretFingerprint, DateTimeOffset now)
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        AuthenticationCacheKey cacheKey = new(authStateRevision, keyIdentifier, secretFingerprint);
+        if (_authenticationCache.TryGetValue(cacheKey, out AuthenticationCacheEntry? entry)
+            && entry is not null)
+        {
+            _authenticationCache.Set(
+                cacheKey,
+                entry with { LastUsedRecordedAtUtc = now },
+                new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = _options.EntryTtl,
+                    Size = 1
+                });
+        }
+    }
+
+    public bool TryGetAuthorizedOperation(long authStateRevision, Guid clientId, string aliasName, string operation, CryptoApiAuthenticatedClient client, DateTimeOffset now, out CryptoApiAuthorizedKeyOperation authorization)
+    {
+        authorization = null!;
+
+        if (!Enabled)
+        {
+            return false;
+        }
+
+        if (!_authorizationCache.TryGetValue(new AuthorizationCacheKey(authStateRevision, clientId, aliasName, operation), out AuthorizationCacheEntry? entry)
+            || entry is null)
+        {
+            return false;
+        }
+
+        authorization = new CryptoApiAuthorizedKeyOperation(
+            Client: client,
+            Operation: entry.Operation,
+            AliasId: entry.AliasId,
+            AliasName: entry.AliasName,
+            ResolvedRoute: entry.ResolvedRoute,
+            MatchedPolicies: entry.MatchedPolicies,
+            AuthorizedAtUtc: now);
+        return true;
+    }
+
+    public void SetAuthorizedOperation(long authStateRevision, Guid clientId, CryptoApiAuthorizedKeyOperation authorization)
+    {
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        if (!Enabled)
+        {
+            return;
+        }
+
+        _authorizationCache.Set(
+            new AuthorizationCacheKey(authStateRevision, clientId, authorization.AliasName, authorization.Operation),
+            new AuthorizationCacheEntry(
+                authorization.Operation,
+                authorization.AliasId,
+                authorization.AliasName,
+                authorization.ResolvedRoute,
+                authorization.MatchedPolicies),
+            new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = _options.EntryTtl,
+                Size = 1
+            });
+    }
+
+    public void Dispose()
+    {
+        _authenticationCache.Dispose();
+        _authorizationCache.Dispose();
+    }
+
+    private sealed record AuthenticationCacheKey(long AuthStateRevision, string KeyIdentifier, string SecretFingerprint);
+
+    private sealed record AuthenticationCacheEntry(
+        CryptoApiAuthenticatedClient Template,
+        DateTimeOffset LastUsedRecordedAtUtc);
+
+    private sealed record AuthorizationCacheKey(long AuthStateRevision, Guid ClientId, string AliasName, string Operation);
+
+    private sealed record AuthorizationCacheEntry(
+        string Operation,
+        Guid AliasId,
+        string AliasName,
+        CryptoApiResolvedKeyRoute ResolvedRoute,
+        IReadOnlyList<CryptoApiMatchedPolicy> MatchedPolicies);
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Clients/CryptoApiClientAuthenticationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Clients/CryptoApiClientAuthenticationService.cs
@@ -1,12 +1,27 @@
+using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
 namespace Pkcs11Wrapper.CryptoApi.Clients;
 
-public sealed class CryptoApiClientAuthenticationService(
-    ICryptoApiSharedStateStore sharedStateStore,
-    CryptoApiClientSecretHasher secretHasher,
-    TimeProvider timeProvider)
+public sealed class CryptoApiClientAuthenticationService
 {
+    private readonly ICryptoApiSharedStateStore _sharedStateStore;
+    private readonly CryptoApiClientSecretHasher _secretHasher;
+    private readonly TimeProvider _timeProvider;
+    private readonly CryptoApiRequestPathCache _requestPathCache;
+
+    public CryptoApiClientAuthenticationService(
+        ICryptoApiSharedStateStore sharedStateStore,
+        CryptoApiClientSecretHasher secretHasher,
+        TimeProvider timeProvider,
+        CryptoApiRequestPathCache? requestPathCache = null)
+    {
+        _sharedStateStore = sharedStateStore;
+        _secretHasher = secretHasher;
+        _timeProvider = timeProvider;
+        _requestPathCache = requestPathCache ?? new CryptoApiRequestPathCache(timeProvider);
+    }
+
     public async Task<CryptoApiClientAuthenticationResult> AuthenticateAsync(string? keyIdentifier, string? secret, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(keyIdentifier) || string.IsNullOrWhiteSpace(secret))
@@ -14,14 +29,28 @@ public sealed class CryptoApiClientAuthenticationService(
             return Failed("API key id and secret are required.");
         }
 
-        CryptoApiSharedStateStatus status = await sharedStateStore.GetStatusAsync(cancellationToken);
-        if (!status.Configured)
+        string normalizedKeyIdentifier = keyIdentifier.Trim();
+        string normalizedSecret = secret.Trim();
+
+        long authStateRevision = await _sharedStateStore.GetAuthStateRevisionAsync(cancellationToken);
+        if (authStateRevision <= 0)
         {
             return Failed("Shared persistence is not configured.");
         }
 
-        CryptoApiSharedStateSnapshot snapshot = await sharedStateStore.GetSnapshotAsync(cancellationToken);
-        CryptoApiClientKeyRecord? key = snapshot.ClientKeys.FirstOrDefault(candidate => string.Equals(candidate.KeyIdentifier, keyIdentifier.Trim(), StringComparison.Ordinal));
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        string secretFingerprint = _requestPathCache.CreateSecretFingerprint(normalizedSecret);
+        if (_requestPathCache.TryGetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now, out CryptoApiAuthenticatedClient cachedClient))
+        {
+            await RefreshLastUsedIfNeededAsync(authStateRevision, cachedClient.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+            return new CryptoApiClientAuthenticationResult(
+                Succeeded: true,
+                FailureReason: null,
+                Client: cachedClient);
+        }
+
+        CryptoApiSharedStateSnapshot snapshot = await _sharedStateStore.GetSnapshotAsync(cancellationToken);
+        CryptoApiClientKeyRecord? key = snapshot.ClientKeys.FirstOrDefault(candidate => string.Equals(candidate.KeyIdentifier, normalizedKeyIdentifier, StringComparison.Ordinal));
         if (key is null)
         {
             return Failed("API key was not found.");
@@ -33,7 +62,6 @@ public sealed class CryptoApiClientAuthenticationService(
             return Failed("Owning API client was not found.");
         }
 
-        DateTimeOffset now = timeProvider.GetUtcNow();
         if (!client.IsEnabled)
         {
             return Failed("API client is disabled.");
@@ -54,16 +82,12 @@ public sealed class CryptoApiClientAuthenticationService(
             return Failed("API key has expired.");
         }
 
-        if (!secretHasher.VerifySecret(secret.Trim(), key.SecretHash))
+        if (!_secretHasher.VerifySecret(normalizedSecret, key.SecretHash))
         {
             return Failed("API key secret is invalid.");
         }
 
-        await sharedStateStore.UpsertClientKeyAsync(key with
-        {
-            LastUsedAtUtc = now,
-            UpdatedAtUtc = now
-        }, cancellationToken);
+        await RefreshLastUsedIfNeededAsync(authStateRevision, key.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, key.LastUsedAtUtc, cancellationToken);
 
         Guid[] boundPolicyIds = snapshot.ClientPolicyBindings
             .Where(binding => binding.ClientId == client.ClientId)
@@ -72,23 +96,58 @@ public sealed class CryptoApiClientAuthenticationService(
             .OrderBy(id => id)
             .ToArray();
 
+        CryptoApiAuthenticatedClient authenticatedClient = new(
+            ClientId: client.ClientId,
+            ClientName: client.ClientName,
+            DisplayName: client.DisplayName,
+            ApplicationType: client.ApplicationType,
+            AuthenticationMode: client.AuthenticationMode,
+            ClientKeyId: key.ClientKeyId,
+            KeyIdentifier: key.KeyIdentifier,
+            CredentialType: key.CredentialType,
+            AuthenticatedAtUtc: now,
+            ExpiresAtUtc: key.ExpiresAtUtc,
+            BoundPolicyIds: boundPolicyIds);
+
+        _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
+
         return new CryptoApiClientAuthenticationResult(
             Succeeded: true,
             FailureReason: null,
-            Client: new CryptoApiAuthenticatedClient(
-                ClientId: client.ClientId,
-                ClientName: client.ClientName,
-                DisplayName: client.DisplayName,
-                ApplicationType: client.ApplicationType,
-                AuthenticationMode: client.AuthenticationMode,
-                ClientKeyId: key.ClientKeyId,
-                KeyIdentifier: key.KeyIdentifier,
-                CredentialType: key.CredentialType,
-                AuthenticatedAtUtc: now,
-                ExpiresAtUtc: key.ExpiresAtUtc,
-                BoundPolicyIds: boundPolicyIds));
+            Client: authenticatedClient);
     }
 
+    private async Task RefreshLastUsedIfNeededAsync(
+        long authStateRevision,
+        Guid clientKeyId,
+        string normalizedKeyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+        => await RefreshLastUsedIfNeededAsync(authStateRevision, clientKeyId, normalizedKeyIdentifier, secretFingerprint, now, null, cancellationToken);
+
+    private async Task RefreshLastUsedIfNeededAsync(
+        long authStateRevision,
+        Guid clientKeyId,
+        string normalizedKeyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        DateTimeOffset? currentLastUsedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        TimeSpan minimumInterval = _requestPathCache.LastUsedWriteInterval;
+        bool shouldRefresh = currentLastUsedAtUtc is DateTimeOffset lastUsedAtUtc
+            ? now - lastUsedAtUtc >= minimumInterval
+            : _requestPathCache.ShouldRefreshLastUsed(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
+
+        if (!shouldRefresh)
+        {
+            return;
+        }
+
+        _ = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, minimumInterval, cancellationToken);
+        _requestPathCache.RecordLastUsedRefresh(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
+    }
     private static CryptoApiClientAuthenticationResult Failed(string reason)
         => new(
             Succeeded: false,

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiRequestPathCachingOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiRequestPathCachingOptions.cs
@@ -1,0 +1,22 @@
+namespace Pkcs11Wrapper.CryptoApi.Configuration;
+
+public sealed class CryptoApiRequestPathCachingOptions
+{
+    public const string SectionName = "CryptoApiRequestPathCaching";
+
+    public bool Enabled { get; set; } = true;
+
+    public int AuthenticationEntryLimit { get; set; } = 512;
+
+    public int AuthorizationEntryLimit { get; set; } = 2048;
+
+    public int EntryTtlSeconds { get; set; } = 30;
+
+    public int LastUsedWriteIntervalSeconds { get; set; } = 30;
+
+    internal TimeSpan EntryTtl
+        => TimeSpan.FromSeconds(EntryTtlSeconds);
+
+    internal TimeSpan LastUsedWriteInterval
+        => TimeSpan.FromSeconds(LastUsedWriteIntervalSeconds);
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Pkcs11Wrapper.CryptoApi.Shared.csproj
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Pkcs11Wrapper.CryptoApi.Shared.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/ICryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/ICryptoApiSharedStateStore.cs
@@ -6,9 +6,13 @@ public interface ICryptoApiSharedStateStore
 
     Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default);
 
+    Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default);
+
     Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default);
 
     Task UpsertClientKeyAsync(CryptoApiClientKeyRecord clientKey, CancellationToken cancellationToken = default);
+
+    Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default);
 
     Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default);
 

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/SqliteCryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/SqliteCryptoApiSharedStateStore.cs
@@ -7,6 +7,8 @@ namespace Pkcs11Wrapper.CryptoApi.SharedState;
 
 public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiSharedStateStore
 {
+    private const string AuthStateRevisionMetadataKey = "auth_state_revision";
+
     private readonly CryptoApiSharedPersistenceOptions _options = options.Value;
 
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
@@ -56,6 +58,22 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
             SharedReadyAreas: CryptoApiSharedStateConstants.SharedReadyAreas);
     }
 
+    public async Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsConfigured())
+        {
+            return 0;
+        }
+
+        await InitializeAsync(cancellationToken);
+
+        await using SqliteConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await PrepareConnectionAsync(connection, cancellationToken);
+        await EnsureSchemaAsync(connection, cancellationToken);
+        return await GetAuthStateRevisionCoreAsync(connection, cancellationToken);
+    }
+
     public async Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default)
     {
         await EnsureConfiguredAndInitializedAsync(cancellationToken);
@@ -63,8 +81,10 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         await using SqliteConnection connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
         await PrepareConnectionAsync(connection, cancellationToken);
+        await using SqliteTransaction transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
 
         await using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = """
             INSERT INTO crypto_api_clients (
                 client_id,
@@ -106,6 +126,8 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         AddText(command, "$updatedAtUtc", FormatTimestamp(client.UpdatedAtUtc));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
     }
 
     public async Task UpsertClientKeyAsync(CryptoApiClientKeyRecord clientKey, CancellationToken cancellationToken = default)
@@ -115,8 +137,10 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         await using SqliteConnection connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
         await PrepareConnectionAsync(connection, cancellationToken);
+        await using SqliteTransaction transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
 
         await using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = """
             INSERT INTO crypto_api_client_keys (
                 client_key_id,
@@ -182,6 +206,30 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         AddNullableText(command, "$lastUsedAtUtc", clientKey.LastUsedAtUtc is null ? null : FormatTimestamp(clientKey.LastUsedAtUtc.Value));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using SqliteConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await PrepareConnectionAsync(connection, cancellationToken);
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE crypto_api_client_keys
+            SET last_used_at_utc = $lastUsedAtUtc
+            WHERE client_key_id = $clientKeyId
+              AND (last_used_at_utc IS NULL OR last_used_at_utc < $minimumLastUsedAtUtc);
+            """;
+        AddText(command, "$clientKeyId", clientKeyId.ToString("D", CultureInfo.InvariantCulture));
+        AddText(command, "$lastUsedAtUtc", FormatTimestamp(lastUsedAtUtc));
+        AddText(command, "$minimumLastUsedAtUtc", FormatTimestamp(lastUsedAtUtc - minimumInterval));
+
+        return await command.ExecuteNonQueryAsync(cancellationToken) > 0;
     }
 
     public async Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default)
@@ -191,8 +239,10 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         await using SqliteConnection connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
         await PrepareConnectionAsync(connection, cancellationToken);
+        await using SqliteTransaction transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
 
         await using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = """
             INSERT INTO crypto_api_key_aliases (
                 alias_id,
@@ -238,6 +288,8 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         AddText(command, "$updatedAtUtc", FormatTimestamp(keyAlias.UpdatedAtUtc));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
     }
 
     public async Task UpsertPolicyAsync(CryptoApiPolicyRecord policy, CancellationToken cancellationToken = default)
@@ -247,8 +299,10 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         await using SqliteConnection connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
         await PrepareConnectionAsync(connection, cancellationToken);
+        await using SqliteTransaction transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken);
 
         await using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = """
             INSERT INTO crypto_api_policies (
                 policy_id,
@@ -286,6 +340,8 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         AddText(command, "$updatedAtUtc", FormatTimestamp(policy.UpdatedAtUtc));
 
         await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
     }
 
     public async Task ReplaceClientPolicyBindingsAsync(Guid clientId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
@@ -312,6 +368,7 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
             await insert.ExecuteNonQueryAsync(cancellationToken);
         }
 
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -339,6 +396,7 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
             await insert.ExecuteNonQueryAsync(cancellationToken);
         }
 
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -480,6 +538,11 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
                 FOREIGN KEY(policy_id) REFERENCES crypto_api_policies(policy_id) ON DELETE CASCADE
             );
 
+            CREATE TABLE IF NOT EXISTS crypto_api_metadata (
+                metadata_key TEXT PRIMARY KEY,
+                metadata_value TEXT NOT NULL
+            );
+
             CREATE INDEX IF NOT EXISTS ix_crypto_api_client_keys_client_id
                 ON crypto_api_client_keys(client_id);
 
@@ -491,6 +554,9 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
 
             CREATE INDEX IF NOT EXISTS ix_crypto_api_key_alias_policy_bindings_policy_id
                 ON crypto_api_key_alias_policy_bindings(policy_id);
+
+            INSERT OR IGNORE INTO crypto_api_metadata (metadata_key, metadata_value)
+            VALUES ('auth_state_revision', '1');
             """;
         await command.ExecuteNonQueryAsync(cancellationToken);
 
@@ -538,6 +604,30 @@ public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPers
         command.CommandText = "PRAGMA user_version;";
         object? value = await command.ExecuteScalarAsync(cancellationToken);
         return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<long> GetAuthStateRevisionCoreAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT metadata_value FROM crypto_api_metadata WHERE metadata_key = $metadataKey;";
+        AddText(command, "$metadataKey", AuthStateRevisionMetadataKey);
+        object? value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is null
+            ? 1
+            : Convert.ToInt64(value, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task IncrementAuthStateRevisionAsync(SqliteConnection connection, SqliteTransaction transaction, CancellationToken cancellationToken)
+    {
+        await using SqliteCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE crypto_api_metadata
+            SET metadata_value = CAST(CAST(metadata_value AS INTEGER) + 1 AS TEXT)
+            WHERE metadata_key = $metadataKey;
+            """;
+        AddText(command, "$metadataKey", AuthStateRevisionMetadataKey);
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     private string? GetConnectionTarget()

--- a/src/Pkcs11Wrapper.CryptoApi/Endpoints/CryptoApiRouteBuilderExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Endpoints/CryptoApiRouteBuilderExtensions.cs
@@ -89,15 +89,13 @@ public static class CryptoApiRouteBuilderExtensions
         operationExecutionGroup.MapPost("/authorize", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiAuthorizeKeyOperationRequest request,
-            CryptoApiClientAuthenticationService authenticationService,
             CryptoApiKeyOperationAuthorizationService authorizationService,
             CancellationToken cancellationToken) =>
         {
-            AuthorizationAttempt authorization = await AuthenticateAndAuthorizeAsync(
+            AuthorizationAttempt authorization = await AuthorizeRequestAsync(
                 httpContext,
                 request.KeyAlias,
                 request.Operation,
-                authenticationService,
                 authorizationService,
                 securityOptions,
                 cancellationToken);
@@ -123,16 +121,14 @@ public static class CryptoApiRouteBuilderExtensions
         operationExecutionGroup.MapPost("/sign", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiSignRequest request,
-            CryptoApiClientAuthenticationService authenticationService,
             CryptoApiKeyOperationAuthorizationService authorizationService,
             ICryptoApiCustomerOperationService operationService,
             CancellationToken cancellationToken) =>
         {
-            AuthorizationAttempt authorization = await AuthenticateAndAuthorizeAsync(
+            AuthorizationAttempt authorization = await AuthorizeRequestAsync(
                 httpContext,
                 request.KeyAlias,
                 "sign",
-                authenticationService,
                 authorizationService,
                 securityOptions,
                 cancellationToken);
@@ -163,16 +159,14 @@ public static class CryptoApiRouteBuilderExtensions
         operationExecutionGroup.MapPost("/verify", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiVerifyRequest request,
-            CryptoApiClientAuthenticationService authenticationService,
             CryptoApiKeyOperationAuthorizationService authorizationService,
             ICryptoApiCustomerOperationService operationService,
             CancellationToken cancellationToken) =>
         {
-            AuthorizationAttempt authorization = await AuthenticateAndAuthorizeAsync(
+            AuthorizationAttempt authorization = await AuthorizeRequestAsync(
                 httpContext,
                 request.KeyAlias,
                 "verify",
-                authenticationService,
                 authorizationService,
                 securityOptions,
                 cancellationToken);
@@ -202,16 +196,14 @@ public static class CryptoApiRouteBuilderExtensions
         operationExecutionGroup.MapPost("/random", async Task<IResult> (
             HttpContext httpContext,
             CryptoApiRandomRequest request,
-            CryptoApiClientAuthenticationService authenticationService,
             CryptoApiKeyOperationAuthorizationService authorizationService,
             ICryptoApiCustomerOperationService operationService,
             CancellationToken cancellationToken) =>
         {
-            AuthorizationAttempt authorization = await AuthenticateAndAuthorizeAsync(
+            AuthorizationAttempt authorization = await AuthorizeRequestAsync(
                 httpContext,
                 request.KeyAlias,
                 "random",
-                authenticationService,
                 authorizationService,
                 securityOptions,
                 cancellationToken);
@@ -265,39 +257,45 @@ public static class CryptoApiRouteBuilderExtensions
         return new AuthenticationAttempt(result.Client, null);
     }
 
-    private static async Task<AuthorizationAttempt> AuthenticateAndAuthorizeAsync(
+    private static async Task<AuthorizationAttempt> AuthorizeRequestAsync(
         HttpContext httpContext,
         string? keyAlias,
         string? operation,
-        CryptoApiClientAuthenticationService authenticationService,
         CryptoApiKeyOperationAuthorizationService authorizationService,
         CryptoApiSecurityOptions securityOptions,
         CancellationToken cancellationToken)
     {
-        AuthenticationAttempt authentication = await AuthenticateAsync(httpContext, authenticationService, securityOptions, cancellationToken);
-        if (authentication.Error is not null)
-        {
-            return new AuthorizationAttempt(null, authentication.Error);
-        }
-
         try
         {
-            CryptoApiKeyOperationAuthorizationResult authorization = await authorizationService.AuthorizeAsync(
-                authentication.Client!,
+            string? keyIdentifier = httpContext.Request.Headers[CryptoApiAuthenticationDefaults.ApiKeyIdHeaderName].ToString();
+            string? secret = httpContext.Request.Headers[CryptoApiAuthenticationDefaults.ApiKeySecretHeaderName].ToString();
+            CryptoApiRequestAuthorizationResult authorization = await authorizationService.AuthorizeRequestAsync(
+                keyIdentifier,
+                secret,
                 keyAlias,
                 operation,
                 cancellationToken);
 
             if (!authorization.Succeeded || authorization.Authorization is null)
             {
+                int statusCode = authorization.FailureStatusCode ?? StatusCodes.Status403Forbidden;
+                string title = statusCode == StatusCodes.Status401Unauthorized
+                    ? "API key authentication failed."
+                    : "Key alias authorization failed.";
+                string detail = statusCode == StatusCodes.Status401Unauthorized
+                    ? (securityOptions.ExposeDetailedErrors
+                        ? authorization.FailureReason ?? "The provided API credentials were rejected."
+                        : "The provided API credentials were rejected.")
+                    : (securityOptions.ExposeDetailedErrors
+                        ? authorization.FailureReason ?? "The caller is not allowed to use the requested key alias or operation."
+                        : "The caller is not allowed to use the requested key alias or operation.");
+
                 return new AuthorizationAttempt(
                     null,
                     Results.Problem(
-                        title: "Key alias authorization failed.",
-                        detail: securityOptions.ExposeDetailedErrors
-                            ? authorization.FailureReason
-                            : "The caller is not allowed to use the requested key alias or operation.",
-                        statusCode: StatusCodes.Status403Forbidden));
+                        title: title,
+                        detail: detail,
+                        statusCode: statusCode));
             }
 
             return new AuthorizationAttempt(authorization.Authorization, null);

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Endpoints;
@@ -38,6 +39,16 @@ builder.Services.AddOptions<CryptoApiRuntimeOptions>()
 builder.Services.AddOptions<CryptoApiSecurityOptions>()
     .Bind(builder.Configuration.GetSection(CryptoApiSecurityOptions.SectionName));
 
+builder.Services.AddOptions<CryptoApiRequestPathCachingOptions>()
+    .Bind(builder.Configuration.GetSection(CryptoApiRequestPathCachingOptions.SectionName))
+    .Validate(
+        static options => options.AuthenticationEntryLimit > 0
+            && options.AuthorizationEntryLimit > 0
+            && options.EntryTtlSeconds > 0
+            && options.LastUsedWriteIntervalSeconds > 0,
+        "Crypto API request-path caching must define positive cache limits, TTL, and last-used write interval values.")
+    .ValidateOnStart();
+
 builder.Services.AddOptions<CryptoApiRateLimitingOptions>()
     .Bind(builder.Configuration.GetSection(CryptoApiRateLimitingOptions.SectionName))
     .Validate(
@@ -61,6 +72,9 @@ builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
     .ValidateOnStart();
 
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton(sp => new CryptoApiRequestPathCache(
+    sp.GetRequiredService<TimeProvider>(),
+    sp.GetRequiredService<IOptions<CryptoApiRequestPathCachingOptions>>().Value));
 builder.Services.AddSingleton<CryptoApiRuntimeDescriptorProvider>();
 builder.Services.AddSingleton<CryptoApiPkcs11Runtime>();
 builder.Services.AddSingleton<CryptoApiClientSecretGenerator>();

--- a/src/Pkcs11Wrapper.CryptoApi/appsettings.json
+++ b/src/Pkcs11Wrapper.CryptoApi/appsettings.json
@@ -19,6 +19,13 @@
     "ExposeDetailedErrors": false,
     "ExposeSharedStateDetails": false
   },
+  "CryptoApiRequestPathCaching": {
+    "Enabled": true,
+    "AuthenticationEntryLimit": 512,
+    "AuthorizationEntryLimit": 2048,
+    "EntryTtlSeconds": 30,
+    "LastUsedWriteIntervalSeconds": 30
+  },
   "CryptoApiRateLimiting": {
     "Enabled": true,
     "Authentication": {

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
@@ -229,6 +229,16 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
         return new OperationResponse(path, response.StatusCode, body);
     }
 
+    private static void DeleteDatabaseArtifacts(string databasePath)
+    {
+        string walPath = databasePath + "-wal";
+        string shmPath = databasePath + "-shm";
+
+        if (File.Exists(databasePath)) File.Delete(databasePath);
+        if (File.Exists(walPath)) File.Delete(walPath);
+        if (File.Exists(shmPath)) File.Delete(shmPath);
+    }
+
     private sealed record SeededAccess(
         CryptoApiManagedClient Client,
         CryptoApiCreatedClientKey Key,
@@ -439,4 +449,43 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
             return false;
         }
 
-        private static async Task<ProcessResult> RunP
+        private static async Task<ProcessResult> RunProcessAsync(string fileName, IReadOnlyList<string> arguments, string softHsmConfigPath)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = fileName,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            foreach (string argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            startInfo.Environment[SoftHsmConfEnvironmentVariable] = softHsmConfigPath;
+
+            using Process process = new() { StartInfo = startInfo };
+            if (!process.Start())
+            {
+                throw new InvalidOperationException($"Process '{fileName}' could not be started.");
+            }
+
+            string standardOutput = await process.StandardOutput.ReadToEndAsync();
+            string standardError = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            ProcessResult result = new(process.ExitCode, standardOutput, standardError);
+            if (result.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Process '{fileName}' exited with code {result.ExitCode}.{Environment.NewLine}stdout:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}stderr:{Environment.NewLine}{result.StandardError}");
+            }
+
+            return result;
+        }
+
+        private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+    }
+}

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
@@ -5,9 +5,13 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Operations;
+using Pkcs11Wrapper.CryptoApi.SharedState;
 
 namespace Pkcs11Wrapper.CryptoApi.Tests;
 
@@ -339,6 +343,166 @@ public sealed class CryptoApiRoutesTests
         }
     }
 
+    [Fact]
+    public async Task AuthSelfWarmPathReusesCachedAuthenticationAndThrottlesLastUsedWrites()
+    {
+        string databasePath = CreateDatabasePath();
+        MutableTimeProvider timeProvider = new(DateTimeOffset.Parse("2026-04-04T10:00:00Z"));
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            databasePath,
+            services => ConfigureCountingSharedState(services, timeProvider),
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiRequestPathCaching:EntryTtlSeconds"] = "300",
+                ["CryptoApiRequestPathCaching:LastUsedWriteIntervalSeconds"] = "30"
+            });
+
+        try
+        {
+            SeededAccess access = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer");
+            CountingSharedStateStore store = factory.Services.GetRequiredService<CountingSharedStateStore>();
+            int baselineSnapshotReads = store.SnapshotReads;
+            int baselineLastUsedTouches = store.LastUsedTouches;
+
+            using HttpClient httpClient = factory.CreateClient();
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+            for (int i = 0; i < 3; i++)
+            {
+                using HttpResponseMessage response = await httpClient.GetAsync("/api/v1/auth/self");
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                timeProvider.Advance(TimeSpan.FromSeconds(10));
+            }
+
+            Assert.Equal(1, store.SnapshotReads - baselineSnapshotReads);
+            Assert.Equal(1, store.LastUsedTouches - baselineLastUsedTouches);
+
+            timeProvider.Advance(TimeSpan.FromSeconds(15));
+            using HttpResponseMessage afterInterval = await httpClient.GetAsync("/api/v1/auth/self");
+            Assert.Equal(HttpStatusCode.OK, afterInterval.StatusCode);
+
+            Assert.Equal(1, store.SnapshotReads - baselineSnapshotReads);
+            Assert.Equal(2, store.LastUsedTouches - baselineLastUsedTouches);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task OperationWarmPathReusesAuthenticationAndAuthorizationCaches()
+    {
+        string databasePath = CreateDatabasePath();
+        MutableTimeProvider timeProvider = new(DateTimeOffset.Parse("2026-04-04T10:00:00Z"));
+        FakeCustomerOperationService fakeOperations = new();
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            databasePath,
+            services =>
+            {
+                ConfigureCountingSharedState(services, timeProvider);
+                services.AddSingleton<ICryptoApiCustomerOperationService>(fakeOperations);
+            },
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiRequestPathCaching:EntryTtlSeconds"] = "300",
+                ["CryptoApiRequestPathCaching:LastUsedWriteIntervalSeconds"] = "30"
+            });
+
+        try
+        {
+            SeededAccess access = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer");
+            CountingSharedStateStore store = factory.Services.GetRequiredService<CountingSharedStateStore>();
+            int baselineSnapshotReads = store.SnapshotReads;
+            int baselineLastUsedTouches = store.LastUsedTouches;
+
+            using HttpClient httpClient = factory.CreateClient();
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+            for (int i = 0; i < 3; i++)
+            {
+                using HttpResponseMessage response = await httpClient.PostAsync(
+                    "/api/v1/operations/sign",
+                    CreateJsonContent("{\"keyAlias\":\"payments-signer\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                timeProvider.Advance(TimeSpan.FromSeconds(5));
+            }
+
+            Assert.Equal(1, store.SnapshotReads - baselineSnapshotReads);
+            Assert.Equal(1, store.LastUsedTouches - baselineLastUsedTouches);
+            Assert.Equal(3, fakeOperations.Calls.Count);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task OperationAuthorizationCacheInvalidatesWhenKeyIsRevoked()
+    {
+        string databasePath = CreateDatabasePath();
+        MutableTimeProvider timeProvider = new(DateTimeOffset.Parse("2026-04-04T10:00:00Z"));
+        FakeCustomerOperationService fakeOperations = new();
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            databasePath,
+            services =>
+            {
+                ConfigureCountingSharedState(services, timeProvider);
+                services.AddSingleton<ICryptoApiCustomerOperationService>(fakeOperations);
+            },
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiRequestPathCaching:EntryTtlSeconds"] = "300",
+                ["CryptoApiRequestPathCaching:LastUsedWriteIntervalSeconds"] = "30"
+            });
+
+        try
+        {
+            SeededAccess access = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer");
+
+            using HttpClient httpClient = factory.CreateClient();
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+            httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+            using HttpResponseMessage firstResponse = await httpClient.PostAsync(
+                "/api/v1/operations/sign",
+                CreateJsonContent("{\"keyAlias\":\"payments-signer\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
+            Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+
+            using (IServiceScope scope = factory.Services.CreateScope())
+            {
+                CryptoApiClientManagementService clientManagement = scope.ServiceProvider.GetRequiredService<CryptoApiClientManagementService>();
+                await clientManagement.RevokeClientKeyAsync(access.Key.ClientKeyId, "rotation");
+            }
+
+            using HttpResponseMessage secondResponse = await httpClient.PostAsync(
+                "/api/v1/operations/sign",
+                CreateJsonContent("{\"keyAlias\":\"payments-signer\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
+            string content = await secondResponse.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.Unauthorized, secondResponse.StatusCode);
+            Assert.Contains("The provided API credentials were rejected.", content, StringComparison.Ordinal);
+            Assert.Single(fakeOperations.Calls);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    private static void ConfigureCountingSharedState(IServiceCollection services, TimeProvider timeProvider)
+    {
+        services.RemoveAll<TimeProvider>();
+        services.AddSingleton<TimeProvider>(timeProvider);
+        services.RemoveAll<ICryptoApiSharedStateStore>();
+        services.AddSingleton(sp => new SqliteCryptoApiSharedStateStore(sp.GetRequiredService<IOptions<CryptoApiSharedPersistenceOptions>>()));
+        services.AddSingleton<CountingSharedStateStore>();
+        services.AddSingleton<ICryptoApiSharedStateStore>(sp => sp.GetRequiredService<CountingSharedStateStore>());
+    }
+
     private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, IReadOnlyCollection<string> allowedOperations, string aliasName, string? policyName = null)
     {
         using IServiceScope scope = factory.Services.CreateScope();
@@ -452,4 +616,61 @@ public sealed class CryptoApiRoutesTests
     }
 
     private sealed record FakeOperationCall(string Operation, string AliasName, string Algorithm);
+
+    private sealed class CountingSharedStateStore(SqliteCryptoApiSharedStateStore inner) : ICryptoApiSharedStateStore
+    {
+        public int SnapshotReads { get; private set; }
+
+        public int LastUsedTouches { get; private set; }
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+            => inner.InitializeAsync(cancellationToken);
+
+        public Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+            => inner.GetStatusAsync(cancellationToken);
+
+        public Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+            => inner.GetAuthStateRevisionAsync(cancellationToken);
+
+        public Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default)
+            => inner.UpsertClientAsync(client, cancellationToken);
+
+        public Task UpsertClientKeyAsync(CryptoApiClientKeyRecord clientKey, CancellationToken cancellationToken = default)
+            => inner.UpsertClientKeyAsync(clientKey, cancellationToken);
+
+        public async Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default)
+        {
+            LastUsedTouches++;
+            return await inner.TryTouchClientKeyLastUsedAsync(clientKeyId, lastUsedAtUtc, minimumInterval, cancellationToken);
+        }
+
+        public Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default)
+            => inner.UpsertKeyAliasAsync(keyAlias, cancellationToken);
+
+        public Task UpsertPolicyAsync(CryptoApiPolicyRecord policy, CancellationToken cancellationToken = default)
+            => inner.UpsertPolicyAsync(policy, cancellationToken);
+
+        public Task ReplaceClientPolicyBindingsAsync(Guid clientId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+            => inner.ReplaceClientPolicyBindingsAsync(clientId, policyIds, cancellationToken);
+
+        public Task ReplaceKeyAliasPolicyBindingsAsync(Guid aliasId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+            => inner.ReplaceKeyAliasPolicyBindingsAsync(aliasId, policyIds, cancellationToken);
+
+        public async Task<CryptoApiSharedStateSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            SnapshotReads++;
+            return await inner.GetSnapshotAsync(cancellationToken);
+        }
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset initialUtcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = initialUtcNow;
+
+        public override DateTimeOffset GetUtcNow()
+            => _utcNow;
+
+        public void Advance(TimeSpan delta)
+            => _utcNow = _utcNow.Add(delta);
+    }
 }

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiSharedStateStoreTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiSharedStateStoreTests.cs
@@ -125,6 +125,76 @@ public sealed class CryptoApiSharedStateStoreTests
         }
     }
 
+    [Fact]
+    public async Task AuthStateRevisionTracksSemanticChangesButNotLastUsedTouches()
+    {
+        string databasePath = Path.Combine(Path.GetTempPath(), $"pkcs11wrapper-cryptoapi-revision-{Guid.NewGuid():N}.db");
+        try
+        {
+            CryptoApiSharedPersistenceOptions options = new()
+            {
+                Provider = "Sqlite",
+                ConnectionString = $"Data Source={databasePath}",
+                AutoInitialize = true
+            };
+
+            ICryptoApiSharedStateStore store = new SqliteCryptoApiSharedStateStore(Options.Create(options));
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            Guid clientId = Guid.NewGuid();
+            Guid clientKeyId = Guid.NewGuid();
+
+            long initialRevision = await store.GetAuthStateRevisionAsync();
+            await store.UpsertClientAsync(new CryptoApiClientRecord(
+                clientId,
+                "throughput-client",
+                "Throughput Client",
+                "gateway",
+                "api-key",
+                true,
+                null,
+                now,
+                now));
+            long afterClientUpsert = await store.GetAuthStateRevisionAsync();
+
+            await store.UpsertClientKeyAsync(new CryptoApiClientKeyRecord(
+                clientKeyId,
+                clientId,
+                "primary",
+                "kid-throughput-primary",
+                "api-key-secret",
+                "pbkdf2-sha256-v1",
+                "pbkdf2-sha256-v1$100000$salt$hash",
+                "thr...ary",
+                true,
+                now,
+                now,
+                null,
+                null,
+                null,
+                null));
+            long afterKeyUpsert = await store.GetAuthStateRevisionAsync();
+
+            bool firstTouchUpdated = await store.TryTouchClientKeyLastUsedAsync(clientKeyId, now.AddSeconds(5), TimeSpan.FromSeconds(30));
+            long afterFirstTouch = await store.GetAuthStateRevisionAsync();
+            bool secondTouchUpdated = await store.TryTouchClientKeyLastUsedAsync(clientKeyId, now.AddSeconds(10), TimeSpan.FromSeconds(30));
+            long afterSecondTouch = await store.GetAuthStateRevisionAsync();
+
+            Assert.True(afterClientUpsert > initialRevision);
+            Assert.True(afterKeyUpsert > afterClientUpsert);
+            Assert.True(firstTouchUpdated);
+            Assert.False(secondTouchUpdated);
+            Assert.Equal(afterKeyUpsert, afterFirstTouch);
+            Assert.Equal(afterFirstTouch, afterSecondTouch);
+
+            CryptoApiClientKeyRecord key = Assert.Single((await store.GetSnapshotAsync()).ClientKeys);
+            Assert.Equal(now.AddSeconds(5).UtcDateTime, key.LastUsedAtUtc!.Value.UtcDateTime);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
     private static void DeleteDatabaseArtifacts(string databasePath)
     {
         string walPath = databasePath + "-wal";


### PR DESCRIPTION
Improve steady-state Crypto API throughput by adding bounded auth/authz request-path caches, shared auth-state revision invalidation, and throttled last-used writes. This reduces repeated shared-state loads and per-request PBKDF2/SQLite hot-path cost. Closes #133.