### PR TITLE
Add PostgreSQL shared persistence provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 - DI/config binding for service identity, API base path, PKCS#11 runtime, and shared persistence
 - `/health/live` + `/health/ready` endpoints, with readiness validating the configured PKCS#11 module and shared persistence when configured
 - `/api/v1`, `/api/v1/runtime`, `/api/v1/operations`, `POST /api/v1/operations/authorize`, `/api/v1/shared-state`, and `/api/v1/auth/self` route space for the emerging machine-facing contract
-- pragmatic shared SQLite-backed persistence for multi-instance API clients/keys, key aliases, policies, and policy bindings
+- shared persistence for multi-instance API clients/keys, key aliases, policies, and policy bindings, with SQLite for local/dev/lab and PostgreSQL for server-grade shared deployments
 - practical access-control slice: generated API-key secrets are shown once, stored only as hashes, and can now be paired end-to-end with alias routing, policy definitions, and binding management from the admin dashboard without exposing raw PKCS#11 locator details to callers
 - admin-panel/shared-store control-plane model for Crypto API applications, aliases, policies, and bindings without turning the machine-facing host into a tenant portal
 - intended deployment model: **one admin dashboard + many stateless crypto API instances**
@@ -101,7 +101,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 | PKCS#11 v3 interface discovery | ✅ | capability-gated when not exported by the module |
 | PKCS#11 v3 message APIs | ✅ | managed/API support implemented; runtime depends on module support |
 | Admin panel | ✅ | functional Blazor Server management surface with auth, local users, config transfer, audit integrity, PKCS#11 Lab, telemetry, and Crypto API Access control-plane flows |
-| Crypto API host scaffold | ✅ | stateless ASP.NET Core host with DI/config, service documents, health/readiness, shared SQLite-backed auth/policy persistence, hashed API-key lifecycle controls, and the first alias-routing/policy-enforcement slice |
+| Crypto API host scaffold | ✅ | stateless ASP.NET Core host with DI/config, service documents, health/readiness, SQLite/PostgreSQL shared auth/policy persistence, hashed API-key lifecycle controls, and the first alias-routing/policy-enforcement slice |
 | Vendor regression lane | ✅ | optional non-SoftHSM validation path |
 
 ## Repository architecture
@@ -111,7 +111,7 @@ flowchart LR
     A[Pkcs11Wrapper.Admin.Web\nBlazor Server Admin Panel] --> B[Pkcs11Wrapper.Admin.Application]
     B --> C[Pkcs11Wrapper.Admin.Infrastructure]
     B --> D[Pkcs11Wrapper]
-    A --> S[(Shared Crypto API state\nSQLite control-plane DB)]
+    A --> S[(Shared Crypto API state\nSQLite or PostgreSQL control-plane DB)]
     H[Pkcs11Wrapper.CryptoApi\nStateless ASP.NET Core Host] --> D
     H --> S
     D --> E[Pkcs11Wrapper.Native]

--- a/deploy/compose/softhsm-lab/README.md
+++ b/deploy/compose/softhsm-lab/README.md
@@ -49,7 +49,7 @@ docker compose ps
 
 Then open <http://localhost:8080> and sign in with the bootstrap admin credential from `.env`.
 
-The **Crypto API Access** page should be usable immediately after sign-in; this compose bundle now preconfigures the admin service with a local shared SQLite database and auto-initializes its schema on first use.
+The **Crypto API Access** page should be usable immediately after sign-in; this compose bundle intentionally stays on a local shared SQLite database for lab use and auto-initializes its schema on first use.
 
 Default values from `.env.example`:
 
@@ -115,6 +115,6 @@ docker compose down -v
 - The admin service now reports healthy only after its storage-backed readiness probe succeeds, which makes startup status easier to understand from `docker compose ps`.
 - Rotate the bootstrap admin password from the `Users` page after first sign-in if the stack will live longer than a quick demo.
 - The `admin-data` volume includes the bootstrap notice, local users, Data Protection keys, device profiles, telemetry retention files, audit log, lab templates, and protected PIN cache.
-- The `cryptoapi-shared-state` volume contains the local/dev shared SQLite database that powers the admin panel's Crypto API Access control-plane workflow.
+- The `cryptoapi-shared-state` volume contains the local/dev shared SQLite database that powers the admin panel's Crypto API Access control-plane workflow. Production-oriented multi-instance deployments can switch the same control plane to `Provider=Postgres` instead.
 - The SoftHSM lab state lives entirely in the `softhsm-state` named volume; deleting that volume resets the token/config.
 - For persistent non-lab container deployments, back up and preserve the admin data volume intentionally rather than treating this compose bundle as the long-term deployment model.

--- a/deploy/container/crypto-api.env.example
+++ b/deploy/container/crypto-api.env.example
@@ -24,12 +24,18 @@ CryptoApiRuntime__ModulePath=/opt/pkcs11/lib/libvendorpkcs11.so
 # Treat this as secret material. Prefer secret-manager/orchestrator injection.
 CryptoApiRuntime__UserPin=ChangeMe
 
-# Current shared-state provider support is SQLite only.
-# Every API instance and the admin dashboard should point at the same database
-# file when they are meant to share one control plane.
+# Supported shared-state providers:
+# - Sqlite   -> local/dev/lab and bounded shared-volume deployments
+# - Postgres -> server-grade shared deployments and multi-host scale-out
+# Every API instance and the admin dashboard should point at the same shared
+# persistence target when they are meant to share one control plane.
 CryptoApiSharedPersistence__Provider=Sqlite
 CryptoApiSharedPersistence__ConnectionString=Data Source=/var/lib/pkcs11wrapper-cryptoapi/shared-state.db
 CryptoApiSharedPersistence__AutoInitialize=true
+
+# PostgreSQL example:
+# CryptoApiSharedPersistence__Provider=Postgres
+# CryptoApiSharedPersistence__ConnectionString=Host=db.internal;Port=5432;Database=pkcs11wrapper_cryptoapi;Username=cryptoapi;Password=ChangeMe;SSL Mode=Require
 
 # Keep verbose auth/shared-state diagnostics disabled on exposed deployments.
 # Enable only for tightly controlled internal troubleshooting.

