### PR TITLE
Add Redis-backed Crypto API hot-path acceleration

### DIFF
--- a/deploy/container/crypto-api.env.example
+++ b/deploy/container/crypto-api.env.example
@@ -37,6 +37,16 @@ CryptoApiSharedPersistence__AutoInitialize=true
 # CryptoApiSharedPersistence__Provider=Postgres
 # CryptoApiSharedPersistence__ConnectionString=Host=db.internal;Port=5432;Database=pkcs11wrapper_cryptoapi;Username=cryptoapi;Password=ChangeMe;SSL Mode=Require
 
+# Optional Redis-backed hot-path acceleration.
+# This remains a disposable cache/lease layer only: PostgreSQL/SQLite stays the
+# source of truth for clients, keys, aliases, policies, and bindings.
+CryptoApiRequestPathCaching__Redis__Enabled=false
+CryptoApiRequestPathCaching__Redis__Configuration=
+CryptoApiRequestPathCaching__Redis__InstanceName=pkcs11wrapper:cryptoapi:
+CryptoApiRequestPathCaching__Redis__ConnectTimeoutMilliseconds=5000
+CryptoApiRequestPathCaching__Redis__OperationTimeoutMilliseconds=1000
+CryptoApiRequestPathCaching__Redis__AuthStateRevisionTtlSeconds=30
+
 # Keep verbose auth/shared-state diagnostics disabled on exposed deployments.
 # Enable only for tightly controlled internal troubleshooting.
 CryptoApiSecurity__ExposeDetailedErrors=false

--- a/docs/crypto-api-deployment.md
+++ b/docs/crypto-api-deployment.md
@@ -133,8 +133,9 @@ When both point at the same `CryptoApiSharedPersistence:ConnectionString`, they 
 - usage metadata such as `last_used_at_utc`
 
 Each API node may still keep a **small local request-path cache** for successful auth + authorization decisions.
-That cache is intentionally node-local and disposable; correctness still comes from the shared database because cache keys are tied to a shared auth-state revision that advances when clients, keys, aliases, policies, or bindings change.
-`last_used_at_utc` remains shared metadata, but the host now writes it on a short throttled interval instead of once per successful request.
+Operators can also layer in an optional **Redis-backed hot-path accelerator** so instances can share warm auth/authz decisions, reuse a shared auth-state revision hint, and coordinate `last_used_at_utc` throttling across the fleet.
+Those caches remain disposable; correctness still comes from the shared database because cache keys are tied to a shared auth-state revision that advances when clients, keys, aliases, policies, or bindings change.
+`last_used_at_utc` remains shared metadata, but the host now writes it on a short throttled interval instead of once per successful request, and Redis can reduce duplicate cross-node touches within that interval.
 
 ### Not shared
 
@@ -224,6 +225,7 @@ CryptoApiRuntime__DisableHttpsRedirection=true
 CryptoApiSharedPersistence__Provider=Sqlite
 CryptoApiSharedPersistence__ConnectionString=Data Source=/srv/pkcs11wrapper/cryptoapi-shared/shared-state.db
 CryptoApiSharedPersistence__AutoInitialize=true
+CryptoApiRequestPathCaching__Redis__Enabled=false
 ```
 
 Postgres variant:
@@ -236,6 +238,9 @@ CryptoApiRuntime__DisableHttpsRedirection=true
 CryptoApiSharedPersistence__Provider=Postgres
 CryptoApiSharedPersistence__ConnectionString=Host=db.internal;Port=5432;Database=pkcs11wrapper_cryptoapi;Username=cryptoapi;Password=<secret>;SSL Mode=Require
 CryptoApiSharedPersistence__AutoInitialize=true
+CryptoApiRequestPathCaching__Redis__Enabled=true
+CryptoApiRequestPathCaching__Redis__Configuration=redis.internal:6379,password=<secret>,ssl=false
+CryptoApiRequestPathCaching__Redis__InstanceName=pkcs11wrapper:cryptoapi:
 ```
 
 Important:
@@ -243,6 +248,8 @@ Important:
 - `ModulePath` must be the path the process/container can actually open
 - `UserPin` is deployment secret material; do not hard-code it in checked-in config
 - `AutoInitialize=true` is fine for first-run convenience; the schema creation path is designed to be idempotent
+- Redis acceleration is optional and should be treated as a performance layer only; the relational shared persistence backend remains authoritative
+- if Redis is unavailable, the request path falls back to the relational/shared-store behavior rather than rejecting healthy traffic
 
 ## Scaling expectations for the stateless Crypto API service
 
@@ -255,6 +262,7 @@ Adding more API instances helps with:
 - HTTP connection handling
 - request parsing/serialization
 - concurrent authentication and authorization work
+- sharing warm auth/authz state across nodes when the optional Redis accelerator is enabled
 - reducing the blast radius of a single process crash or restart
 - rolling upgrades behind a gateway/load balancer
 

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -73,10 +73,12 @@ Steady-state request execution is now intentionally **two-tiered**:
 
 - the source of truth for auth, alias, and policy state remains the shared persistence store
 - each API node keeps a small bounded in-memory cache for successful auth and authorization decisions
+- operators can optionally add Redis as a **shared hot-path accelerator** for auth revision lookups, successful auth/authz cache reuse across nodes, and fleet-wide `last_used_at_utc` write throttling
 - cache entries are keyed by a lightweight shared-state auth revision so admin changes still invalidate warm entries across nodes without forcing full snapshot reloads on every request
 - `last_used_at_utc` updates are throttled to a short interval per key instead of writing synchronously on every successful request
 
 This keeps the instance stateless in the deployment sense while removing avoidable per-request PBKDF2, full-snapshot, and shared-store write overhead from the hot path.
+Redis does **not** become a second control plane; if Redis is unavailable or cold, the host falls back to the relational/shared store path.
 
 ## Shared persistence approach
 
@@ -142,6 +144,16 @@ Current settings live under three sections:
     "Provider": "Sqlite",
     "ConnectionString": "Data Source=/srv/pkcs11wrapper-cryptoapi/shared-state.db",
     "AutoInitialize": true
