### PR TITLE
Configure compose lab Crypto API shared persistence

### DIFF
--- a/deploy/compose/softhsm-lab/.env.example
+++ b/deploy/compose/softhsm-lab/.env.example
@@ -9,6 +9,9 @@
 #
 # The defaults intentionally match the repository's SoftHSM fixture labels/PINs
 # so local demos and troubleshooting line up with existing docs/tests.
+# Crypto API Access is preconfigured by compose itself to use an internal
+# shared SQLite volume, so the admin dashboard can manage clients/keys/aliases/
+# policies out of the box without extra env wiring.
 
 PKCS11WRAPPER_ADMIN_PORT=8080
 PKCS11WRAPPER_ADMIN_USER=admin

--- a/deploy/compose/softhsm-lab/README.md
+++ b/deploy/compose/softhsm-lab/README.md
@@ -18,12 +18,18 @@ If you need the **standalone container deployment** path for the admin panel, us
 
 - `admin` - a lab-flavored admin-panel image that preserves the existing container runtime contract for local use:
   - `AdminStorage__DataRoot=/var/lib/pkcs11wrapper-admin`
+  - `CryptoApiSharedPersistence__ConnectionString=Data Source=/var/lib/pkcs11wrapper-cryptoapi/shared-state.db`
   - `AdminRuntime__DisableHttpsRedirection=true`
   - built-in `/health/live` and `/health/ready` endpoints plus a compose healthcheck wired to the readiness probe
   - SoftHSM module exposed at `/opt/pkcs11/lib/libsofthsm2.so`
 - `softhsm` - a utility/backend container that owns the shared SoftHSM config/token store and can seed or reset the token with `softhsm2-util` + `pkcs11-tool`
 
-The two services share a named volume mounted at `/opt/pkcs11/softhsm`. The admin panel points `SOFTHSM2_CONF` at that shared config, so the in-container SoftHSM library sees the same token store as the helper container.
+The services use two named volumes for shared state:
+
+- `/opt/pkcs11/softhsm` keeps the SoftHSM config/token store shared between `softhsm` and `admin`
+- `/var/lib/pkcs11wrapper-cryptoapi` keeps the local/dev shared SQLite control-plane database used by the admin panel's **Crypto API Access** workflow
+
+The admin panel points `SOFTHSM2_CONF` at the shared SoftHSM config, so the in-container library sees the same token store as the helper container.
 
 ## Quick start
 