--- a/docs/crypto-api-deployment.md
+++ b/docs/crypto-api-deployment.md
@@ -21,7 +21,7 @@ For the standalone admin image contract, see [docs/admin-container.md](docs/admi
 flowchart LR
     O[Operators] --> A[Pkcs11Wrapper.Admin.Web\nsingle admin dashboard]
     A --> AR[(AdminStorage__DataRoot\nusers, audit log, telemetry,\ndevice profiles, protected pins,\nData Protection keys)]
-    A -->|CryptoApiSharedPersistence| S[(Shared Crypto API state\nSQLite database)]
+    A -->|CryptoApiSharedPersistence| S[(Shared Crypto API state\nSQLite or PostgreSQL database)]
 
     G[Gateway / load balancer] --> C1[Crypto API instance A]
     G --> C2[Crypto API instance B]
@@ -42,6 +42,21 @@ Operationally:
 - run **one or more** `Pkcs11Wrapper.CryptoApi` instances behind your gateway/load balancer
 - point the admin dashboard and every Crypto API instance at the **same** `CryptoApiSharedPersistence:ConnectionString`
 - keep the admin dashboard's own storage root **separate** from the shared Crypto API state database
+
+## Choosing a shared persistence provider
+
+The repo now supports two shared persistence backends for the same control-plane model:
+
+- **SQLite**
+  - best for local/dev/lab, demos, bounded single-host deployments, and small shared-volume setups you already trust
+  - simplest operational footprint
+  - still the default in checked-in appsettings and the SoftHSM lab compose stack
+- **Postgres**
+  - best for production-oriented multi-instance deployments, especially when you do not want correctness to depend on shared filesystem locking/WAL behavior
+  - recommended starting point for server-grade scale-out
+  - uses the same admin workflow and the same runtime control-plane concepts as SQLite
+
+Provider choice changes the database target, not the higher-level model. The admin dashboard and every Crypto API instance still need to point at the **same** shared control-plane store.
 
 ## Responsibilities by component
 
@@ -137,20 +152,22 @@ That separation is deliberate: the admin dashboard remains an operator console, 
 
 ### Why the shared store is safe enough for the current model
 
-The current store implementation prepares every SQLite connection with:
+Both supported backends keep the control-plane schema normalized into separate client, key, alias, policy, and binding tables, and binding replacement flows run transactionally.
 
-- `PRAGMA foreign_keys = ON`
-- `PRAGMA busy_timeout = 5000`
-- `PRAGMA journal_mode = WAL`
+Provider-specific notes:
 
-And it keeps the control-plane schema normalized into separate client, key, alias, policy, and binding tables.
-Binding replacement flows run transactionally.
+- **SQLite** connections are prepared with:
+  - `PRAGMA foreign_keys = ON`
+  - `PRAGMA busy_timeout = 5000`
+  - `PRAGMA journal_mode = WAL`
+- **Postgres** uses the server database engine for concurrency, transactions, and locking instead of shared-file coordination
 
 Operator implications:
 
-- multiple independent processes can coordinate through the same database file when the underlying storage really supports SQLite locking/WAL semantics
 - API secrets are **not** stored in plaintext; the repo persists hashed secret material and only reveals the generated secret once at creation time
 - the admin dashboard can manage the same shared client/key state without becoming the runtime for machine traffic
+- SQLite remains practical when the underlying storage truly supports its locking/WAL model
+- Postgres is the safer default when you need a shared backend across multiple workers or hosts without filesystem caveats
 
 ## Recommended filesystem and state layout
 
@@ -159,14 +176,19 @@ Even on a single host, keep these storage concerns distinct:
 ```text
 /srv/pkcs11wrapper/
   admin-data/              # AdminStorage__DataRoot
-  cryptoapi-shared/
-    shared-state.db        # CryptoApiSharedPersistence database
+  cryptoapi-shared/        # SQLite: shared-state.db lives here
   pkcs11-client/           # mounted vendor PKCS#11 libraries / client bundle
   vendor-state/            # only if the vendor client truly requires writable side files
 ```
 
-Prefer this separation over dropping the shared SQLite file inside the admin storage root.
+Prefer this separation over dropping the shared control-plane database inside the admin storage root.
 It makes backup, restore, and responsibility boundaries much clearer.
+
+For Postgres deployments, the equivalent separation is:
+
+- admin local files under `AdminStorage__DataRoot`
+- a dedicated Postgres database/schema/role for `CryptoApiSharedPersistence`
+- PKCS#11 libraries and any vendor-writable state mounted separately from both of those
 
 ## Configuration recipe
 
@@ -181,6 +203,15 @@ CryptoApiSharedPersistence__ConnectionString=Data Source=/srv/pkcs11wrapper/cryp
 CryptoApiSharedPersistence__AutoInitialize=true
 ```
 
+Postgres variant:
+
+```text
+AdminStorage__DataRoot=/srv/pkcs11wrapper/admin-data
+CryptoApiSharedPersistence__Provider=Postgres
+CryptoApiSharedPersistence__ConnectionString=Host=db.internal;Port=5432;Database=pkcs11wrapper_cryptoapi;Username=adminpanel;Password=<secret>;SSL Mode=Require
+CryptoApiSharedPersistence__AutoInitialize=true
+```
+
 ### Every Crypto API instance
 
 Point every instance at the **same** shared persistence target and the same PKCS#11 client layout:
@@ -192,6 +223,18 @@ CryptoApiRuntime__UserPin=<secret>
 CryptoApiRuntime__DisableHttpsRedirection=true
 CryptoApiSharedPersistence__Provider=Sqlite
 CryptoApiSharedPersistence__ConnectionString=Data Source=/srv/pkcs11wrapper/cryptoapi-shared/shared-state.db
+CryptoApiSharedPersistence__AutoInitialize=true
+```
+
+Postgres variant:
+
+```text
+CryptoApiHost__ApiBasePath=/api/v1
+CryptoApiRuntime__ModulePath=/srv/pkcs11wrapper/pkcs11-client/libvendorpkcs11.so
+CryptoApiRuntime__UserPin=<secret>
+CryptoApiRuntime__DisableHttpsRedirection=true
+CryptoApiSharedPersistence__Provider=Postgres
+CryptoApiSharedPersistence__ConnectionString=Host=db.internal;Port=5432;Database=pkcs11wrapper_cryptoapi;Username=cryptoapi;Password=<secret>;SSL Mode=Require
 CryptoApiSharedPersistence__AutoInitialize=true
 ```
 
@@ -267,14 +310,14 @@ What that means operationally:
 
 - if you run one API instance, the built-in limiter gives a real local abuse-control baseline
 - if you run many API instances behind a load balancer, the effective fleet-wide budget is roughly the per-instance budget multiplied by the number of healthy instances that can receive the caller's traffic
-- if you need strict tenant/global quotas, keep enforcing them at the ingress/gateway layer rather than trying to treat the current SQLite control-plane store as a hot-path distributed counter system
+- if you need strict tenant/global quotas, keep enforcing them at the ingress/gateway layer rather than trying to treat the shared control-plane store as a hot-path distributed counter system
 
 This is a deliberate trade-off for the current product shape:
 
 - it protects the machine-facing API immediately
 - it does not add shared-state writes on every request
 - it keeps the stateless-HTTP-worker architecture honest
-- it avoids overselling SQLite as a distributed rate-limit backend
+- it avoids overselling the shared control-plane database as a distributed rate-limit backend
 
 ## Current routing/alias expectations
 
@@ -328,7 +371,7 @@ Today the repository does **not** ship:
 
 - a supported `Pkcs11Wrapper.CryptoApi` Dockerfile
 - a production compose/Kubernetes manifest for the multi-instance Crypto API service
-- a non-SQLite shared persistence provider
+- a production-owned Postgres image/compose/Kubernetes bundle for the shared control plane
 
 So for Crypto API containers, the image/wrapper is currently **operator-owned**.
 Base it on `src/Pkcs11Wrapper.CryptoApi`, but preserve the runtime contract described here.
@@ -359,7 +402,8 @@ For every Crypto API container you build around the host project:
 A practical split is:
 
 - one persistent volume for the admin dashboard data root
-- one persistent/shared volume for the Crypto API SQLite database file
+- for SQLite: one persistent/shared volume for the Crypto API database file
+- for Postgres: a managed database instance plus credentials/CA material supplied through your secret manager/orchestrator
 - one read-only mount for PKCS#11 client libraries
 - one separate writable vendor-state mount only if the vendor client requires it
 
@@ -367,13 +411,12 @@ Do **not** collapse everything into one writable directory just because containe
 
 ### Multi-host caution with SQLite
 
-The current shared-state provider is SQLite.
-That works well for small-to-medium deployments **only when** every process sees storage with correct SQLite file-locking and WAL behavior.
+SQLite remains supported, but it works well for shared scale-out **only when** every process sees storage with correct SQLite file-locking and WAL behavior.
 
 If you cannot guarantee that for your shared volume/filesystem:
 
-- keep the admin dashboard and Crypto API instances on a topology with trustworthy shared storage semantics
-- or keep Crypto API scale-out on a single host until a server-grade shared backend lands
+- prefer `CryptoApiSharedPersistence__Provider=Postgres`
+- or keep Crypto API scale-out on a topology where the SQLite storage semantics are trustworthy
 
 Do not assume every network filesystem is automatically safe for SQLite WAL.
 
@@ -393,9 +436,9 @@ The current deployment model is intentionally conservative.
 Plan around these present-day constraints:
 
 - one admin dashboard is the documented operating model
-- Crypto API instances are stateless, but the shared control-plane state currently depends on SQLite
+- Crypto API instances are stateless, but they still depend on a reachable shared control-plane database
 - the repository does not yet provide a first-class Crypto API container image
 - the current admin UI now covers the practical shared-store workflow for clients, keys, aliases, policies, and bindings, but the overall control plane is still intentionally conservative
 - current request execution depends on the locally configured PKCS#11 module path and HSM reachability on every API instance
 
-If you need a larger multi-host topology with stronger shared-state guarantees, treat that as a future backend/infrastructure step rather than forcing the current SQLite-based control plane into a shape it does not yet claim to support.
+If you need a larger multi-host topology with stronger shared-state guarantees, start with Postgres rather than forcing SQLite onto storage semantics it does not claim to support.

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -46,7 +46,7 @@ The current slice is still deliberately small, but now includes the first practi
 - liveness endpoint at `/health/live`
 - readiness endpoint at `/health/ready`
 - readiness check that attempts to load the configured PKCS#11 module via `Pkcs11Module.Load(...)`
-- shared SQLite-backed persistence for:
+- shared persistence for:
   - API clients / applications
   - API client keys / key identifiers
   - key aliases
@@ -76,21 +76,21 @@ Steady-state request execution is now intentionally **two-tiered**:
 - cache entries are keyed by a lightweight shared-state auth revision so admin changes still invalidate warm entries across nodes without forcing full snapshot reloads on every request
 - `last_used_at_utc` updates are throttled to a short interval per key instead of writing synchronously on every successful request
 
-This keeps the instance stateless in the deployment sense while removing avoidable per-request PBKDF2, full-snapshot, and SQLite write overhead from the hot path.
+This keeps the instance stateless in the deployment sense while removing avoidable per-request PBKDF2, full-snapshot, and shared-store write overhead from the hot path.
 
 ## Shared persistence approach
 
-The first persistence provider is intentionally pragmatic: **SQLite via a shared database file**.
+The host now supports two shared persistence providers without changing the control-plane model:
 
-Why this first:
+- **SQLite** via a shared database file for local/dev/lab and smaller bounded deployments
+- **PostgreSQL** for server-grade shared deployments where API instances need a real multi-process database backend instead of shared filesystem/WAL semantics
 
-- it is real and immediately usable
-- it keeps the initial auth/policy state model simple
-- it avoids inventing a full control-plane or migration system before the public crypto contract exists
-- it is enough for small-to-medium deployments where API instances share a mounted volume or otherwise coordinate through the same SQLite file
+Why keep both:
 
-This is **not** claiming SQLite is the final answer for every distributed deployment.
-For larger/server-grade topologies, the stored concepts can move to another relational backend later without changing the basic state model introduced here.
+- SQLite remains friction-free for local onboarding, labs, and small deployments
+- PostgreSQL provides a better default for production-oriented multi-instance topologies
+- both providers store the same core concepts: clients, keys, aliases, policies, bindings, last-used metadata, and auth-state revision
+- higher layers keep the same `ICryptoApiSharedStateStore` contract so the admin dashboard and Crypto API host do not need a different control-plane model per backend
 
 ### Shared-ready state
 
@@ -146,15 +146,29 @@ Current settings live under three sections:
 }
 ```
 
+PostgreSQL example:
+
+```json
+{
+  "CryptoApiSharedPersistence": {
+    "Provider": "Postgres",
+    "ConnectionString": "Host=db.internal;Port=5432;Database=pkcs11wrapper_cryptoapi;Username=cryptoapi;Password=change-me;SSL Mode=Require",
+    "AutoInitialize": true
+  }
+}
+```
+
 Notes:
 
 - `CryptoApiHost:ApiBasePath` defines where machine-facing routes live.
 - `CryptoApiRuntime:ModulePath` is required for readiness because the host is not actually ready to serve crypto traffic until it can load a PKCS#11 module.
 - `CryptoApiRuntime:UserPin` is optional but practically required for many sign / HMAC / private-object flows. Treat it as deployment secret material, not as checked-in config.
 - `CryptoApiRuntime:DisableHttpsRedirection=true` is useful for local/container smoke flows behind a trusted reverse proxy or local HTTP test loop.
-- `CryptoApiSharedPersistence:Provider` currently supports only `Sqlite`.
+- `CryptoApiSharedPersistence:Provider` supports `Sqlite` and `Postgres`.
 - `CryptoApiSharedPersistence:ConnectionString` enables the shared state store. If omitted, the host still runs, but `/api/v1/shared-state` reports that shared persistence is not configured.
 - `CryptoApiSharedPersistence:AutoInitialize=true` creates the schema on startup/first use.
+- With `Provider=Sqlite`, the connection string is a SQLite file path such as `Data Source=/srv/pkcs11wrapper-cryptoapi/shared-state.db`.
+- With `Provider=Postgres`, use a standard Npgsql/PostgreSQL connection string and prefer a dedicated database/role for the Crypto API control plane.
 - `CryptoApiRateLimiting` adds built-in limits for `/api/v1/auth/self` and the customer-facing `/api/v1/operations/*` POST routes.
 - The first slice is intentionally **instance-local**, not shared across the fleet. A caller can consume up to the configured budget on each Crypto API instance behind the load balancer.
 - Partitioning is keyed by the presented `X-Api-Key-Id` header when present, with remote-IP fallback when no key id is available.
@@ -171,6 +185,7 @@ cd src/Pkcs11Wrapper.CryptoApi
 export CryptoApiRuntime__ModulePath=/usr/lib/libsofthsm2.so
 export CryptoApiRuntime__UserPin=98765432
 export CryptoApiRuntime__DisableHttpsRedirection=true
+export CryptoApiSharedPersistence__Provider=Sqlite
 export CryptoApiSharedPersistence__ConnectionString='Data Source=/tmp/pkcs11wrapper-cryptoapi-shared.db'
 dotnet run
 ```
@@ -209,7 +224,7 @@ The host now ships a practical first built-in rate-limiting slice for customer-f
 
 Why this shape:
 
-- it protects the public Crypto API surface without introducing shared counter writes into the SQLite control-plane path
+- it protects the public Crypto API surface without introducing shared counter writes into the control-plane data store
 - it keeps the API instances stateless and horizontally replaceable
 - it gives machine callers deterministic backoff behavior instead of silent slowdowns or long server-side queues
 
@@ -240,7 +255,7 @@ That means:
 
 - auth failures return generic rejection text by default
 - alias/policy authorization failures return generic access-denied text by default
-- `/api/v1/shared-state` omits the SQLite path/connection target and record counts by default
+- `/api/v1/shared-state` omits the shared-store connection target and record counts by default
 
 For private/internal troubleshooting, operators can opt back into the verbose behavior with:
 

--- a/docs/security-review-issue-112.md
+++ b/docs/security-review-issue-112.md
@@ -10,7 +10,7 @@ Reviewed surfaces:
 - admin dashboard authentication and session handling
 - customer-facing Crypto API authentication and alias/policy authorization
 - API key handling and public error behavior
-- shared SQLite-backed control-plane persistence exposure
+- shared control-plane persistence exposure
 - exposed HTTP endpoints and container/operator-facing defaults
 - operator-facing docs for the above behavior
 
@@ -22,7 +22,7 @@ The customer-facing host exposed:
 
 - detailed API-key authentication failure reasons (`not found`, `revoked`, `expired`, etc.)
 - detailed key-alias authorization failure reasons (`alias not found`, policy mismatch, invalid stored policy document)
-- shared-state metadata including SQLite connection target/path and record counts
+- shared-state metadata including connection target/path and record counts
 
 That was useful for private debugging, but too chatty as a default internet-facing or semi-exposed API surface.
 It increased enumeration and deployment-fingerprint leakage without being required for normal clients.
@@ -100,8 +100,8 @@ These are **not** fixed by this issue and should remain explicit in docs/roadmap
 3. **Crypto API rate limiting is now built in, but it is intentionally instance-local.**
    The host now enforces per-instance customer-endpoint rate limits keyed by presented API key id (with remote-IP fallback when no key id is present), and 429 responses include `Retry-After` plus problem-details metadata. Upstream gateways/load balancers should still enforce fleet-wide request-rate, body-size, and abuse controls.
 
-4. **SQLite is still the shared control-plane backend.**
-   That remains acceptable only for the documented conservative deployment model with trustworthy file-locking/WAL semantics.
+4. **Provider choice still matters operationally.**
+   SQLite remains acceptable for local/dev/lab and conservative shared-volume deployments with trustworthy file-locking/WAL semantics, while production-oriented multi-instance deployments should prefer Postgres.
 
 5. **Security headers are intentionally conservative.**
    A strict CSP was not added in this pass because the current interactive admin UI would need CSP-specific tuning/testing rather than a guessy header that could break the product.

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccess.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccess.razor
@@ -30,7 +30,7 @@
         <div class="hero-panel">
             <div class="hero-panel-title">Operator model</div>
             <div class="hero-panel-value">End-to-end</div>
-            <div class="hero-panel-copy">Applications, aliases, policies, and bindings now live on one admin workflow so operators can finish a usable route without hand-editing SQLite or local files.</div>
+            <div class="hero-panel-copy">Applications, aliases, policies, and bindings now live on one admin workflow so operators can finish a usable route without hand-editing shared-state tables or local files.</div>
         </div>
     </div>
 </section>
@@ -60,7 +60,7 @@ else if (!SharedPersistenceConfigured)
 {
     <div class="alert alert-warning">
         <div class="fw-semibold">Crypto API shared persistence is not configured for the admin app.</div>
-        <div class="small mt-2">Set <code>CryptoApiSharedPersistence:ConnectionString</code> to the same shared SQLite database used by the Crypto API host, then reopen this page.</div>
+        <div class="small mt-2">Set <code>CryptoApiSharedPersistence:Provider</code> and <code>CryptoApiSharedPersistence:ConnectionString</code> to the same shared persistence target used by the Crypto API host, then reopen this page.</div>
     </div>
 }
 else

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -55,8 +55,8 @@ builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
         options.ConnectionString = options.ConnectionString?.Trim();
     })
     .Validate(
-        static options => string.Equals(options.Provider, CryptoApiSharedPersistenceDefaults.SqliteProvider, StringComparison.OrdinalIgnoreCase),
-        $"Crypto API shared persistence currently supports only '{CryptoApiSharedPersistenceDefaults.SqliteProvider}'.")
+        static options => CryptoApiSharedPersistenceDefaults.IsSupportedProvider(options.Provider),
+        $"Crypto API shared persistence supports '{CryptoApiSharedPersistenceDefaults.SqliteProvider}' and '{CryptoApiSharedPersistenceDefaults.PostgresProvider}'.")
     .ValidateOnStart();
 
 AdminStorageOptions adminStorage = builder.Configuration.GetSection("AdminStorage").Get<AdminStorageOptions>() ?? new();
@@ -90,7 +90,7 @@ builder.Services.AddDataProtection()
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<CryptoApiClientSecretGenerator>();
 builder.Services.AddSingleton<CryptoApiClientSecretHasher>();
-builder.Services.AddSingleton<ICryptoApiSharedStateStore, SqliteCryptoApiSharedStateStore>();
+builder.Services.AddCryptoApiSharedStateStore();
 builder.Services.AddScoped<CryptoApiClientManagementService>();
 builder.Services.AddScoped<CryptoApiClientAuthenticationService>();
 builder.Services.AddScoped<CryptoApiKeyAccessManagementService>();

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiSharedPersistenceDefaults.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiSharedPersistenceDefaults.cs
@@ -3,9 +3,26 @@ namespace Pkcs11Wrapper.CryptoApi.Configuration;
 public static class CryptoApiSharedPersistenceDefaults
 {
     public const string SqliteProvider = "Sqlite";
+    public const string PostgresProvider = "Postgres";
 
     public static string NormalizeProvider(string? provider)
-        => string.IsNullOrWhiteSpace(provider)
-            ? SqliteProvider
-            : provider.Trim();
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return SqliteProvider;
+        }
+
+        return provider.Trim().ToLowerInvariant() switch
+        {
+            "sqlite" => SqliteProvider,
+            "postgres" => PostgresProvider,
+            "postgresql" => PostgresProvider,
+            "npgsql" => PostgresProvider,
+            _ => provider.Trim()
+        };
+    }
+
+    public static bool IsSupportedProvider(string? provider)
+        => string.Equals(NormalizeProvider(provider), SqliteProvider, StringComparison.Ordinal)
+            || string.Equals(NormalizeProvider(provider), PostgresProvider, StringComparison.Ordinal);
 }

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Pkcs11Wrapper.CryptoApi.Shared.csproj
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Pkcs11Wrapper.CryptoApi.Shared.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageReference Include="Npgsql" Version="10.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/CryptoApiSharedStateServiceCollectionExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/CryptoApiSharedStateServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+
+namespace Pkcs11Wrapper.CryptoApi.SharedState;
+
+public static class CryptoApiSharedStateServiceCollectionExtensions
+{
+    public static IServiceCollection AddCryptoApiSharedStateStore(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<SqliteCryptoApiSharedStateStore>();
+        services.AddSingleton<PostgresCryptoApiSharedStateStore>();
+        services.AddSingleton<ICryptoApiSharedStateStore>(static serviceProvider =>
+        {
+            CryptoApiSharedPersistenceOptions options = serviceProvider.GetRequiredService<IOptions<CryptoApiSharedPersistenceOptions>>().Value;
+            return CryptoApiSharedPersistenceDefaults.NormalizeProvider(options.Provider) switch
+            {
+                CryptoApiSharedPersistenceDefaults.SqliteProvider => serviceProvider.GetRequiredService<SqliteCryptoApiSharedStateStore>(),
+                CryptoApiSharedPersistenceDefaults.PostgresProvider => serviceProvider.GetRequiredService<PostgresCryptoApiSharedStateStore>(),
+                _ => throw new InvalidOperationException($"Unsupported Crypto API shared persistence provider '{options.Provider}'.")
+            };
+        });
+
+        return services;
+    }
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
@@ -1,0 +1,1079 @@
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+
+namespace Pkcs11Wrapper.CryptoApi.SharedState;
+
+public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiSharedStateStore
+{
+    private const string AuthStateRevisionMetadataKey = "auth_state_revision";
+    private const string SchemaVersionMetadataKey = "schema_version";
+
+    private readonly CryptoApiSharedPersistenceOptions _options = options.Value;
+    private readonly SemaphoreSlim _initializationGate = new(1, 1);
+    private volatile bool _databaseInitialized;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsConfigured())
+        {
+            return;
+        }
+
+        if (_databaseInitialized)
+        {
+            return;
+        }
+
+        await _initializationGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_databaseInitialized)
+            {
+                return;
+            }
+
+            await using NpgsqlConnection connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            if (_options.AutoInitialize)
+            {
+                await EnsureSchemaAsync(connection, cancellationToken);
+            }
+
+            _databaseInitialized = true;
+        }
+        finally
+        {
+            _initializationGate.Release();
+        }
+    }
+
+    public async Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsConfigured())
+        {
+            return CreateUnconfiguredStatus();
+        }
+
+        await InitializeAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await EnsureSchemaAsync(connection, cancellationToken);
+
+        return new CryptoApiSharedStateStatus(
+            Configured: true,
+            Provider: CryptoApiSharedPersistenceDefaults.PostgresProvider,
+            ConnectionTarget: GetConnectionTarget(),
+            SchemaVersion: await GetSchemaVersionAsync(connection, cancellationToken),
+            ApiClientCount: await CountRowsAsync(connection, "crypto_api_clients", cancellationToken),
+            ApiClientKeyCount: await CountRowsAsync(connection, "crypto_api_client_keys", cancellationToken),
+            KeyAliasCount: await CountRowsAsync(connection, "crypto_api_key_aliases", cancellationToken),
+            PolicyCount: await CountRowsAsync(connection, "crypto_api_policies", cancellationToken),
+            ClientPolicyBindingCount: await CountRowsAsync(connection, "crypto_api_client_policy_bindings", cancellationToken),
+            KeyAliasPolicyBindingCount: await CountRowsAsync(connection, "crypto_api_key_alias_policy_bindings", cancellationToken),
+            SharedReadyAreas: CryptoApiSharedStateConstants.SharedReadyAreas);
+    }
+
+    public async Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsConfigured())
+        {
+            return 0;
+        }
+
+        await InitializeAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        return await GetAuthStateRevisionCoreAsync(connection, cancellationToken);
+    }
+
+    public async Task<CryptoApiClientAuthenticationState?> GetClientAuthenticationStateAsync(string keyIdentifier, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(keyIdentifier);
+
+        if (!IsConfigured())
+        {
+            return null;
+        }
+
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT
+                c.client_id,
+                c.client_name,
+                c.display_name,
+                c.application_type,
+                c.authentication_mode,
+                c.is_enabled,
+                c.notes,
+                c.created_at_utc,
+                c.updated_at_utc,
+                k.client_key_id,
+                k.key_name,
+                k.key_identifier,
+                k.credential_type,
+                k.secret_hash_algorithm,
+                k.secret_hash,
+                k.secret_hint,
+                k.is_enabled,
+                k.created_at_utc,
+                k.updated_at_utc,
+                k.expires_at_utc,
+                k.revoked_at_utc,
+                k.revoked_reason,
+                k.last_used_at_utc
+            FROM crypto_api_client_keys k
+            INNER JOIN crypto_api_clients c ON c.client_id = k.client_id
+            WHERE k.key_identifier = @keyIdentifier
+            LIMIT 1;
+            """;
+        AddText(command, "@keyIdentifier", keyIdentifier);
+
+        CryptoApiClientRecord client;
+        CryptoApiClientKeyRecord key;
+
+        await using (NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken))
+        {
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                return null;
+            }
+
+            client = new CryptoApiClientRecord(
+                ClientId: reader.GetGuid(0),
+                ClientName: reader.GetString(1),
+                DisplayName: reader.GetString(2),
+                ApplicationType: reader.GetString(3),
+                AuthenticationMode: reader.GetString(4),
+                IsEnabled: reader.GetBoolean(5),
+                Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
+                CreatedAtUtc: ReadTimestamp(reader, 7),
+                UpdatedAtUtc: ReadTimestamp(reader, 8));
+
+            key = new CryptoApiClientKeyRecord(
+                ClientKeyId: reader.GetGuid(9),
+                ClientId: client.ClientId,
+                KeyName: reader.GetString(10),
+                KeyIdentifier: reader.GetString(11),
+                CredentialType: reader.GetString(12),
+                SecretHashAlgorithm: reader.GetString(13),
+                SecretHash: reader.GetString(14),
+                SecretHint: reader.IsDBNull(15) ? null : reader.GetString(15),
+                IsEnabled: reader.GetBoolean(16),
+                CreatedAtUtc: ReadTimestamp(reader, 17),
+                UpdatedAtUtc: ReadTimestamp(reader, 18),
+                ExpiresAtUtc: ReadNullableTimestamp(reader, 19),
+                RevokedAtUtc: ReadNullableTimestamp(reader, 20),
+                RevokedReason: reader.IsDBNull(21) ? null : reader.GetString(21),
+                LastUsedAtUtc: ReadNullableTimestamp(reader, 22));
+        }
+
+        Guid[] boundPolicyIds = await ReadClientBoundPolicyIdsAsync(connection, client.ClientId, cancellationToken);
+        return new CryptoApiClientAuthenticationState(client, key, boundPolicyIds);
+    }
+
+    public async Task<CryptoApiKeyAuthorizationState> GetKeyAuthorizationStateAsync(Guid clientId, string aliasName, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(aliasName);
+
+        if (!IsConfigured())
+        {
+            return new CryptoApiKeyAuthorizationState(null, null, []);
+        }
+
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        CryptoApiClientRecord? client = await ReadClientByIdAsync(connection, clientId, cancellationToken);
+        if (client is null)
+        {
+            return new CryptoApiKeyAuthorizationState(null, null, []);
+        }
+
+        CryptoApiKeyAliasRecord? alias = await ReadKeyAliasByNameAsync(connection, aliasName, cancellationToken);
+        if (alias is null)
+        {
+            return new CryptoApiKeyAuthorizationState(client, null, []);
+        }
+
+        IReadOnlyList<CryptoApiPolicyRecord> sharedPolicies = await ReadSharedPoliciesAsync(connection, clientId, alias.AliasId, cancellationToken);
+        return new CryptoApiKeyAuthorizationState(client, alias, sharedPolicies);
+    }
+
+    public async Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using NpgsqlTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO crypto_api_clients (
+                client_id,
+                client_name,
+                display_name,
+                application_type,
+                authentication_mode,
+                is_enabled,
+                notes,
+                created_at_utc,
+                updated_at_utc)
+            VALUES (
+                @clientId,
+                @clientName,
+                @displayName,
+                @applicationType,
+                @authenticationMode,
+                @isEnabled,
+                @notes,
+                @createdAtUtc,
+                @updatedAtUtc)
+            ON CONFLICT (client_id) DO UPDATE SET
+                client_name = EXCLUDED.client_name,
+                display_name = EXCLUDED.display_name,
+                application_type = EXCLUDED.application_type,
+                authentication_mode = EXCLUDED.authentication_mode,
+                is_enabled = EXCLUDED.is_enabled,
+                notes = EXCLUDED.notes,
+                updated_at_utc = EXCLUDED.updated_at_utc;
+            """;
+        AddGuid(command, "@clientId", client.ClientId);
+        AddText(command, "@clientName", client.ClientName);
+        AddText(command, "@displayName", client.DisplayName);
+        AddText(command, "@applicationType", client.ApplicationType);
+        AddText(command, "@authenticationMode", client.AuthenticationMode);
+        AddBoolean(command, "@isEnabled", client.IsEnabled);
+        AddNullableText(command, "@notes", client.Notes);
+        AddTimestamp(command, "@createdAtUtc", client.CreatedAtUtc);
+        AddTimestamp(command, "@updatedAtUtc", client.UpdatedAtUtc);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task UpsertClientKeyAsync(CryptoApiClientKeyRecord clientKey, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using NpgsqlTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO crypto_api_client_keys (
+                client_key_id,
+                client_id,
+                key_name,
+                key_identifier,
+                credential_type,
+                secret_hash_algorithm,
+                secret_hash,
+                secret_hint,
+                is_enabled,
+                created_at_utc,
+                updated_at_utc,
+                expires_at_utc,
+                revoked_at_utc,
+                revoked_reason,
+                last_used_at_utc)
+            VALUES (
+                @clientKeyId,
+                @clientId,
+                @keyName,
+                @keyIdentifier,
+                @credentialType,
+                @secretHashAlgorithm,
+                @secretHash,
+                @secretHint,
+                @isEnabled,
+                @createdAtUtc,
+                @updatedAtUtc,
+                @expiresAtUtc,
+                @revokedAtUtc,
+                @revokedReason,
+                @lastUsedAtUtc)
+            ON CONFLICT (client_key_id) DO UPDATE SET
+                client_id = EXCLUDED.client_id,
+                key_name = EXCLUDED.key_name,
+                key_identifier = EXCLUDED.key_identifier,
+                credential_type = EXCLUDED.credential_type,
+                secret_hash_algorithm = EXCLUDED.secret_hash_algorithm,
+                secret_hash = EXCLUDED.secret_hash,
+                secret_hint = EXCLUDED.secret_hint,
+                is_enabled = EXCLUDED.is_enabled,
+                updated_at_utc = EXCLUDED.updated_at_utc,
+                expires_at_utc = EXCLUDED.expires_at_utc,
+                revoked_at_utc = EXCLUDED.revoked_at_utc,
+                revoked_reason = EXCLUDED.revoked_reason,
+                last_used_at_utc = EXCLUDED.last_used_at_utc;
+            """;
+        AddGuid(command, "@clientKeyId", clientKey.ClientKeyId);
+        AddGuid(command, "@clientId", clientKey.ClientId);
+        AddText(command, "@keyName", clientKey.KeyName);
+        AddText(command, "@keyIdentifier", clientKey.KeyIdentifier);
+        AddText(command, "@credentialType", clientKey.CredentialType);
+        AddText(command, "@secretHashAlgorithm", clientKey.SecretHashAlgorithm);
+        AddText(command, "@secretHash", clientKey.SecretHash);
+        AddNullableText(command, "@secretHint", clientKey.SecretHint);
+        AddBoolean(command, "@isEnabled", clientKey.IsEnabled);
+        AddTimestamp(command, "@createdAtUtc", clientKey.CreatedAtUtc);
+        AddTimestamp(command, "@updatedAtUtc", clientKey.UpdatedAtUtc);
+        AddNullableTimestamp(command, "@expiresAtUtc", clientKey.ExpiresAtUtc);
+        AddNullableTimestamp(command, "@revokedAtUtc", clientKey.RevokedAtUtc);
+        AddNullableText(command, "@revokedReason", clientKey.RevokedReason);
+        AddNullableTimestamp(command, "@lastUsedAtUtc", clientKey.LastUsedAtUtc);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE crypto_api_client_keys
+            SET last_used_at_utc = @lastUsedAtUtc
+            WHERE client_key_id = @clientKeyId
+              AND (last_used_at_utc IS NULL OR last_used_at_utc < @minimumLastUsedAtUtc);
+            """;
+        AddGuid(command, "@clientKeyId", clientKeyId);
+        AddTimestamp(command, "@lastUsedAtUtc", lastUsedAtUtc);
+        AddTimestamp(command, "@minimumLastUsedAtUtc", lastUsedAtUtc - minimumInterval);
+
+        return await command.ExecuteNonQueryAsync(cancellationToken) > 0;
+    }
+
+    public async Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using NpgsqlTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO crypto_api_key_aliases (
+                alias_id,
+                alias_name,
+                device_route,
+                slot_id,
+                object_label,
+                object_id_hex,
+                notes,
+                is_enabled,
+                created_at_utc,
+                updated_at_utc)
+            VALUES (
+                @aliasId,
+                @aliasName,
+                @deviceRoute,
+                @slotId,
+                @objectLabel,
+                @objectIdHex,
+                @notes,
+                @isEnabled,
+                @createdAtUtc,
+                @updatedAtUtc)
+            ON CONFLICT (alias_id) DO UPDATE SET
+                alias_name = EXCLUDED.alias_name,
+                device_route = EXCLUDED.device_route,
+                slot_id = EXCLUDED.slot_id,
+                object_label = EXCLUDED.object_label,
+                object_id_hex = EXCLUDED.object_id_hex,
+                notes = EXCLUDED.notes,
+                is_enabled = EXCLUDED.is_enabled,
+                updated_at_utc = EXCLUDED.updated_at_utc;
+            """;
+        AddGuid(command, "@aliasId", keyAlias.AliasId);
+        AddText(command, "@aliasName", keyAlias.AliasName);
+        AddNullableText(command, "@deviceRoute", keyAlias.DeviceRoute);
+        AddNullableInt64(command, "@slotId", keyAlias.SlotId is null ? null : checked((long)keyAlias.SlotId.Value));
+        AddNullableText(command, "@objectLabel", keyAlias.ObjectLabel);
+        AddNullableText(command, "@objectIdHex", keyAlias.ObjectIdHex);
+        AddNullableText(command, "@notes", keyAlias.Notes);
+        AddBoolean(command, "@isEnabled", keyAlias.IsEnabled);
+        AddTimestamp(command, "@createdAtUtc", keyAlias.CreatedAtUtc);
+        AddTimestamp(command, "@updatedAtUtc", keyAlias.UpdatedAtUtc);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task UpsertPolicyAsync(CryptoApiPolicyRecord policy, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using NpgsqlTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO crypto_api_policies (
+                policy_id,
+                policy_name,
+                description,
+                revision,
+                document_json,
+                is_enabled,
+                created_at_utc,
+                updated_at_utc)
+            VALUES (
+                @policyId,
+                @policyName,
+                @description,
+                @revision,
+                @documentJson,
+                @isEnabled,
+                @createdAtUtc,
+                @updatedAtUtc)
+            ON CONFLICT (policy_id) DO UPDATE SET
+                policy_name = EXCLUDED.policy_name,
+                description = EXCLUDED.description,
+                revision = EXCLUDED.revision,
+                document_json = EXCLUDED.document_json,
+                is_enabled = EXCLUDED.is_enabled,
+                updated_at_utc = EXCLUDED.updated_at_utc;
+            """;
+        AddGuid(command, "@policyId", policy.PolicyId);
+        AddText(command, "@policyName", policy.PolicyName);
+        AddNullableText(command, "@description", policy.Description);
+        command.Parameters.AddWithValue("@revision", policy.Revision);
+        AddText(command, "@documentJson", policy.DocumentJson);
+        AddBoolean(command, "@isEnabled", policy.IsEnabled);
+        AddTimestamp(command, "@createdAtUtc", policy.CreatedAtUtc);
+        AddTimestamp(command, "@updatedAtUtc", policy.UpdatedAtUtc);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task ReplaceClientPolicyBindingsAsync(Guid clientId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using NpgsqlTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await DeleteBindingsAsync(connection, transaction, "crypto_api_client_policy_bindings", "client_id", clientId, cancellationToken);
+        foreach (Guid policyId in policyIds.Distinct())
+        {
+            await using NpgsqlCommand insert = connection.CreateCommand();
+            insert.Transaction = transaction;
+            insert.CommandText = """
+                INSERT INTO crypto_api_client_policy_bindings (client_id, policy_id, bound_at_utc)
+                VALUES (@clientId, @policyId, @boundAtUtc);
+                """;
+            AddGuid(insert, "@clientId", clientId);
+            AddGuid(insert, "@policyId", policyId);
+            AddTimestamp(insert, "@boundAtUtc", DateTimeOffset.UtcNow);
+            await insert.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task ReplaceKeyAliasPolicyBindingsAsync(Guid aliasId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using NpgsqlTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await DeleteBindingsAsync(connection, transaction, "crypto_api_key_alias_policy_bindings", "alias_id", aliasId, cancellationToken);
+        foreach (Guid policyId in policyIds.Distinct())
+        {
+            await using NpgsqlCommand insert = connection.CreateCommand();
+            insert.Transaction = transaction;
+            insert.CommandText = """
+                INSERT INTO crypto_api_key_alias_policy_bindings (alias_id, policy_id, bound_at_utc)
+                VALUES (@aliasId, @policyId, @boundAtUtc);
+                """;
+            AddGuid(insert, "@aliasId", aliasId);
+            AddGuid(insert, "@policyId", policyId);
+            AddTimestamp(insert, "@boundAtUtc", DateTimeOffset.UtcNow);
+            await insert.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task<CryptoApiSharedStateSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+
+        await using NpgsqlConnection connection = CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        return new CryptoApiSharedStateSnapshot(
+            Clients: await ReadClientsAsync(connection, cancellationToken),
+            ClientKeys: await ReadClientKeysAsync(connection, cancellationToken),
+            KeyAliases: await ReadKeyAliasesAsync(connection, cancellationToken),
+            Policies: await ReadPoliciesAsync(connection, cancellationToken),
+            ClientPolicyBindings: await ReadClientPolicyBindingsAsync(connection, cancellationToken),
+            KeyAliasPolicyBindings: await ReadKeyAliasPolicyBindingsAsync(connection, cancellationToken));
+    }
+
+    private bool IsConfigured()
+        => !string.IsNullOrWhiteSpace(_options.ConnectionString);
+
+    private CryptoApiSharedStateStatus CreateUnconfiguredStatus()
+        => new(
+            Configured: false,
+            Provider: CryptoApiSharedPersistenceDefaults.PostgresProvider,
+            ConnectionTarget: null,
+            SchemaVersion: 0,
+            ApiClientCount: 0,
+            ApiClientKeyCount: 0,
+            KeyAliasCount: 0,
+            PolicyCount: 0,
+            ClientPolicyBindingCount: 0,
+            KeyAliasPolicyBindingCount: 0,
+            SharedReadyAreas: CryptoApiSharedStateConstants.SharedReadyAreas);
+
+    private async Task EnsureConfiguredAndInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (!IsConfigured())
+        {
+            throw new InvalidOperationException("Shared persistence is not configured.");
+        }
+
+        await InitializeAsync(cancellationToken);
+    }
+
+    private NpgsqlConnection CreateConnection()
+        => new(_options.ConnectionString);
+
+    private static async Task EnsureSchemaAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS crypto_api_clients (
+                client_id UUID PRIMARY KEY,
+                client_name TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                application_type TEXT NOT NULL DEFAULT 'service',
+                authentication_mode TEXT NOT NULL,
+                is_enabled BOOLEAN NOT NULL,
+                notes TEXT NULL,
+                created_at_utc TIMESTAMPTZ NOT NULL,
+                updated_at_utc TIMESTAMPTZ NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS crypto_api_client_keys (
+                client_key_id UUID PRIMARY KEY,
+                client_id UUID NOT NULL,
+                key_name TEXT NOT NULL,
+                key_identifier TEXT NOT NULL UNIQUE,
+                credential_type TEXT NOT NULL,
+                secret_hash_algorithm TEXT NOT NULL DEFAULT 'legacy-placeholder',
+                secret_hash TEXT NOT NULL,
+                secret_hint TEXT NULL,
+                is_enabled BOOLEAN NOT NULL,
+                created_at_utc TIMESTAMPTZ NOT NULL,
+                updated_at_utc TIMESTAMPTZ NOT NULL,
+                expires_at_utc TIMESTAMPTZ NULL,
+                revoked_at_utc TIMESTAMPTZ NULL,
+                revoked_reason TEXT NULL,
+                last_used_at_utc TIMESTAMPTZ NULL,
+                CONSTRAINT fk_crypto_api_client_keys_client FOREIGN KEY (client_id) REFERENCES crypto_api_clients (client_id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS crypto_api_key_aliases (
+                alias_id UUID PRIMARY KEY,
+                alias_name TEXT NOT NULL UNIQUE,
+                device_route TEXT NULL,
+                slot_id BIGINT NULL,
+                object_label TEXT NULL,
+                object_id_hex TEXT NULL,
+                notes TEXT NULL,
+                is_enabled BOOLEAN NOT NULL,
+                created_at_utc TIMESTAMPTZ NOT NULL,
+                updated_at_utc TIMESTAMPTZ NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS crypto_api_policies (
+                policy_id UUID PRIMARY KEY,
+                policy_name TEXT NOT NULL UNIQUE,
+                description TEXT NULL,
+                revision INTEGER NOT NULL,
+                document_json TEXT NOT NULL,
+                is_enabled BOOLEAN NOT NULL,
+                created_at_utc TIMESTAMPTZ NOT NULL,
+                updated_at_utc TIMESTAMPTZ NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS crypto_api_client_policy_bindings (
+                client_id UUID NOT NULL,
+                policy_id UUID NOT NULL,
+                bound_at_utc TIMESTAMPTZ NOT NULL,
+                PRIMARY KEY (client_id, policy_id),
+                CONSTRAINT fk_crypto_api_client_policy_bindings_client FOREIGN KEY (client_id) REFERENCES crypto_api_clients (client_id) ON DELETE CASCADE,
+                CONSTRAINT fk_crypto_api_client_policy_bindings_policy FOREIGN KEY (policy_id) REFERENCES crypto_api_policies (policy_id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS crypto_api_key_alias_policy_bindings (
+                alias_id UUID NOT NULL,
+                policy_id UUID NOT NULL,
+                bound_at_utc TIMESTAMPTZ NOT NULL,
+                PRIMARY KEY (alias_id, policy_id),
+                CONSTRAINT fk_crypto_api_key_alias_policy_bindings_alias FOREIGN KEY (alias_id) REFERENCES crypto_api_key_aliases (alias_id) ON DELETE CASCADE,
+                CONSTRAINT fk_crypto_api_key_alias_policy_bindings_policy FOREIGN KEY (policy_id) REFERENCES crypto_api_policies (policy_id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS crypto_api_metadata (
+                metadata_key TEXT PRIMARY KEY,
+                metadata_value TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_crypto_api_client_keys_client_id
+                ON crypto_api_client_keys(client_id);
+
+            CREATE INDEX IF NOT EXISTS ix_crypto_api_client_keys_key_identifier
+                ON crypto_api_client_keys(key_identifier);
+
+            CREATE INDEX IF NOT EXISTS ix_crypto_api_client_policy_bindings_policy_id
+                ON crypto_api_client_policy_bindings(policy_id);
+
+            CREATE INDEX IF NOT EXISTS ix_crypto_api_key_alias_policy_bindings_policy_id
+                ON crypto_api_key_alias_policy_bindings(policy_id);
+            """;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+
+        await EnsureColumnExistsAsync(connection, "crypto_api_clients", "application_type", "TEXT NOT NULL DEFAULT 'service'", cancellationToken);
+        await EnsureColumnExistsAsync(connection, "crypto_api_client_keys", "secret_hash_algorithm", "TEXT NOT NULL DEFAULT 'legacy-placeholder'", cancellationToken);
+        await EnsureColumnExistsAsync(connection, "crypto_api_client_keys", "revoked_at_utc", "TIMESTAMPTZ NULL", cancellationToken);
+        await EnsureColumnExistsAsync(connection, "crypto_api_client_keys", "revoked_reason", "TEXT NULL", cancellationToken);
+        await EnsureColumnExistsAsync(connection, "crypto_api_client_keys", "last_used_at_utc", "TIMESTAMPTZ NULL", cancellationToken);
+        await EnsureColumnExistsAsync(connection, "crypto_api_key_aliases", "device_route", "TEXT NULL", cancellationToken);
+
+        await using NpgsqlCommand metadata = connection.CreateCommand();
+        metadata.CommandText = """
+            INSERT INTO crypto_api_metadata (metadata_key, metadata_value)
+            VALUES (@authStateRevisionKey, '1')
+            ON CONFLICT (metadata_key) DO NOTHING;
+
+            INSERT INTO crypto_api_metadata (metadata_key, metadata_value)
+            VALUES (@schemaVersionKey, @schemaVersion)
+            ON CONFLICT (metadata_key) DO UPDATE
+            SET metadata_value = EXCLUDED.metadata_value;
+            """;
+        AddText(metadata, "@authStateRevisionKey", AuthStateRevisionMetadataKey);
+        AddText(metadata, "@schemaVersionKey", SchemaVersionMetadataKey);
+        AddText(metadata, "@schemaVersion", CryptoApiSharedStateConstants.SchemaVersion.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        await metadata.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task EnsureColumnExistsAsync(NpgsqlConnection connection, string tableName, string columnName, string sqlTypeClause, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand alter = connection.CreateCommand();
+        alter.CommandText = $"ALTER TABLE {tableName} ADD COLUMN IF NOT EXISTS {columnName} {sqlTypeClause};";
+        await alter.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task<int> CountRowsAsync(NpgsqlConnection connection, string tableName, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = $"SELECT COUNT(*) FROM {tableName};";
+        object? value = await command.ExecuteScalarAsync(cancellationToken);
+        return Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<int> GetSchemaVersionAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT metadata_value FROM crypto_api_metadata WHERE metadata_key = @metadataKey;";
+        AddText(command, "@metadataKey", SchemaVersionMetadataKey);
+        object? value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is null
+            ? CryptoApiSharedStateConstants.SchemaVersion
+            : Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<long> GetAuthStateRevisionCoreAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT metadata_value FROM crypto_api_metadata WHERE metadata_key = @metadataKey;";
+        AddText(command, "@metadataKey", AuthStateRevisionMetadataKey);
+        object? value = await command.ExecuteScalarAsync(cancellationToken);
+        return value is null
+            ? 1
+            : Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<Guid[]> ReadClientBoundPolicyIdsAsync(NpgsqlConnection connection, Guid clientId, CancellationToken cancellationToken)
+    {
+        List<Guid> policyIds = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT policy_id
+            FROM crypto_api_client_policy_bindings
+            WHERE client_id = @clientId
+            ORDER BY policy_id;
+            """;
+        AddGuid(command, "@clientId", clientId);
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            policyIds.Add(reader.GetGuid(0));
+        }
+
+        return policyIds.ToArray();
+    }
+
+    private static async Task<CryptoApiClientRecord?> ReadClientByIdAsync(NpgsqlConnection connection, Guid clientId, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT client_id, client_name, display_name, application_type, authentication_mode, is_enabled, notes, created_at_utc, updated_at_utc
+            FROM crypto_api_clients
+            WHERE client_id = @clientId
+            LIMIT 1;
+            """;
+        AddGuid(command, "@clientId", clientId);
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new CryptoApiClientRecord(
+            ClientId: reader.GetGuid(0),
+            ClientName: reader.GetString(1),
+            DisplayName: reader.GetString(2),
+            ApplicationType: reader.GetString(3),
+            AuthenticationMode: reader.GetString(4),
+            IsEnabled: reader.GetBoolean(5),
+            Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
+            CreatedAtUtc: ReadTimestamp(reader, 7),
+            UpdatedAtUtc: ReadTimestamp(reader, 8));
+    }
+
+    private static async Task<CryptoApiKeyAliasRecord?> ReadKeyAliasByNameAsync(NpgsqlConnection connection, string aliasName, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT alias_id, alias_name, device_route, slot_id, object_label, object_id_hex, notes, is_enabled, created_at_utc, updated_at_utc
+            FROM crypto_api_key_aliases
+            WHERE lower(alias_name) = lower(@aliasName)
+            LIMIT 1;
+            """;
+        AddText(command, "@aliasName", aliasName);
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new CryptoApiKeyAliasRecord(
+            AliasId: reader.GetGuid(0),
+            AliasName: reader.GetString(1),
+            DeviceRoute: reader.IsDBNull(2) ? null : reader.GetString(2),
+            SlotId: reader.IsDBNull(3) ? null : checked((ulong)reader.GetInt64(3)),
+            ObjectLabel: reader.IsDBNull(4) ? null : reader.GetString(4),
+            ObjectIdHex: reader.IsDBNull(5) ? null : reader.GetString(5),
+            Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
+            IsEnabled: reader.GetBoolean(7),
+            CreatedAtUtc: ReadTimestamp(reader, 8),
+            UpdatedAtUtc: ReadTimestamp(reader, 9));
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiPolicyRecord>> ReadSharedPoliciesAsync(NpgsqlConnection connection, Guid clientId, Guid aliasId, CancellationToken cancellationToken)
+    {
+        List<CryptoApiPolicyRecord> policies = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT DISTINCT p.policy_id, p.policy_name, p.description, p.revision, p.document_json, p.is_enabled, p.created_at_utc, p.updated_at_utc
+            FROM crypto_api_policies p
+            INNER JOIN crypto_api_client_policy_bindings cpb ON cpb.policy_id = p.policy_id
+            INNER JOIN crypto_api_key_alias_policy_bindings kapb ON kapb.policy_id = p.policy_id
+            WHERE cpb.client_id = @clientId
+              AND kapb.alias_id = @aliasId
+              AND p.is_enabled = TRUE
+            ORDER BY p.policy_name;
+            """;
+        AddGuid(command, "@clientId", clientId);
+        AddGuid(command, "@aliasId", aliasId);
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            policies.Add(new CryptoApiPolicyRecord(
+                PolicyId: reader.GetGuid(0),
+                PolicyName: reader.GetString(1),
+                Description: reader.IsDBNull(2) ? null : reader.GetString(2),
+                Revision: reader.GetInt32(3),
+                DocumentJson: reader.GetString(4),
+                IsEnabled: reader.GetBoolean(5),
+                CreatedAtUtc: ReadTimestamp(reader, 6),
+                UpdatedAtUtc: ReadTimestamp(reader, 7)));
+        }
+
+        return policies;
+    }
+
+    private static async Task IncrementAuthStateRevisionAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO crypto_api_metadata (metadata_key, metadata_value)
+            VALUES (@metadataKey, '2')
+            ON CONFLICT (metadata_key) DO UPDATE
+            SET metadata_value = CAST(CAST(crypto_api_metadata.metadata_value AS BIGINT) + 1 AS TEXT);
+            """;
+        AddText(command, "@metadataKey", AuthStateRevisionMetadataKey);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private string? GetConnectionTarget()
+    {
+        NpgsqlConnectionStringBuilder builder = new(_options.ConnectionString);
+        string host = string.IsNullOrWhiteSpace(builder.Host) ? "localhost" : builder.Host;
+        string database = string.IsNullOrWhiteSpace(builder.Database) ? "postgres" : builder.Database;
+        string target = $"{host}:{builder.Port}/{database}";
+        return string.IsNullOrWhiteSpace(builder.SearchPath)
+            ? target
+            : $"{target}?search_path={builder.SearchPath}";
+    }
+
+    private static async Task DeleteBindingsAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, string tableName, string keyColumn, Guid keyValue, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand delete = connection.CreateCommand();
+        delete.Transaction = transaction;
+        delete.CommandText = $"DELETE FROM {tableName} WHERE {keyColumn} = @keyValue;";
+        AddGuid(delete, "@keyValue", keyValue);
+        await delete.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiClientRecord>> ReadClientsAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        List<CryptoApiClientRecord> clients = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT client_id, client_name, display_name, application_type, authentication_mode, is_enabled, notes, created_at_utc, updated_at_utc
+            FROM crypto_api_clients
+            ORDER BY client_name;
+            """;
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            clients.Add(new CryptoApiClientRecord(
+                ClientId: reader.GetGuid(0),
+                ClientName: reader.GetString(1),
+                DisplayName: reader.GetString(2),
+                ApplicationType: reader.GetString(3),
+                AuthenticationMode: reader.GetString(4),
+                IsEnabled: reader.GetBoolean(5),
+                Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
+                CreatedAtUtc: ReadTimestamp(reader, 7),
+                UpdatedAtUtc: ReadTimestamp(reader, 8)));
+        }
+
+        return clients;
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiClientKeyRecord>> ReadClientKeysAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        List<CryptoApiClientKeyRecord> clientKeys = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT client_key_id, client_id, key_name, key_identifier, credential_type, secret_hash_algorithm, secret_hash, secret_hint, is_enabled, created_at_utc, updated_at_utc, expires_at_utc, revoked_at_utc, revoked_reason, last_used_at_utc
+            FROM crypto_api_client_keys
+            ORDER BY key_name;
+            """;
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            clientKeys.Add(new CryptoApiClientKeyRecord(
+                ClientKeyId: reader.GetGuid(0),
+                ClientId: reader.GetGuid(1),
+                KeyName: reader.GetString(2),
+                KeyIdentifier: reader.GetString(3),
+                CredentialType: reader.GetString(4),
+                SecretHashAlgorithm: reader.GetString(5),
+                SecretHash: reader.GetString(6),
+                SecretHint: reader.IsDBNull(7) ? null : reader.GetString(7),
+                IsEnabled: reader.GetBoolean(8),
+                CreatedAtUtc: ReadTimestamp(reader, 9),
+                UpdatedAtUtc: ReadTimestamp(reader, 10),
+                ExpiresAtUtc: ReadNullableTimestamp(reader, 11),
+                RevokedAtUtc: ReadNullableTimestamp(reader, 12),
+                RevokedReason: reader.IsDBNull(13) ? null : reader.GetString(13),
+                LastUsedAtUtc: ReadNullableTimestamp(reader, 14)));
+        }
+
+        return clientKeys;
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiKeyAliasRecord>> ReadKeyAliasesAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        List<CryptoApiKeyAliasRecord> aliases = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT alias_id, alias_name, device_route, slot_id, object_label, object_id_hex, notes, is_enabled, created_at_utc, updated_at_utc
+            FROM crypto_api_key_aliases
+            ORDER BY alias_name;
+            """;
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            aliases.Add(new CryptoApiKeyAliasRecord(
+                AliasId: reader.GetGuid(0),
+                AliasName: reader.GetString(1),
+                DeviceRoute: reader.IsDBNull(2) ? null : reader.GetString(2),
+                SlotId: reader.IsDBNull(3) ? null : checked((ulong)reader.GetInt64(3)),
+                ObjectLabel: reader.IsDBNull(4) ? null : reader.GetString(4),
+                ObjectIdHex: reader.IsDBNull(5) ? null : reader.GetString(5),
+                Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
+                IsEnabled: reader.GetBoolean(7),
+                CreatedAtUtc: ReadTimestamp(reader, 8),
+                UpdatedAtUtc: ReadTimestamp(reader, 9)));
+        }
+
+        return aliases;
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiPolicyRecord>> ReadPoliciesAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        List<CryptoApiPolicyRecord> policies = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT policy_id, policy_name, description, revision, document_json, is_enabled, created_at_utc, updated_at_utc
+            FROM crypto_api_policies
+            ORDER BY policy_name;
+            """;
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            policies.Add(new CryptoApiPolicyRecord(
+                PolicyId: reader.GetGuid(0),
+                PolicyName: reader.GetString(1),
+                Description: reader.IsDBNull(2) ? null : reader.GetString(2),
+                Revision: reader.GetInt32(3),
+                DocumentJson: reader.GetString(4),
+                IsEnabled: reader.GetBoolean(5),
+                CreatedAtUtc: ReadTimestamp(reader, 6),
+                UpdatedAtUtc: ReadTimestamp(reader, 7)));
+        }
+
+        return policies;
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiClientPolicyBinding>> ReadClientPolicyBindingsAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        List<CryptoApiClientPolicyBinding> bindings = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT client_id, policy_id, bound_at_utc
+            FROM crypto_api_client_policy_bindings
+            ORDER BY client_id, policy_id;
+            """;
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            bindings.Add(new CryptoApiClientPolicyBinding(
+                ClientId: reader.GetGuid(0),
+                PolicyId: reader.GetGuid(1),
+                BoundAtUtc: ReadTimestamp(reader, 2)));
+        }
+
+        return bindings;
+    }
+
+    private static async Task<IReadOnlyList<CryptoApiKeyAliasPolicyBinding>> ReadKeyAliasPolicyBindingsAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        List<CryptoApiKeyAliasPolicyBinding> bindings = [];
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT alias_id, policy_id, bound_at_utc
+            FROM crypto_api_key_alias_policy_bindings
+            ORDER BY alias_id, policy_id;
+            """;
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            bindings.Add(new CryptoApiKeyAliasPolicyBinding(
+                AliasId: reader.GetGuid(0),
+                PolicyId: reader.GetGuid(1),
+                BoundAtUtc: ReadTimestamp(reader, 2)));
+        }
+
+        return bindings;
+    }
+
+    private static DateTimeOffset ReadTimestamp(NpgsqlDataReader reader, int ordinal)
+    {
+        DateTime value = reader.GetDateTime(ordinal);
+        if (value.Kind == DateTimeKind.Unspecified)
+        {
+            value = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+        }
+        else if (value.Kind == DateTimeKind.Local)
+        {
+            value = value.ToUniversalTime();
+        }
+
+        return new DateTimeOffset(value, TimeSpan.Zero);
+    }
+
+    private static DateTimeOffset? ReadNullableTimestamp(NpgsqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal)
+            ? null
+            : ReadTimestamp(reader, ordinal);
+
+    private static void AddGuid(NpgsqlCommand command, string parameterName, Guid value)
+        => command.Parameters.AddWithValue(parameterName, value);
+
+    private static void AddText(NpgsqlCommand command, string parameterName, string value)
+        => command.Parameters.AddWithValue(parameterName, value);
+
+    private static void AddNullableText(NpgsqlCommand command, string parameterName, string? value)
+        => command.Parameters.AddWithValue(parameterName, value ?? (object)DBNull.Value);
+
+    private static void AddNullableInt64(NpgsqlCommand command, string parameterName, long? value)
+        => command.Parameters.AddWithValue(parameterName, value ?? (object)DBNull.Value);
+
+    private static void AddBoolean(NpgsqlCommand command, string parameterName, bool value)
+        => command.Parameters.AddWithValue(parameterName, value);
+
+    private static void AddTimestamp(NpgsqlCommand command, string parameterName, DateTimeOffset value)
+        => command.Parameters.AddWithValue(parameterName, value.UtcDateTime);
+
+    private static void AddNullableTimestamp(NpgsqlCommand command, string parameterName, DateTimeOffset? value)
+        => command.Parameters.AddWithValue(parameterName, value?.UtcDateTime ?? (object)DBNull.Value);
+}

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -67,8 +67,8 @@ builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
         options.ConnectionString = options.ConnectionString?.Trim();
     })
     .Validate(
-        static options => string.Equals(options.Provider, CryptoApiSharedPersistenceDefaults.SqliteProvider, StringComparison.OrdinalIgnoreCase),
-        $"Crypto API shared persistence currently supports only '{CryptoApiSharedPersistenceDefaults.SqliteProvider}'.")
+        static options => CryptoApiSharedPersistenceDefaults.IsSupportedProvider(options.Provider),
+        $"Crypto API shared persistence supports '{CryptoApiSharedPersistenceDefaults.SqliteProvider}' and '{CryptoApiSharedPersistenceDefaults.PostgresProvider}'.")
     .ValidateOnStart();
 
 builder.Services.AddSingleton(TimeProvider.System);
@@ -84,7 +84,7 @@ builder.Services.AddSingleton<CryptoApiClientAuthenticationService>();
 builder.Services.AddSingleton<CryptoApiKeyAccessManagementService>();
 builder.Services.AddSingleton<CryptoApiKeyOperationAuthorizationService>();
 builder.Services.AddSingleton<ICryptoApiCustomerOperationService, CryptoApiPkcs11CustomerOperationService>();
-builder.Services.AddSingleton<ICryptoApiSharedStateStore, SqliteCryptoApiSharedStateStore>();
+builder.Services.AddCryptoApiSharedStateStore();
 
 builder.Services.AddSingleton<IConfigureOptions<RateLimiterOptions>, ConfigureCryptoApiRateLimiterOptions>();
 builder.Services.AddRateLimiter(_ => { });

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiConfigurationTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiConfigurationTests.cs
@@ -7,6 +7,20 @@ namespace Pkcs11Wrapper.CryptoApi.Tests;
 public sealed class CryptoApiConfigurationTests
 {
     [Theory]
+    [InlineData(null, "Sqlite")]
+    [InlineData("", "Sqlite")]
+    [InlineData("sqlite", "Sqlite")]
+    [InlineData(" Postgres ", "Postgres")]
+    [InlineData("postgresql", "Postgres")]
+    [InlineData("Npgsql", "Postgres")]
+    public void NormalizeProviderReturnsExpectedValue(string? configuredProvider, string expected)
+    {
+        string actual = CryptoApiSharedPersistenceDefaults.NormalizeProvider(configuredProvider);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
     [InlineData(null, "/api/v1")]
     [InlineData("", "/api/v1")]
     [InlineData("api/v1", "/api/v1")]
@@ -57,5 +71,28 @@ public sealed class CryptoApiConfigurationTests
         Assert.Contains("POST /api/crypto/operations/random", descriptor.CurrentSurface);
         Assert.NotEqual(default, descriptor.StartedAtUtc);
         Assert.False(string.IsNullOrWhiteSpace(descriptor.InstanceId));
+    }
+
+    [Fact]
+    public void RuntimeDescriptorProviderReportsPostgresWhenConfigured()
+    {
+        CryptoApiRuntimeDescriptorProvider provider = new(
+            Options.Create(new CryptoApiHostOptions
+            {
+                ServiceName = "Pkcs11Wrapper.CryptoApi",
+                ApiBasePath = "/api/v1"
+            }),
+            Options.Create(new CryptoApiRuntimeOptions()),
+            Options.Create(new CryptoApiSharedPersistenceOptions
+            {
+                Provider = "postgresql",
+                ConnectionString = "Host=localhost;Port=5432;Database=pkcs11wrapper;Username=tester;Password=secret"
+            }),
+            TimeProvider.System);
+
+        CryptoApiRuntimeDescriptor descriptor = provider.Describe();
+
+        Assert.True(descriptor.SharedPersistenceConfigured);
+        Assert.Equal("Postgres", descriptor.SharedPersistenceProvider);
     }
 }

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiPostgresSharedStateStoreTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiPostgresSharedStateStoreTests.cs
@@ -1,0 +1,235 @@
+using Pkcs11Wrapper.CryptoApi.SharedState;
+using static Pkcs11Wrapper.CryptoApi.Tests.PostgresTestEnvironment;
+
+namespace Pkcs11Wrapper.CryptoApi.Tests;
+
+public sealed class CryptoApiPostgresSharedStateStoreTests
+{
+    [PostgresFact]
+    public async Task SharedStateStoreSharesStateAcrossIndependentInstances()
+    {
+        await using PostgresTestScope scope = await CreateScopeAsync();
+
+        ICryptoApiSharedStateStore writer = new PostgresCryptoApiSharedStateStore(scope.AsOptions());
+        Guid clientId = Guid.NewGuid();
+        Guid clientKeyId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid policyId = Guid.NewGuid();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        await writer.UpsertClientAsync(new CryptoApiClientRecord(
+            clientId,
+            "ingress-gateway",
+            "Ingress Gateway",
+            "gateway",
+            "api-key",
+            true,
+            "Primary calling service",
+            now,
+            now));
+        await writer.UpsertClientKeyAsync(new CryptoApiClientKeyRecord(
+            clientKeyId,
+            clientId,
+            "primary-hmac",
+            "kid-ingress-primary",
+            "api-key-secret",
+            "pbkdf2-sha256-v1",
+            "pbkdf2-sha256-v1$100000$salt$hash",
+            "ing...mary",
+            true,
+            now,
+            now,
+            null,
+            null,
+            null,
+            null));
+        await writer.UpsertPolicyAsync(new CryptoApiPolicyRecord(
+            policyId,
+            "signing-default",
+            "Default sign policy",
+            1,
+            "{\"version\":1,\"allowedOperations\":[\"sign\"]}",
+            true,
+            now,
+            now));
+        await writer.UpsertKeyAliasAsync(new CryptoApiKeyAliasRecord(
+            aliasId,
+            "payments-signer",
+            "hsm-eu-primary",
+            7,
+            "Payments signing key",
+            "A1B2C3D4",
+            "Resolves the default outbound signing key.",
+            true,
+            now,
+            now));
+        await writer.ReplaceClientPolicyBindingsAsync(clientId, [policyId]);
+        await writer.ReplaceKeyAliasPolicyBindingsAsync(aliasId, [policyId]);
+
+        ICryptoApiSharedStateStore reader = new PostgresCryptoApiSharedStateStore(scope.AsOptions());
+        CryptoApiSharedStateStatus status = await reader.GetStatusAsync();
+        CryptoApiSharedStateSnapshot snapshot = await reader.GetSnapshotAsync();
+
+        Assert.True(status.Configured);
+        Assert.Equal("Postgres", status.Provider);
+        Assert.Equal(CryptoApiSharedStateConstants.SchemaVersion, status.SchemaVersion);
+        Assert.Equal(1, status.ApiClientCount);
+        Assert.Equal(1, status.ApiClientKeyCount);
+        Assert.Equal(1, status.KeyAliasCount);
+        Assert.Equal(1, status.PolicyCount);
+        Assert.Equal(1, status.ClientPolicyBindingCount);
+        Assert.Equal(1, status.KeyAliasPolicyBindingCount);
+        Assert.Contains($"search_path={scope.SchemaName}", status.ConnectionTarget, StringComparison.Ordinal);
+
+        CryptoApiClientRecord client = Assert.Single(snapshot.Clients);
+        Assert.Equal("ingress-gateway", client.ClientName);
+        Assert.Equal("gateway", client.ApplicationType);
+
+        CryptoApiClientKeyRecord clientKey = Assert.Single(snapshot.ClientKeys);
+        Assert.Equal(clientId, clientKey.ClientId);
+        Assert.Equal("kid-ingress-primary", clientKey.KeyIdentifier);
+        Assert.Null(clientKey.RevokedAtUtc);
+        Assert.Null(clientKey.LastUsedAtUtc);
+
+        CryptoApiKeyAliasRecord alias = Assert.Single(snapshot.KeyAliases);
+        Assert.Equal("hsm-eu-primary", alias.DeviceRoute);
+        Assert.Equal((ulong)7, alias.SlotId);
+
+        CryptoApiPolicyRecord policy = Assert.Single(snapshot.Policies);
+        Assert.Equal("signing-default", policy.PolicyName);
+        Assert.Contains("allowedOperations", policy.DocumentJson, StringComparison.Ordinal);
+    }
+
+    [PostgresFact]
+    public async Task AuthStateRevisionTracksSemanticChangesButNotLastUsedTouches()
+    {
+        await using PostgresTestScope scope = await CreateScopeAsync();
+
+        ICryptoApiSharedStateStore store = new PostgresCryptoApiSharedStateStore(scope.AsOptions());
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        Guid clientId = Guid.NewGuid();
+        Guid clientKeyId = Guid.NewGuid();
+
+        long initialRevision = await store.GetAuthStateRevisionAsync();
+        await store.UpsertClientAsync(new CryptoApiClientRecord(
+            clientId,
+            "throughput-client",
+            "Throughput Client",
+            "gateway",
+            "api-key",
+            true,
+            null,
+            now,
+            now));
+        long afterClientUpsert = await store.GetAuthStateRevisionAsync();
+
+        await store.UpsertClientKeyAsync(new CryptoApiClientKeyRecord(
+            clientKeyId,
+            clientId,
+            "primary",
+            "kid-throughput-primary",
+            "api-key-secret",
+            "pbkdf2-sha256-v1",
+            "pbkdf2-sha256-v1$100000$salt$hash",
+            "thr...ary",
+            true,
+            now,
+            now,
+            null,
+            null,
+            null,
+            null));
+        long afterKeyUpsert = await store.GetAuthStateRevisionAsync();
+
+        bool firstTouchUpdated = await store.TryTouchClientKeyLastUsedAsync(clientKeyId, now.AddSeconds(5), TimeSpan.FromSeconds(30));
+        long afterFirstTouch = await store.GetAuthStateRevisionAsync();
+        bool secondTouchUpdated = await store.TryTouchClientKeyLastUsedAsync(clientKeyId, now.AddSeconds(10), TimeSpan.FromSeconds(30));
+        long afterSecondTouch = await store.GetAuthStateRevisionAsync();
+
+        Assert.True(afterClientUpsert > initialRevision);
+        Assert.True(afterKeyUpsert > afterClientUpsert);
+        Assert.True(firstTouchUpdated);
+        Assert.False(secondTouchUpdated);
+        Assert.Equal(afterKeyUpsert, afterFirstTouch);
+        Assert.Equal(afterFirstTouch, afterSecondTouch);
+
+        CryptoApiClientKeyRecord key = Assert.Single((await store.GetSnapshotAsync()).ClientKeys);
+        Assert.Equal(now.AddSeconds(5).UtcDateTime, key.LastUsedAtUtc!.Value.UtcDateTime);
+    }
+
+    [PostgresFact]
+    public async Task KeyAuthorizationStateQueryReturnsOnlySharedEnabledPoliciesForAlias()
+    {
+        await using PostgresTestScope scope = await CreateScopeAsync();
+
+        PostgresCryptoApiSharedStateStore store = new(scope.AsOptions());
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid sharedPolicyId = Guid.NewGuid();
+        Guid clientOnlyPolicyId = Guid.NewGuid();
+        Guid disabledSharedPolicyId = Guid.NewGuid();
+
+        await store.UpsertClientAsync(new CryptoApiClientRecord(
+            clientId,
+            "targeted-authorization-client",
+            "Targeted Authorization Client",
+            "gateway",
+            "api-key",
+            true,
+            null,
+            now,
+            now));
+        await store.UpsertKeyAliasAsync(new CryptoApiKeyAliasRecord(
+            aliasId,
+            "payments-signer",
+            "hsm-eu-primary",
+            7,
+            "Payments signing key",
+            "A1B2C3D4",
+            null,
+            true,
+            now,
+            now));
+        await store.UpsertPolicyAsync(new CryptoApiPolicyRecord(
+            sharedPolicyId,
+            "shared-sign",
+            null,
+            1,
+            "{\"version\":1,\"allowedOperations\":[\"sign\"]}",
+            true,
+            now,
+            now));
+        await store.UpsertPolicyAsync(new CryptoApiPolicyRecord(
+            clientOnlyPolicyId,
+            "client-only",
+            null,
+            1,
+            "{\"version\":1,\"allowedOperations\":[\"verify\"]}",
+            true,
+            now,
+            now));
+        await store.UpsertPolicyAsync(new CryptoApiPolicyRecord(
+            disabledSharedPolicyId,
+            "disabled-shared",
+            null,
+            1,
+            "{\"version\":1,\"allowedOperations\":[\"unwrap\"]}",
+            false,
+            now,
+            now));
+
+        await store.ReplaceClientPolicyBindingsAsync(clientId, [sharedPolicyId, clientOnlyPolicyId, disabledSharedPolicyId]);
+        await store.ReplaceKeyAliasPolicyBindingsAsync(aliasId, [sharedPolicyId, disabledSharedPolicyId]);
+
+        CryptoApiKeyAuthorizationState authorizationState = await store.GetKeyAuthorizationStateAsync(clientId, "PAYMENTS-SIGNER");
+
+        Assert.NotNull(authorizationState.Client);
+        Assert.NotNull(authorizationState.Alias);
+        Assert.Equal(clientId, authorizationState.Client!.ClientId);
+        Assert.Equal(aliasId, authorizationState.Alias!.AliasId);
+        CryptoApiPolicyRecord policy = Assert.Single(authorizationState.SharedPolicies);
+        Assert.Equal(sharedPolicyId, policy.PolicyId);
+        Assert.Equal("shared-sign", policy.PolicyName);
+    }
+}

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/Pkcs11Wrapper.CryptoApi.Tests.csproj
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/Pkcs11Wrapper.CryptoApi.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Npgsql" Version="10.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/PostgresTestEnvironment.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/PostgresTestEnvironment.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+
+namespace Pkcs11Wrapper.CryptoApi.Tests;
+
+internal static class PostgresTestEnvironment
+{
+    public const string ConnectionStringEnvironmentVariable = "PKCS11WRAPPER_TEST_POSTGRES_CONNECTION_STRING";
+
+    public static bool IsConfigured()
+        => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable));
+
+    public static async Task<PostgresTestScope> CreateScopeAsync(CancellationToken cancellationToken = default)
+    {
+        string baseConnectionString = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable)
+            ?? throw new InvalidOperationException($"Set {ConnectionStringEnvironmentVariable} to run PostgreSQL integration tests.");
+
+        string schemaName = $"cryptoapi_test_{Guid.NewGuid():N}";
+
+        await using (NpgsqlConnection connection = new(baseConnectionString))
+        {
+            await connection.OpenAsync(cancellationToken);
+            await using NpgsqlCommand command = connection.CreateCommand();
+            command.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{schemaName}\";";
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        NpgsqlConnectionStringBuilder builder = new(baseConnectionString)
+        {
+            SearchPath = schemaName
+        };
+
+        return new PostgresTestScope(schemaName, new CryptoApiSharedPersistenceOptions
+        {
+            Provider = CryptoApiSharedPersistenceDefaults.PostgresProvider,
+            ConnectionString = builder.ConnectionString,
+            AutoInitialize = true
+        });
+    }
+
+    public sealed class PostgresTestScope(string schemaName, CryptoApiSharedPersistenceOptions options) : IAsyncDisposable
+    {
+        public string SchemaName { get; } = schemaName;
+
+        public CryptoApiSharedPersistenceOptions Options { get; } = options;
+
+        public IOptions<CryptoApiSharedPersistenceOptions> AsOptions()
+            => Microsoft.Extensions.Options.Options.Create(Options);
+
+        public async ValueTask DisposeAsync()
+        {
+            NpgsqlConnection.ClearAllPools();
+
+            string baseConnectionString = Environment.GetEnvironmentVariable(ConnectionStringEnvironmentVariable)
+                ?? throw new InvalidOperationException($"Set {ConnectionStringEnvironmentVariable} to run PostgreSQL integration tests.");
+
+            await using NpgsqlConnection connection = new(baseConnectionString);
+            await connection.OpenAsync();
+            await using NpgsqlCommand command = connection.CreateCommand();
+            command.CommandText = $"DROP SCHEMA IF EXISTS \"{SchemaName}\" CASCADE;";
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+}
+
+internal sealed class PostgresFactAttribute : FactAttribute
+{
+    public PostgresFactAttribute()
+    {
+        if (!PostgresTestEnvironment.IsConfigured())
+        {
+            Skip = $"Set {PostgresTestEnvironment.ConnectionStringEnvironmentVariable} to run PostgreSQL integration tests.";
+        }
+    }
+}


### PR DESCRIPTION
Add a PostgreSQL-backed shared persistence provider for the Crypto API control-plane state while keeping SQLite for local/dev/lab. This wires provider-based selection into both the admin dashboard and Crypto API hosts and preserves the existing clients/keys/aliases/policies/bindings model. Closes #138.