+  },
+  "CryptoApiRequestPathCaching": {
+    "Redis": {
+      "Enabled": true,
+      "Configuration": "redis.internal:6379,password=change-me,ssl=false",
+      "InstanceName": "pkcs11wrapper:cryptoapi:",
+      "ConnectTimeoutMilliseconds": 5000,
+      "OperationTimeoutMilliseconds": 1000,
+      "AuthStateRevisionTtlSeconds": 30
+    }
   }
 }
 ```
@@ -169,6 +181,12 @@ Notes:
 - `CryptoApiSharedPersistence:AutoInitialize=true` creates the schema on startup/first use.
 - With `Provider=Sqlite`, the connection string is a SQLite file path such as `Data Source=/srv/pkcs11wrapper-cryptoapi/shared-state.db`.
 - With `Provider=Postgres`, use a standard Npgsql/PostgreSQL connection string and prefer a dedicated database/role for the Crypto API control plane.
+- `CryptoApiRequestPathCaching:Redis:Enabled=true` turns on the optional Redis-backed hot-path accelerator.
+- `CryptoApiRequestPathCaching:Redis:Configuration` is a standard StackExchange.Redis configuration string.
+- `CryptoApiRequestPathCaching:Redis:InstanceName` prefixes cache/lease keys so multiple environments can share one Redis fleet safely.
+- `CryptoApiRequestPathCaching:Redis:AuthStateRevisionTtlSeconds` bounds how long the shared auth-revision hint lives in Redis before the service refreshes it from the relational source of truth.
+- When Redis acceleration is enabled, warm instances can reuse successful auth/authz decisions across the fleet and coordinate `last_used_at_utc` throttling, but correctness still comes from the shared persistence store plus the auth-state revision.
+- Repo-managed client/key/alias/policy/binding writes refresh the shared auth-state revision in Redis immediately after commit. If some external actor changes the database behind the repo's back, Redis does not become authoritative; the revision hint simply ages out and is re-read from the source of truth on the configured TTL.
 - `CryptoApiRateLimiting` adds built-in limits for `/api/v1/auth/self` and the customer-facing `/api/v1/operations/*` POST routes.
 - The first slice is intentionally **instance-local**, not shared across the fleet. A caller can consume up to the configured budget on each Crypto API instance behind the load balancer.
 - Partitioning is keyed by the presented `X-Api-Key-Id` header when present, with remote-IP fallback when no key id is available.

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyOperationAuthorizationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyOperationAuthorizationService.cs
@@ -8,17 +8,20 @@ namespace Pkcs11Wrapper.CryptoApi.Access;
 public sealed class CryptoApiKeyOperationAuthorizationService
 {
     private readonly ICryptoApiSharedStateStore _sharedStateStore;
+    private readonly ICryptoApiDistributedHotPathCache _distributedHotPathCache;
     private readonly TimeProvider _timeProvider;
     private readonly CryptoApiClientSecretHasher _secretHasher;
     private readonly CryptoApiRequestPathCache _requestPathCache;
 
     public CryptoApiKeyOperationAuthorizationService(
         ICryptoApiSharedStateStore sharedStateStore,
+        ICryptoApiDistributedHotPathCache distributedHotPathCache,
         TimeProvider timeProvider,
         CryptoApiClientSecretHasher? secretHasher = null,
         CryptoApiRequestPathCache? requestPathCache = null)
     {
         _sharedStateStore = sharedStateStore;
+        _distributedHotPathCache = distributedHotPathCache;
         _timeProvider = timeProvider;
         _secretHasher = secretHasher ?? new CryptoApiClientSecretHasher();
         _requestPathCache = requestPathCache ?? new CryptoApiRequestPathCache(timeProvider);
@@ -57,16 +60,31 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         }
         else
         {
-            CryptoApiClientAuthenticationState? authenticationState = await _sharedStateStore.GetClientAuthenticationStateAsync(normalizedKeyIdentifier, cancellationToken);
-            AuthenticatedClientAuthenticationResult authentication = AuthenticateClient(authenticationState, normalizedSecret, now);
-            if (!authentication.Succeeded || authentication.Template is null)
+            CryptoApiAuthenticatedClient? distributedClient = await _distributedHotPathCache.GetAuthenticatedClientAsync(
+                authStateRevision,
+                normalizedKeyIdentifier,
+                secretFingerprint,
+                now,
+                cancellationToken);
+            if (distributedClient is not null)
             {
-                return AuthenticationFailed(authentication.FailureReason ?? "The provided API credentials were rejected.");
+                authenticatedClient = distributedClient;
+                _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
             }
+            else
+            {
+                CryptoApiClientAuthenticationState? authenticationState = await _sharedStateStore.GetClientAuthenticationStateAsync(normalizedKeyIdentifier, cancellationToken);
+                AuthenticatedClientAuthenticationResult authentication = AuthenticateClient(authenticationState, normalizedSecret, now);
+                if (!authentication.Succeeded || authentication.Template is null)
+                {
+                    return AuthenticationFailed(authentication.FailureReason ?? "The provided API credentials were rejected.");
+                }
 
-            authenticatedClient = authentication.Template.Client;
-            await RefreshLastUsedIfNeededAsync(authStateRevision, authentication.Template.Key, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
-            _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
+                authenticatedClient = authentication.Template.Client;
+                await RefreshLastUsedIfNeededAsync(authStateRevision, authentication.Template.Key, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+                _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
+                await _distributedHotPathCache.SetAuthenticatedClientAsync(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, cancellationToken);
+            }
         }
 
         await RefreshLastUsedIfNeededAsync(authStateRevision, authenticatedClient.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
@@ -80,6 +98,24 @@ public sealed class CryptoApiKeyOperationAuthorizationService
             Authorization: cachedAuthorization);
         }
 
+        CryptoApiAuthorizedKeyOperation? distributedAuthorization = await _distributedHotPathCache.GetAuthorizedOperationAsync(
+            authStateRevision,
+            authenticatedClient.ClientId,
+            normalizedAliasName,
+            normalizedOperation,
+            authenticatedClient,
+            now,
+            cancellationToken);
+        if (distributedAuthorization is not null)
+        {
+            _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, distributedAuthorization);
+            return new CryptoApiRequestAuthorizationResult(
+                Succeeded: true,
+                FailureStatusCode: null,
+                FailureReason: null,
+                Authorization: distributedAuthorization);
+        }
+
         CryptoApiKeyAuthorizationState authorizationState = await _sharedStateStore.GetKeyAuthorizationStateAsync(authenticatedClient.ClientId, normalizedAliasName, cancellationToken);
         CryptoApiKeyOperationAuthorizationResult authorization = Authorize(authorizationState, authenticatedClient, normalizedOperation);
         if (!authorization.Succeeded || authorization.Authorization is null)
@@ -88,6 +124,7 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         }
 
         _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, authorization.Authorization);
+        await _distributedHotPathCache.SetAuthorizedOperationAsync(authStateRevision, authenticatedClient.ClientId, authorization.Authorization, cancellationToken);
         return new CryptoApiRequestAuthorizationResult(
             Succeeded: true,
             FailureStatusCode: null,
@@ -121,11 +158,29 @@ public sealed class CryptoApiKeyOperationAuthorizationService
             Authorization: cachedAuthorization);
         }
 
+        CryptoApiAuthorizedKeyOperation? distributedAuthorization = await _distributedHotPathCache.GetAuthorizedOperationAsync(
+            authStateRevision,
+            authenticatedClient.ClientId,
+            normalizedAliasName,
+            normalizedOperation,
+            authenticatedClient,
+            now,
+            cancellationToken);
+        if (distributedAuthorization is not null)
+        {
+            _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, distributedAuthorization);
+            return new CryptoApiKeyOperationAuthorizationResult(
+                Succeeded: true,
+                FailureReason: null,
+                Authorization: distributedAuthorization);
+        }
+
         CryptoApiKeyAuthorizationState authorizationState = await _sharedStateStore.GetKeyAuthorizationStateAsync(authenticatedClient.ClientId, normalizedAliasName, cancellationToken);
         CryptoApiKeyOperationAuthorizationResult authorization = Authorize(authorizationState, authenticatedClient, normalizedOperation);
         if (authorization.Succeeded && authorization.Authorization is not null)
         {
             _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, authorization.Authorization);
+            await _distributedHotPathCache.SetAuthorizedOperationAsync(authStateRevision, authenticatedClient.ClientId, authorization.Authorization, cancellationToken);
         }
 
         return authorization;
@@ -215,6 +270,16 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         if (!_requestPathCache.ShouldRefreshLastUsed(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now))
         {
             return;
+        }
+
+        if (_distributedHotPathCache.Enabled)
+        {
+            bool? leaseAcquired = await _distributedHotPathCache.TryAcquireLastUsedRefreshLeaseAsync(clientKeyId, now, _requestPathCache.LastUsedWriteInterval, cancellationToken);
+            if (leaseAcquired is false)
+            {
+                _requestPathCache.RecordLastUsedRefresh(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
+                return;
+            }
         }
 
         _ = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, _requestPathCache.LastUsedWriteInterval, cancellationToken);

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/ICryptoApiDistributedHotPathCache.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/ICryptoApiDistributedHotPathCache.cs
@@ -1,0 +1,48 @@
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Clients;
+
+namespace Pkcs11Wrapper.CryptoApi.Caching;
+
+public interface ICryptoApiDistributedHotPathCache
+{
+    bool Enabled { get; }
+
+    Task<long?> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default);
+
+    Task SetAuthStateRevisionAsync(long authStateRevision, CancellationToken cancellationToken = default);
+
+    Task<CryptoApiAuthenticatedClient?> GetAuthenticatedClientAsync(
+        long authStateRevision,
+        string keyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+
+    Task SetAuthenticatedClientAsync(
+        long authStateRevision,
+        string keyIdentifier,
+        string secretFingerprint,
+        CryptoApiAuthenticatedClient authenticatedClient,
+        CancellationToken cancellationToken = default);
+
+    Task<CryptoApiAuthorizedKeyOperation?> GetAuthorizedOperationAsync(
+        long authStateRevision,
+        Guid clientId,
+        string aliasName,
+        string operation,
+        CryptoApiAuthenticatedClient client,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default);
+
+    Task SetAuthorizedOperationAsync(
+        long authStateRevision,
+        Guid clientId,
+        CryptoApiAuthorizedKeyOperation authorization,
+        CancellationToken cancellationToken = default);
+
+    Task<bool?> TryAcquireLastUsedRefreshLeaseAsync(
+        Guid clientKeyId,
+        DateTimeOffset now,
+        TimeSpan minimumInterval,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/NoOpCryptoApiDistributedHotPathCache.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/NoOpCryptoApiDistributedHotPathCache.cs
@@ -1,0 +1,55 @@
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Clients;
+
+namespace Pkcs11Wrapper.CryptoApi.Caching;
+
+public sealed class NoOpCryptoApiDistributedHotPathCache : ICryptoApiDistributedHotPathCache
+{
+    public bool Enabled => false;
+
+    public Task<long?> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<long?>(null);
+
+    public Task SetAuthStateRevisionAsync(long authStateRevision, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<CryptoApiAuthenticatedClient?> GetAuthenticatedClientAsync(
+        long authStateRevision,
+        string keyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<CryptoApiAuthenticatedClient?>(null);
+
+    public Task SetAuthenticatedClientAsync(
+        long authStateRevision,
+        string keyIdentifier,
+        string secretFingerprint,
+        CryptoApiAuthenticatedClient authenticatedClient,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<CryptoApiAuthorizedKeyOperation?> GetAuthorizedOperationAsync(
+        long authStateRevision,
+        Guid clientId,
+        string aliasName,
+        string operation,
+        CryptoApiAuthenticatedClient client,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<CryptoApiAuthorizedKeyOperation?>(null);
+
+    public Task SetAuthorizedOperationAsync(
+        long authStateRevision,
+        Guid clientId,
+        CryptoApiAuthorizedKeyOperation authorization,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<bool?> TryAcquireLastUsedRefreshLeaseAsync(
+        Guid clientKeyId,
+        DateTimeOffset now,
+        TimeSpan minimumInterval,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<bool?>(null);
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/RedisCryptoApiDistributedHotPathCache.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/RedisCryptoApiDistributedHotPathCache.cs
@@ -1,0 +1,359 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+using StackExchange.Redis;
+
+namespace Pkcs11Wrapper.CryptoApi.Caching;
+
+public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistributedHotPathCache, IAsyncDisposable
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<RedisCryptoApiDistributedHotPathCache> _logger;
+    private readonly CryptoApiRequestPathCachingOptions _options;
+    private readonly CryptoApiRequestPathRedisOptions _redisOptions;
+    private readonly SemaphoreSlim _connectionGate = new(1, 1);
+
+    private IConnectionMultiplexer? _connection;
+    private DateTimeOffset _nextConnectAttemptUtc;
+
+    public RedisCryptoApiDistributedHotPathCache(
+        IOptions<CryptoApiRequestPathCachingOptions> options,
+        TimeProvider timeProvider,
+        ILogger<RedisCryptoApiDistributedHotPathCache> logger)
+    {
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _options = options.Value;
+        _redisOptions = _options.Redis ?? new CryptoApiRequestPathRedisOptions();
+    }
+
+    public bool Enabled
+        => _redisOptions.Enabled && !string.IsNullOrWhiteSpace(_redisOptions.Configuration);
+
+    public async Task<long?> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+    {
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            RedisValue value = await database.StringGetAsync(GetAuthStateRevisionKey()).WaitAsync(cancellationToken);
+            string? text = value.IsNullOrEmpty ? null : value.ToString();
+            return string.IsNullOrWhiteSpace(text) || !long.TryParse(text, out long parsed)
+                ? null
+                : parsed;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "read auth-state revision");
+            return null;
+        }
+    }
+
+    public async Task SetAuthStateRevisionAsync(long authStateRevision, CancellationToken cancellationToken = default)
+    {
+        if (authStateRevision <= 0)
+        {
+            return;
+        }
+
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = await database.StringSetAsync(
+                    GetAuthStateRevisionKey(),
+                    authStateRevision.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    _redisOptions.AuthStateRevisionTtl)
+                .WaitAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "write auth-state revision");
+        }
+    }
+
+    public async Task<CryptoApiAuthenticatedClient?> GetAuthenticatedClientAsync(
+        long authStateRevision,
+        string keyIdentifier,
+        string secretFingerprint,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            RedisValue value = await database.StringGetAsync(GetAuthenticationKey(authStateRevision, keyIdentifier, secretFingerprint)).WaitAsync(cancellationToken);
+            if (value.IsNullOrEmpty)
+            {
+                return null;
+            }
+
+            CryptoApiAuthenticatedClient? cached = JsonSerializer.Deserialize<CryptoApiAuthenticatedClient>(value.ToString()!, SerializerOptions);
+            if (cached is null)
+            {
+                return null;
+            }
+
+            if (cached.ExpiresAtUtc is DateTimeOffset expiresAtUtc && expiresAtUtc <= now)
+            {
+                return null;
+            }
+
+            return cached with { AuthenticatedAtUtc = now };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "read distributed authenticated-client entry");
+            return null;
+        }
+    }
+
+    public async Task SetAuthenticatedClientAsync(
+        long authStateRevision,
+        string keyIdentifier,
+        string secretFingerprint,
+        CryptoApiAuthenticatedClient authenticatedClient,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(authenticatedClient);
+
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = await database.StringSetAsync(
+                    GetAuthenticationKey(authStateRevision, keyIdentifier, secretFingerprint),
+                    JsonSerializer.Serialize(authenticatedClient, SerializerOptions),
+                    _options.EntryTtl)
+                .WaitAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "write distributed authenticated-client entry");
+        }
+    }
+
+    public async Task<CryptoApiAuthorizedKeyOperation?> GetAuthorizedOperationAsync(
+        long authStateRevision,
+        Guid clientId,
+        string aliasName,
+        string operation,
+        CryptoApiAuthenticatedClient client,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            RedisValue value = await database.StringGetAsync(GetAuthorizationKey(authStateRevision, clientId, aliasName, operation)).WaitAsync(cancellationToken);
+            if (value.IsNullOrEmpty)
+            {
+                return null;
+            }
+
+            AuthorizationCachePayload? payload = JsonSerializer.Deserialize<AuthorizationCachePayload>(value.ToString()!, SerializerOptions);
+            if (payload is null)
+            {
+                return null;
+            }
+
+            return new CryptoApiAuthorizedKeyOperation(
+                Client: client,
+                Operation: payload.Operation,
+                AliasId: payload.AliasId,
+                AliasName: payload.AliasName,
+                ResolvedRoute: payload.ResolvedRoute,
+                MatchedPolicies: payload.MatchedPolicies,
+                AuthorizedAtUtc: now);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "read distributed authorization entry");
+            return null;
+        }
+    }
+
+    public async Task SetAuthorizedOperationAsync(
+        long authStateRevision,
+        Guid clientId,
+        CryptoApiAuthorizedKeyOperation authorization,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return;
+        }
+
+        AuthorizationCachePayload payload = new(
+            authorization.Operation,
+            authorization.AliasId,
+            authorization.AliasName,
+            authorization.ResolvedRoute,
+            authorization.MatchedPolicies);
+
+        try
+        {
+            _ = await database.StringSetAsync(
+                    GetAuthorizationKey(authStateRevision, clientId, authorization.AliasName, authorization.Operation),
+                    JsonSerializer.Serialize(payload, SerializerOptions),
+                    _options.EntryTtl)
+                .WaitAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "write distributed authorization entry");
+        }
+    }
+
+    public async Task<bool?> TryAcquireLastUsedRefreshLeaseAsync(
+        Guid clientKeyId,
+        DateTimeOffset now,
+        TimeSpan minimumInterval,
+        CancellationToken cancellationToken = default)
+    {
+        IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
+        if (database is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await database.StringSetAsync(
+                    GetLastUsedLeaseKey(clientKeyId),
+                    now.ToUnixTimeMilliseconds().ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    minimumInterval,
+                    when: When.NotExists)
+                .WaitAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRedisFailure(ex, "acquire last-used refresh lease");
+            return null;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _connectionGate.Dispose();
+
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+
+    private async Task<IDatabase?> TryGetDatabaseAsync(CancellationToken cancellationToken)
+    {
+        if (!Enabled)
+        {
+            return null;
+        }
+
+        IConnectionMultiplexer? connection = _connection;
+        if (connection is not null && connection.IsConnected)
+        {
+            return connection.GetDatabase();
+        }
+
+        await _connectionGate.WaitAsync(cancellationToken);
+        try
+        {
+            connection = _connection;
+            if (connection is not null && connection.IsConnected)
+            {
+                return connection.GetDatabase();
+            }
+
+            DateTimeOffset now = _timeProvider.GetUtcNow();
+            if (_nextConnectAttemptUtc > now)
+            {
+                return null;
+            }
+
+            ConfigurationOptions configuration = ConfigurationOptions.Parse(_redisOptions.Configuration!, true);
+            configuration.AbortOnConnectFail = false;
+            configuration.ConnectTimeout = _redisOptions.ConnectTimeoutMilliseconds;
+            configuration.SyncTimeout = _redisOptions.OperationTimeoutMilliseconds;
+            configuration.AsyncTimeout = _redisOptions.OperationTimeoutMilliseconds;
+            configuration.ClientName ??= "Pkcs11Wrapper.CryptoApi";
+
+            _connection = await ConnectionMultiplexer.ConnectAsync(configuration).WaitAsync(cancellationToken);
+            _nextConnectAttemptUtc = DateTimeOffset.MinValue;
+            return _connection.GetDatabase();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _nextConnectAttemptUtc = _timeProvider.GetUtcNow().AddSeconds(5);
+            LogRedisFailure(ex, "connect to Redis hot-path cache");
+            return null;
+        }
+        finally
+        {
+            _connectionGate.Release();
+        }
+    }
+
+    private void LogRedisFailure(Exception ex, string operation)
+        => _logger.LogDebug(ex, "Crypto API Redis hot-path accelerator could not {Operation}; falling back to source-of-truth/shared-store behavior.", operation);
+
+    private string GetAuthStateRevisionKey()
+        => $"{_redisOptions.InstanceName}auth-revision";
+
+    private string GetAuthenticationKey(long authStateRevision, string keyIdentifier, string secretFingerprint)
+        => $"{_redisOptions.InstanceName}auth:{authStateRevision}:{HashCompositeKey(keyIdentifier, secretFingerprint)}";
+
+    private string GetAuthorizationKey(long authStateRevision, Guid clientId, string aliasName, string operation)
+        => $"{_redisOptions.InstanceName}authorize:{authStateRevision}:{HashCompositeKey(clientId.ToString("N"), aliasName, operation)}";
+
+    private string GetLastUsedLeaseKey(Guid clientKeyId)
+        => $"{_redisOptions.InstanceName}last-used:{clientKeyId:N}";
+
+    private static string HashCompositeKey(params string[] values)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        byte[] data = Encoding.UTF8.GetBytes(string.Join('\n', values));
+        return Convert.ToHexString(sha256.ComputeHash(data));
+    }
+
+    private sealed record AuthorizationCachePayload(
+        string Operation,
+        Guid AliasId,
+        string AliasName,
+        CryptoApiResolvedKeyRoute ResolvedRoute,
+        IReadOnlyList<CryptoApiMatchedPolicy> MatchedPolicies);
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Clients/CryptoApiClientAuthenticationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Clients/CryptoApiClientAuthenticationService.cs
@@ -6,17 +6,20 @@ namespace Pkcs11Wrapper.CryptoApi.Clients;
 public sealed class CryptoApiClientAuthenticationService
 {
     private readonly ICryptoApiSharedStateStore _sharedStateStore;
+    private readonly ICryptoApiDistributedHotPathCache _distributedHotPathCache;
     private readonly CryptoApiClientSecretHasher _secretHasher;
     private readonly TimeProvider _timeProvider;
     private readonly CryptoApiRequestPathCache _requestPathCache;
 
     public CryptoApiClientAuthenticationService(
         ICryptoApiSharedStateStore sharedStateStore,
+        ICryptoApiDistributedHotPathCache distributedHotPathCache,
         CryptoApiClientSecretHasher secretHasher,
         TimeProvider timeProvider,
         CryptoApiRequestPathCache? requestPathCache = null)
     {
         _sharedStateStore = sharedStateStore;
+        _distributedHotPathCache = distributedHotPathCache;
         _secretHasher = secretHasher;
         _timeProvider = timeProvider;
         _requestPathCache = requestPathCache ?? new CryptoApiRequestPathCache(timeProvider);
@@ -47,6 +50,22 @@ public sealed class CryptoApiClientAuthenticationService
                 Succeeded: true,
                 FailureReason: null,
                 Client: cachedClient);
+        }
+
+        CryptoApiAuthenticatedClient? distributedClient = await _distributedHotPathCache.GetAuthenticatedClientAsync(
+            authStateRevision,
+            normalizedKeyIdentifier,
+            secretFingerprint,
+            now,
+            cancellationToken);
+        if (distributedClient is not null)
+        {
+            _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, distributedClient, now);
+            await RefreshLastUsedIfNeededAsync(authStateRevision, distributedClient.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+            return new CryptoApiClientAuthenticationResult(
+                Succeeded: true,
+                FailureReason: null,
+                Client: distributedClient);
         }
 
         CryptoApiClientAuthenticationState? authenticationState = await _sharedStateStore.GetClientAuthenticationStateAsync(normalizedKeyIdentifier, cancellationToken);
@@ -99,6 +118,7 @@ public sealed class CryptoApiClientAuthenticationService
             BoundPolicyIds: authenticationState.BoundPolicyIds);
 
         _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
+        await _distributedHotPathCache.SetAuthenticatedClientAsync(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, cancellationToken);
 
         return new CryptoApiClientAuthenticationResult(
             Succeeded: true,
@@ -132,6 +152,16 @@ public sealed class CryptoApiClientAuthenticationService
         if (!shouldRefresh)
         {
             return;
+        }
+
+        if (_distributedHotPathCache.Enabled)
+        {
+            bool? leaseAcquired = await _distributedHotPathCache.TryAcquireLastUsedRefreshLeaseAsync(clientKeyId, now, minimumInterval, cancellationToken);
+            if (leaseAcquired is false)
+            {
+                _requestPathCache.RecordLastUsedRefresh(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
+                return;
+            }
         }
 
         _ = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, minimumInterval, cancellationToken);

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiRequestPathCachingOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiRequestPathCachingOptions.cs
@@ -4,6 +4,8 @@ public sealed class CryptoApiRequestPathCachingOptions
 {
     public const string SectionName = "CryptoApiRequestPathCaching";
 
+    public CryptoApiRequestPathRedisOptions Redis { get; set; } = new();
+
     public bool Enabled { get; set; } = true;
 
     public int AuthenticationEntryLimit { get; set; } = 512;

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiRequestPathRedisOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Configuration/CryptoApiRequestPathRedisOptions.cs
@@ -1,0 +1,19 @@
+namespace Pkcs11Wrapper.CryptoApi.Configuration;
+
+public sealed class CryptoApiRequestPathRedisOptions
+{
+    public bool Enabled { get; set; }
+
+    public string? Configuration { get; set; }
+
+    public string InstanceName { get; set; } = "pkcs11wrapper:cryptoapi:";
+
+    public int ConnectTimeoutMilliseconds { get; set; } = 5000;
+
+    public int OperationTimeoutMilliseconds { get; set; } = 1000;
+
+    public int AuthStateRevisionTtlSeconds { get; set; } = 30;
+
+    internal TimeSpan AuthStateRevisionTtl
+        => TimeSpan.FromSeconds(AuthStateRevisionTtlSeconds);
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Pkcs11Wrapper.CryptoApi.Shared.csproj
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Pkcs11Wrapper.CryptoApi.Shared.csproj
@@ -3,8 +3,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Npgsql" Version="10.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/CryptoApiHotPathSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/CryptoApiHotPathSharedStateStore.cs
@@ -1,0 +1,93 @@
+using Pkcs11Wrapper.CryptoApi.Caching;
+
+namespace Pkcs11Wrapper.CryptoApi.SharedState;
+
+public sealed class CryptoApiHotPathSharedStateStore(
+    ICryptoApiAuthoritativeSharedStateStore inner,
+    ICryptoApiDistributedHotPathCache distributedHotPathCache) : ICryptoApiSharedStateStore
+{
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+        => inner.InitializeAsync(cancellationToken);
+
+    public Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+        => inner.GetStatusAsync(cancellationToken);
+
+    public async Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+    {
+        long? cachedRevision = await distributedHotPathCache.GetAuthStateRevisionAsync(cancellationToken);
+        if (cachedRevision is > 0)
+        {
+            return cachedRevision.Value;
+        }
+
+        long authStateRevision = await inner.GetAuthStateRevisionAsync(cancellationToken);
+        if (authStateRevision > 0)
+        {
+            await distributedHotPathCache.SetAuthStateRevisionAsync(authStateRevision, cancellationToken);
+        }
+
+        return authStateRevision;
+    }
+
+    public Task<CryptoApiClientAuthenticationState?> GetClientAuthenticationStateAsync(string keyIdentifier, CancellationToken cancellationToken = default)
+        => inner.GetClientAuthenticationStateAsync(keyIdentifier, cancellationToken);
+
+    public Task<CryptoApiKeyAuthorizationState> GetKeyAuthorizationStateAsync(Guid clientId, string aliasName, CancellationToken cancellationToken = default)
+        => inner.GetKeyAuthorizationStateAsync(clientId, aliasName, cancellationToken);
+
+    public async Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default)
+    {
+        await inner.UpsertClientAsync(client, cancellationToken);
+        await RefreshAuthStateRevisionAsync(cancellationToken);
+    }
+
+    public async Task UpsertClientKeyAsync(CryptoApiClientKeyRecord clientKey, CancellationToken cancellationToken = default)
+    {
+        await inner.UpsertClientKeyAsync(clientKey, cancellationToken);
+        await RefreshAuthStateRevisionAsync(cancellationToken);
+    }
+
+    public Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default)
+        => inner.TryTouchClientKeyLastUsedAsync(clientKeyId, lastUsedAtUtc, minimumInterval, cancellationToken);
+
+    public async Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default)
+    {
+        await inner.UpsertKeyAliasAsync(keyAlias, cancellationToken);
+        await RefreshAuthStateRevisionAsync(cancellationToken);
+    }
+
+    public async Task UpsertPolicyAsync(CryptoApiPolicyRecord policy, CancellationToken cancellationToken = default)
+    {
+        await inner.UpsertPolicyAsync(policy, cancellationToken);
+        await RefreshAuthStateRevisionAsync(cancellationToken);
+    }
+
+    public async Task ReplaceClientPolicyBindingsAsync(Guid clientId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+    {
+        await inner.ReplaceClientPolicyBindingsAsync(clientId, policyIds, cancellationToken);
+        await RefreshAuthStateRevisionAsync(cancellationToken);
+    }
+
+    public async Task ReplaceKeyAliasPolicyBindingsAsync(Guid aliasId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+    {
+        await inner.ReplaceKeyAliasPolicyBindingsAsync(aliasId, policyIds, cancellationToken);
+        await RefreshAuthStateRevisionAsync(cancellationToken);
+    }
+
+    public Task<CryptoApiSharedStateSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+        => inner.GetSnapshotAsync(cancellationToken);
+
+    private async Task RefreshAuthStateRevisionAsync(CancellationToken cancellationToken)
+    {
+        if (!distributedHotPathCache.Enabled)
+        {
+            return;
+        }
+
+        long authStateRevision = await inner.GetAuthStateRevisionAsync(cancellationToken);
+        if (authStateRevision > 0)
+        {
+            await distributedHotPathCache.SetAuthStateRevisionAsync(authStateRevision, cancellationToken);
+        }
+    }
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/CryptoApiSharedStateServiceCollectionExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/CryptoApiSharedStateServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 
 namespace Pkcs11Wrapper.CryptoApi.SharedState;
@@ -12,7 +13,7 @@ public static class CryptoApiSharedStateServiceCollectionExtensions
 
         services.AddSingleton<SqliteCryptoApiSharedStateStore>();
         services.AddSingleton<PostgresCryptoApiSharedStateStore>();
-        services.AddSingleton<ICryptoApiSharedStateStore>(static serviceProvider =>
+        services.AddSingleton<ICryptoApiAuthoritativeSharedStateStore>(static serviceProvider =>
         {
             CryptoApiSharedPersistenceOptions options = serviceProvider.GetRequiredService<IOptions<CryptoApiSharedPersistenceOptions>>().Value;
             return CryptoApiSharedPersistenceDefaults.NormalizeProvider(options.Provider) switch
@@ -22,6 +23,10 @@ public static class CryptoApiSharedStateServiceCollectionExtensions
                 _ => throw new InvalidOperationException($"Unsupported Crypto API shared persistence provider '{options.Provider}'.")
             };
         });
+        services.AddSingleton<ICryptoApiSharedStateStore>(static serviceProvider =>
+            new CryptoApiHotPathSharedStateStore(
+                serviceProvider.GetRequiredService<ICryptoApiAuthoritativeSharedStateStore>(),
+                serviceProvider.GetRequiredService<ICryptoApiDistributedHotPathCache>()));
 
         return services;
     }

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/ICryptoApiAuthoritativeSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/ICryptoApiAuthoritativeSharedStateStore.cs
@@ -1,0 +1,5 @@
+namespace Pkcs11Wrapper.CryptoApi.SharedState;
+
+public interface ICryptoApiAuthoritativeSharedStateStore : ICryptoApiSharedStateStore
+{
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
@@ -4,7 +4,7 @@ using Pkcs11Wrapper.CryptoApi.Configuration;
 
 namespace Pkcs11Wrapper.CryptoApi.SharedState;
 
-public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiSharedStateStore
+public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiAuthoritativeSharedStateStore
 {
     private const string AuthStateRevisionMetadataKey = "auth_state_revision";
     private const string SchemaVersionMetadataKey = "schema_version";

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/SqliteCryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/SqliteCryptoApiSharedStateStore.cs
@@ -5,7 +5,7 @@ using Pkcs11Wrapper.CryptoApi.Configuration;
 
 namespace Pkcs11Wrapper.CryptoApi.SharedState;
 
-public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiSharedStateStore
+public sealed class SqliteCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiAuthoritativeSharedStateStore
 {
     private const string AuthStateRevisionMetadataKey = "auth_state_revision";
 

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -47,6 +47,15 @@ builder.Services.AddOptions<CryptoApiRequestPathCachingOptions>()
             && options.EntryTtlSeconds > 0
             && options.LastUsedWriteIntervalSeconds > 0,
         "Crypto API request-path caching must define positive cache limits, TTL, and last-used write interval values.")
+    .Validate(
+        static options => !options.Redis.Enabled || !string.IsNullOrWhiteSpace(options.Redis.Configuration),
+        "Crypto API Redis hot-path acceleration requires CryptoApiRequestPathCaching:Redis:Configuration when enabled.")
+    .Validate(
+        static options => !options.Redis.Enabled
+            || (options.Redis.ConnectTimeoutMilliseconds > 0
+                && options.Redis.OperationTimeoutMilliseconds > 0
+                && options.Redis.AuthStateRevisionTtlSeconds > 0),
+        "Crypto API Redis hot-path acceleration must define positive Redis timeout and auth-state revision TTL values.")
     .ValidateOnStart();
 
 builder.Services.AddOptions<CryptoApiRateLimitingOptions>()
@@ -75,6 +84,16 @@ builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton(sp => new CryptoApiRequestPathCache(
     sp.GetRequiredService<TimeProvider>(),
     sp.GetRequiredService<IOptions<CryptoApiRequestPathCachingOptions>>().Value));
+builder.Services.AddSingleton<ICryptoApiDistributedHotPathCache>(sp =>
+{
+    CryptoApiRequestPathCachingOptions options = sp.GetRequiredService<IOptions<CryptoApiRequestPathCachingOptions>>().Value;
+    return options.Redis.Enabled && !string.IsNullOrWhiteSpace(options.Redis.Configuration)
+        ? new RedisCryptoApiDistributedHotPathCache(
+            sp.GetRequiredService<IOptions<CryptoApiRequestPathCachingOptions>>(),
+            sp.GetRequiredService<TimeProvider>(),
+            sp.GetRequiredService<ILogger<RedisCryptoApiDistributedHotPathCache>>())
+        : new NoOpCryptoApiDistributedHotPathCache();
+});
 builder.Services.AddSingleton<CryptoApiRuntimeDescriptorProvider>();
 builder.Services.AddSingleton<CryptoApiPkcs11Runtime>();
 builder.Services.AddSingleton<CryptoApiClientSecretGenerator>();

--- a/src/Pkcs11Wrapper.CryptoApi/appsettings.json
+++ b/src/Pkcs11Wrapper.CryptoApi/appsettings.json
@@ -24,7 +24,15 @@
     "AuthenticationEntryLimit": 512,
     "AuthorizationEntryLimit": 2048,
     "EntryTtlSeconds": 30,
-    "LastUsedWriteIntervalSeconds": 30
+    "LastUsedWriteIntervalSeconds": 30,
+    "Redis": {
+      "Enabled": false,
+      "Configuration": "",
+      "InstanceName": "pkcs11wrapper:cryptoapi:",
+      "ConnectTimeoutMilliseconds": 5000,
+      "OperationTimeoutMilliseconds": 1000,
+      "AuthStateRevisionTtlSeconds": 30
+    }
   },
   "CryptoApiRateLimiting": {
     "Enabled": true,

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiClientManagementServiceTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiClientManagementServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.SharedState;
@@ -114,11 +115,12 @@ public sealed class CryptoApiClientManagementServiceTests
         };
 
         ICryptoApiSharedStateStore store = new SqliteCryptoApiSharedStateStore(Options.Create(options));
+        ICryptoApiDistributedHotPathCache distributedHotPathCache = new NoOpCryptoApiDistributedHotPathCache();
         CryptoApiClientSecretGenerator generator = new();
         CryptoApiClientSecretHasher hasher = new();
         TimeProvider timeProvider = TimeProvider.System;
         CryptoApiClientManagementService management = new(store, generator, hasher, timeProvider);
-        CryptoApiClientAuthenticationService authentication = new(store, hasher, timeProvider);
+        CryptoApiClientAuthenticationService authentication = new(store, distributedHotPathCache, hasher, timeProvider);
         return (store, management, authentication);
     }
 

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiDistributedHotPathCacheTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiDistributedHotPathCacheTests.cs
@@ -1,0 +1,393 @@
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Caching;
+using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.SharedState;
+
+namespace Pkcs11Wrapper.CryptoApi.Tests;
+
+public sealed class CryptoApiDistributedHotPathCacheTests
+{
+    [Fact]
+    public async Task DistributedHotCacheSharesWarmAuthorizationAcrossInstances()
+    {
+        string databasePath = CreateDatabasePath();
+        try
+        {
+            FakeDistributedHotPathCache distributedCache = new();
+            ServiceSet instanceA = CreateServiceSet(databasePath, distributedCache, DateTimeOffset.Parse("2026-04-04T12:00:00Z"));
+            ServiceSet instanceB = CreateServiceSet(databasePath, distributedCache, DateTimeOffset.Parse("2026-04-04T12:00:05Z"));
+
+            SeededAccess access = await SeedAuthorizedAccessAsync(instanceA);
+            instanceA.Store.ResetCounters();
+            instanceB.Store.ResetCounters();
+
+            CryptoApiRequestAuthorizationResult first = await instanceA.Authorization.AuthorizeRequestAsync(
+                access.Key.KeyIdentifier,
+                access.Key.Secret,
+                access.Alias.AliasName,
+                "sign");
+
+            Assert.True(first.Succeeded, first.FailureReason);
+            Assert.Equal(1, instanceA.Store.AuthenticationStateReads);
+            Assert.Equal(1, instanceA.Store.AuthorizationStateReads);
+            Assert.Equal(1, instanceA.Store.LastUsedTouches);
+            Assert.Equal(0, instanceA.Store.AuthStateRevisionReads);
+
+            CryptoApiRequestAuthorizationResult second = await instanceB.Authorization.AuthorizeRequestAsync(
+                access.Key.KeyIdentifier,
+                access.Key.Secret,
+                access.Alias.AliasName,
+                "sign");
+
+            Assert.True(second.Succeeded, second.FailureReason);
+            Assert.Equal(0, instanceB.Store.AuthStateRevisionReads);
+            Assert.Equal(0, instanceB.Store.AuthenticationStateReads);
+            Assert.Equal(0, instanceB.Store.AuthorizationStateReads);
+            Assert.Equal(0, instanceB.Store.LastUsedTouches);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task DistributedHotCacheInvalidatesAcrossInstancesWhenKeyIsRevoked()
+    {
+        string databasePath = CreateDatabasePath();
+        try
+        {
+            FakeDistributedHotPathCache distributedCache = new();
+            ServiceSet instanceA = CreateServiceSet(databasePath, distributedCache, DateTimeOffset.Parse("2026-04-04T12:00:00Z"));
+            ServiceSet instanceB = CreateServiceSet(databasePath, distributedCache, DateTimeOffset.Parse("2026-04-04T12:00:05Z"));
+
+            SeededAccess access = await SeedAuthorizedAccessAsync(instanceA);
+            CryptoApiRequestAuthorizationResult warm = await instanceA.Authorization.AuthorizeRequestAsync(
+                access.Key.KeyIdentifier,
+                access.Key.Secret,
+                access.Alias.AliasName,
+                "sign");
+            Assert.True(warm.Succeeded, warm.FailureReason);
+
+            instanceB.Store.ResetCounters();
+            await instanceA.ClientManagement.RevokeClientKeyAsync(access.Key.ClientKeyId, "rotation");
+
+            CryptoApiRequestAuthorizationResult afterRevocation = await instanceB.Authorization.AuthorizeRequestAsync(
+                access.Key.KeyIdentifier,
+                access.Key.Secret,
+                access.Alias.AliasName,
+                "sign");
+
+            Assert.False(afterRevocation.Succeeded);
+            Assert.Equal(401, afterRevocation.FailureStatusCode);
+            Assert.Equal("API key has been revoked.", afterRevocation.FailureReason);
+            Assert.Equal(0, instanceB.Store.AuthStateRevisionReads);
+            Assert.Equal(1, instanceB.Store.AuthenticationStateReads);
+            Assert.Equal(0, instanceB.Store.AuthorizationStateReads);
+            Assert.Equal(0, instanceB.Store.LastUsedTouches);
+        }
+        finally
+        {
+            DeleteDatabaseArtifacts(databasePath);
+        }
+    }
+
+    private static ServiceSet CreateServiceSet(
+        string databasePath,
+        ICryptoApiDistributedHotPathCache distributedCache,
+        DateTimeOffset utcNow)
+    {
+        CryptoApiSharedPersistenceOptions sharedStateOptions = new()
+        {
+            Provider = CryptoApiSharedPersistenceDefaults.SqliteProvider,
+            ConnectionString = $"Data Source={databasePath}",
+            AutoInitialize = true
+        };
+
+        CountingAuthoritativeSharedStateStore authoritativeStore = new(new SqliteCryptoApiSharedStateStore(Options.Create(sharedStateOptions)));
+        ICryptoApiSharedStateStore sharedStateStore = new CryptoApiHotPathSharedStateStore(authoritativeStore, distributedCache);
+        MutableTimeProvider timeProvider = new(utcNow);
+        CryptoApiRequestPathCache requestPathCache = new(timeProvider, new CryptoApiRequestPathCachingOptions
+        {
+            Enabled = true,
+            EntryTtlSeconds = 300,
+            LastUsedWriteIntervalSeconds = 30
+        });
+        CryptoApiClientSecretGenerator generator = new();
+        CryptoApiClientSecretHasher hasher = new();
+
+        return new ServiceSet(
+            Store: authoritativeStore,
+            ClientManagement: new CryptoApiClientManagementService(sharedStateStore, generator, hasher, timeProvider),
+            AccessManagement: new CryptoApiKeyAccessManagementService(sharedStateStore, timeProvider),
+            Authorization: new CryptoApiKeyOperationAuthorizationService(sharedStateStore, distributedCache, timeProvider, hasher, requestPathCache),
+            Authentication: new CryptoApiClientAuthenticationService(sharedStateStore, distributedCache, hasher, timeProvider, requestPathCache));
+    }
+
+    private static async Task<SeededAccess> SeedAuthorizedAccessAsync(ServiceSet services)
+    {
+        CryptoApiManagedClient client = await services.ClientManagement.CreateClientAsync(new CreateCryptoApiClientRequest(
+            ClientName: $"client-{Guid.NewGuid():N}",
+            DisplayName: "Gateway A",
+            ApplicationType: "gateway",
+            Notes: null));
+        CryptoApiCreatedClientKey key = await services.ClientManagement.CreateClientKeyAsync(new CreateCryptoApiClientKeyRequest(client.ClientId, "primary", null));
+        CryptoApiManagedPolicy policy = await services.AccessManagement.CreatePolicyAsync(new CreateCryptoApiPolicyRequest(
+            PolicyName: $"gateway-sign-{Guid.NewGuid():N}",
+            Description: null,
+            AllowedOperations: ["sign"]));
+        CryptoApiManagedKeyAlias alias = await services.AccessManagement.CreateKeyAliasAsync(new CreateCryptoApiKeyAliasRequest(
+            AliasName: "payments-signer",
+            DeviceRoute: "hsm-eu-primary",
+            SlotId: 7,
+            ObjectLabel: "Payments signing key",
+            ObjectIdHex: "A1B2C3D4",
+            Notes: null));
+
+        await services.AccessManagement.ReplaceClientPoliciesAsync(client.ClientId, [policy.PolicyId]);
+        await services.AccessManagement.ReplaceKeyAliasPoliciesAsync(alias.AliasId, [policy.PolicyId]);
+        return new SeededAccess(client, key, alias, policy);
+    }
+
+    private static string CreateDatabasePath()
+        => Path.Combine(Path.GetTempPath(), $"pkcs11wrapper-cryptoapi-redis-hot-path-{Guid.NewGuid():N}.db");
+
+    private static void DeleteDatabaseArtifacts(string databasePath)
+    {
+        string walPath = databasePath + "-wal";
+        string shmPath = databasePath + "-shm";
+
+        if (File.Exists(databasePath)) File.Delete(databasePath);
+        if (File.Exists(walPath)) File.Delete(walPath);
+        if (File.Exists(shmPath)) File.Delete(shmPath);
+    }
+
+    private sealed record ServiceSet(
+        CountingAuthoritativeSharedStateStore Store,
+        CryptoApiClientManagementService ClientManagement,
+        CryptoApiKeyAccessManagementService AccessManagement,
+        CryptoApiKeyOperationAuthorizationService Authorization,
+        CryptoApiClientAuthenticationService Authentication);
+
+    private sealed record SeededAccess(
+        CryptoApiManagedClient Client,
+        CryptoApiCreatedClientKey Key,
+        CryptoApiManagedKeyAlias Alias,
+        CryptoApiManagedPolicy Policy);
+
+    private sealed class CountingAuthoritativeSharedStateStore(SqliteCryptoApiSharedStateStore inner) : ICryptoApiAuthoritativeSharedStateStore
+    {
+        public int AuthStateRevisionReads { get; private set; }
+
+        public int AuthenticationStateReads { get; private set; }
+
+        public int AuthorizationStateReads { get; private set; }
+
+        public int LastUsedTouches { get; private set; }
+
+        public void ResetCounters()
+        {
+            AuthStateRevisionReads = 0;
+            AuthenticationStateReads = 0;
+            AuthorizationStateReads = 0;
+            LastUsedTouches = 0;
+        }
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+            => inner.InitializeAsync(cancellationToken);
+
+        public Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+            => inner.GetStatusAsync(cancellationToken);
+
+        public async Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+        {
+            AuthStateRevisionReads++;
+            return await inner.GetAuthStateRevisionAsync(cancellationToken);
+        }
+
+        public async Task<CryptoApiClientAuthenticationState?> GetClientAuthenticationStateAsync(string keyIdentifier, CancellationToken cancellationToken = default)
+        {
+            AuthenticationStateReads++;
+            return await inner.GetClientAuthenticationStateAsync(keyIdentifier, cancellationToken);
+        }
+
+        public async Task<CryptoApiKeyAuthorizationState> GetKeyAuthorizationStateAsync(Guid clientId, string aliasName, CancellationToken cancellationToken = default)
+        {
+            AuthorizationStateReads++;
+            return await inner.GetKeyAuthorizationStateAsync(clientId, aliasName, cancellationToken);
+        }
+
+        public Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default)
+            => inner.UpsertClientAsync(client, cancellationToken);
+
+        public Task UpsertClientKeyAsync(CryptoApiClientKeyRecord clientKey, CancellationToken cancellationToken = default)
+            => inner.UpsertClientKeyAsync(clientKey, cancellationToken);
+
+        public async Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default)
+        {
+            LastUsedTouches++;
+            return await inner.TryTouchClientKeyLastUsedAsync(clientKeyId, lastUsedAtUtc, minimumInterval, cancellationToken);
+        }
+
+        public Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default)
+            => inner.UpsertKeyAliasAsync(keyAlias, cancellationToken);
+
+        public Task UpsertPolicyAsync(CryptoApiPolicyRecord policy, CancellationToken cancellationToken = default)
+            => inner.UpsertPolicyAsync(policy, cancellationToken);
+
+        public Task ReplaceClientPolicyBindingsAsync(Guid clientId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+            => inner.ReplaceClientPolicyBindingsAsync(clientId, policyIds, cancellationToken);
+
+        public Task ReplaceKeyAliasPolicyBindingsAsync(Guid aliasId, IReadOnlyCollection<Guid> policyIds, CancellationToken cancellationToken = default)
+            => inner.ReplaceKeyAliasPolicyBindingsAsync(aliasId, policyIds, cancellationToken);
+
+        public Task<CryptoApiSharedStateSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+            => inner.GetSnapshotAsync(cancellationToken);
+    }
+
+    private sealed class FakeDistributedHotPathCache : ICryptoApiDistributedHotPathCache
+    {
+        private readonly Dictionary<string, CryptoApiAuthenticatedClient> _authenticationCache = [];
+        private readonly Dictionary<string, CryptoApiAuthorizedKeyOperation> _authorizationCache = [];
+        private readonly Dictionary<Guid, DateTimeOffset> _lastUsedLeases = [];
+        private long? _authStateRevision;
+        private readonly Lock _gate = new();
+
+        public bool Enabled => true;
+
+        public Task<long?> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                return Task.FromResult(_authStateRevision);
+            }
+        }
+
+        public Task SetAuthStateRevisionAsync(long authStateRevision, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                _authStateRevision = authStateRevision;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<CryptoApiAuthenticatedClient?> GetAuthenticatedClientAsync(
+            long authStateRevision,
+            string keyIdentifier,
+            string secretFingerprint,
+            DateTimeOffset now,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string key = $"{authStateRevision}:{keyIdentifier}:{secretFingerprint}";
+            lock (_gate)
+            {
+                if (!_authenticationCache.TryGetValue(key, out CryptoApiAuthenticatedClient? cached))
+                {
+                    return Task.FromResult<CryptoApiAuthenticatedClient?>(null);
+                }
+
+                if (cached.ExpiresAtUtc is DateTimeOffset expiresAtUtc && expiresAtUtc <= now)
+                {
+                    _authenticationCache.Remove(key);
+                    return Task.FromResult<CryptoApiAuthenticatedClient?>(null);
+                }
+
+                return Task.FromResult<CryptoApiAuthenticatedClient?>(cached with { AuthenticatedAtUtc = now });
+            }
+        }
+
+        public Task SetAuthenticatedClientAsync(
+            long authStateRevision,
+            string keyIdentifier,
+            string secretFingerprint,
+            CryptoApiAuthenticatedClient authenticatedClient,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                _authenticationCache[$"{authStateRevision}:{keyIdentifier}:{secretFingerprint}"] = authenticatedClient;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<CryptoApiAuthorizedKeyOperation?> GetAuthorizedOperationAsync(
+            long authStateRevision,
+            Guid clientId,
+            string aliasName,
+            string operation,
+            CryptoApiAuthenticatedClient client,
+            DateTimeOffset now,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string key = $"{authStateRevision}:{clientId:N}:{aliasName}:{operation}";
+            lock (_gate)
+            {
+                if (!_authorizationCache.TryGetValue(key, out CryptoApiAuthorizedKeyOperation? authorization))
+                {
+                    return Task.FromResult<CryptoApiAuthorizedKeyOperation?>(null);
+                }
+
+                return Task.FromResult<CryptoApiAuthorizedKeyOperation?>(authorization with
+                {
+                    Client = client,
+                    AuthorizedAtUtc = now
+                });
+            }
+        }
+
+        public Task SetAuthorizedOperationAsync(
+            long authStateRevision,
+            Guid clientId,
+            CryptoApiAuthorizedKeyOperation authorization,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                _authorizationCache[$"{authStateRevision}:{clientId:N}:{authorization.AliasName}:{authorization.Operation}"] = authorization;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<bool?> TryAcquireLastUsedRefreshLeaseAsync(
+            Guid clientKeyId,
+            DateTimeOffset now,
+            TimeSpan minimumInterval,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                if (_lastUsedLeases.TryGetValue(clientKeyId, out DateTimeOffset expiresAtUtc) && expiresAtUtc > now)
+                {
+                    return Task.FromResult<bool?>(false);
+                }
+
+                _lastUsedLeases[clientKeyId] = now.Add(minimumInterval);
+                return Task.FromResult<bool?>(true);
+            }
+        }
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset initialUtcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = initialUtcNow;
+
+        public override DateTimeOffset GetUtcNow()
+            => _utcNow;
+
+        public void Advance(TimeSpan delta)
+            => _utcNow = _utcNow.Add(delta);
+    }
+}

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiKeyAccessManagementServiceTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiKeyAccessManagementServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.SharedState;
@@ -223,15 +224,16 @@ public sealed class CryptoApiKeyAccessManagementServiceTests
         };
 
         ICryptoApiSharedStateStore store = new SqliteCryptoApiSharedStateStore(Options.Create(options));
+        ICryptoApiDistributedHotPathCache distributedHotPathCache = new NoOpCryptoApiDistributedHotPathCache();
         CryptoApiClientSecretGenerator generator = new();
         CryptoApiClientSecretHasher hasher = new();
         TimeProvider timeProvider = TimeProvider.System;
         return (
             Store: store,
             ClientManagement: new CryptoApiClientManagementService(store, generator, hasher, timeProvider),
-            Authentication: new CryptoApiClientAuthenticationService(store, hasher, timeProvider),
+            Authentication: new CryptoApiClientAuthenticationService(store, distributedHotPathCache, hasher, timeProvider),
             AccessManagement: new CryptoApiKeyAccessManagementService(store, timeProvider),
-            Authorization: new CryptoApiKeyOperationAuthorizationService(store, timeProvider));
+            Authorization: new CryptoApiKeyOperationAuthorizationService(store, distributedHotPathCache, timeProvider));
     }
 
     private static string CreateDatabasePath()


### PR DESCRIPTION
Add an optional Redis-backed L2 hot-path acceleration layer for Crypto API auth/authz request execution while keeping SQLite/PostgreSQL as the source of truth. This shares warm auth/authz state across instances, accelerates auth-state revision checks, and throttles fleet-wide last-used writes without making Redis authoritative. Closes #139.