@@ -42,6 +48,8 @@ docker compose ps
 ```
 
 Then open <http://localhost:8080> and sign in with the bootstrap admin credential from `.env`.
+
+The **Crypto API Access** page should be usable immediately after sign-in; this compose bundle now preconfigures the admin service with a local shared SQLite database and auto-initializes its schema on first use.
 
 Default values from `.env.example`:
 
@@ -63,7 +71,8 @@ On first `docker compose up`:
 2. if `SOFTHSM_AUTO_SEED=1` (default), it initializes the token if the configured label is missing
 3. it seeds one AES-256 secret key and one RSA-2048 keypair if they do not already exist
 4. the `admin` service seeds the bootstrap device profile pointing to `/opt/pkcs11/lib/libsofthsm2.so` and the configured token label
-5. the admin panel persists its own runtime state under `/var/lib/pkcs11wrapper-admin`
+5. the `admin` service auto-initializes the local shared Crypto API control-plane database at `/var/lib/pkcs11wrapper-cryptoapi/shared-state.db`
+6. the admin panel persists its own runtime state under `/var/lib/pkcs11wrapper-admin`
 
 The admin device seed follows the app's current behavior: it only applies when the admin data volume is empty. Once `device-profiles.json` exists, later env changes do not overwrite persisted device profiles.
 
@@ -106,5 +115,6 @@ docker compose down -v
 - The admin service now reports healthy only after its storage-backed readiness probe succeeds, which makes startup status easier to understand from `docker compose ps`.
 - Rotate the bootstrap admin password from the `Users` page after first sign-in if the stack will live longer than a quick demo.
 - The `admin-data` volume includes the bootstrap notice, local users, Data Protection keys, device profiles, telemetry retention files, audit log, lab templates, and protected PIN cache.
+- The `cryptoapi-shared-state` volume contains the local/dev shared SQLite database that powers the admin panel's Crypto API Access control-plane workflow.
 - The SoftHSM lab state lives entirely in the `softhsm-state` named volume; deleting that volume resets the token/config.
 - For persistent non-lab container deployments, back up and preserve the admin data volume intentionally rather than treating this compose bundle as the long-term deployment model.

--- a/deploy/compose/softhsm-lab/admin.Dockerfile
+++ b/deploy/compose/softhsm-lab/admin.Dockerfile
@@ -38,12 +38,13 @@ ENV ASPNETCORE_URLS=http://+:8080 \
 WORKDIR /app
 COPY --from=publish /app/publish ./
 RUN mkdir -p /var/lib/pkcs11wrapper-admin/home /var/lib/pkcs11wrapper-admin/keys /var/lib/pkcs11wrapper-admin/tmp /opt/pkcs11/lib /opt/pkcs11/softhsm/tokens \
+    /var/lib/pkcs11wrapper-cryptoapi \
     && ln -sf /usr/lib/softhsm/libsofthsm2.so /opt/pkcs11/lib/libsofthsm2.so \
-    && chown -R ${APP_UID}:0 /app /var/lib/pkcs11wrapper-admin /opt/pkcs11 \
-    && chmod -R g=u /app /var/lib/pkcs11wrapper-admin /opt/pkcs11
+    && chown -R ${APP_UID}:0 /app /var/lib/pkcs11wrapper-admin /var/lib/pkcs11wrapper-cryptoapi /opt/pkcs11 \
+    && chmod -R g=u /app /var/lib/pkcs11wrapper-admin /var/lib/pkcs11wrapper-cryptoapi /opt/pkcs11
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["dotnet", "Pkcs11Wrapper.Admin.Web.dll", "--container-healthcheck", "http://127.0.0.1:8080/health/ready"]
-VOLUME ["/var/lib/pkcs11wrapper-admin", "/opt/pkcs11/softhsm"]
+VOLUME ["/var/lib/pkcs11wrapper-admin", "/var/lib/pkcs11wrapper-cryptoapi", "/opt/pkcs11/softhsm"]
 EXPOSE 8080
 USER ${APP_UID}
 ENTRYPOINT ["dotnet", "Pkcs11Wrapper.Admin.Web.dll"]

--- a/deploy/compose/softhsm-lab/compose.yaml
+++ b/deploy/compose/softhsm-lab/compose.yaml
@@ -43,9 +43,13 @@ services:
       AdminBootstrapDevice__ModulePath: /opt/pkcs11/lib/libsofthsm2.so
       AdminBootstrapDevice__DefaultTokenLabel: ${SOFTHSM_TOKEN_LABEL:-Pkcs11Wrapper CI Token}
       AdminBootstrapDevice__Notes: ${PKCS11WRAPPER_ADMIN_DEVICE_NOTES:-Local/dev/lab SoftHSM compose stack. Not production orchestrated.}
+      CryptoApiSharedPersistence__Provider: Sqlite
+      CryptoApiSharedPersistence__ConnectionString: Data Source=/var/lib/pkcs11wrapper-cryptoapi/shared-state.db
+      CryptoApiSharedPersistence__AutoInitialize: "true"
       SOFTHSM2_CONF: /opt/pkcs11/softhsm/softhsm2.conf
     volumes:
       - admin-data:/var/lib/pkcs11wrapper-admin
+      - cryptoapi-shared-state:/var/lib/pkcs11wrapper-cryptoapi
       - softhsm-state:/opt/pkcs11/softhsm
     healthcheck:
       test: ["CMD", "dotnet", "Pkcs11Wrapper.Admin.Web.dll", "--container-healthcheck", "http://127.0.0.1:8080/health/ready"]
@@ -56,4 +60,5 @@ services:
 
 volumes:
   admin-data:
+  cryptoapi-shared-state:
   softhsm-state:


### PR DESCRIPTION
Configure the SoftHSM compose lab so the admin app gets a usable Crypto API shared SQLite control-plane path out of the box, including the required volume/mount ownership for the non-root container user. Closes #129.