### PR TITLE
Fix Postgres-only Crypto API connection exhaustion

### DIFF
--- a/docs/crypto-api-deployment.md
+++ b/docs/crypto-api-deployment.md
@@ -130,7 +130,9 @@ When both point at the same `CryptoApiSharedPersistence:ConnectionString`, they 
 
 Each API node may still keep a **small local request-path cache** for successful auth + authorization decisions.
 Operators can also layer in an optional **Redis-backed hot-path accelerator** so instances can share warm auth/authz decisions, reuse a shared auth-state revision hint, and coordinate `last_used_at_utc` throttling across the fleet.
+Even without Redis, Postgres-backed instances now keep a local auth-state revision hint synchronized through Postgres `LISTEN` / `NOTIFY`, so warm request paths do not have to re-read the revision row on every request.
 Those caches remain disposable; correctness still comes from the shared database because cache keys are tied to a shared auth-state revision that advances when clients, keys, aliases, policies, or bindings change.
+If the Postgres connection string does not set `Maximum Pool Size` / `Max Pool Size`, the host applies a conservative default of `32` pooled database connections per Crypto API instance; set an explicit value in the connection string if your environment needs a different cap.
 `last_used_at_utc` remains shared metadata, but the host now writes it on a short throttled interval instead of once per successful request, and Redis can reduce duplicate cross-node touches within that interval.
 
 ### Not shared

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -73,6 +73,7 @@ Steady-state request execution is now intentionally **two-tiered**:
 
 - the source of truth for auth, alias, and policy state remains the shared persistence store
 - each API node keeps a small bounded in-memory cache for successful auth and authorization decisions
+- in Postgres-only deployments, each node also keeps a Postgres-backed auth-state revision hint current via `LISTEN` / `NOTIFY`, so warm request paths do not have to re-read the revision row on every call
 - operators can optionally add Redis as a **shared hot-path accelerator** for auth revision lookups, successful auth/authz cache reuse across nodes, and fleet-wide `last_used_at_utc` write throttling
 - cache entries are keyed by a lightweight shared-state auth revision so admin changes still invalidate warm entries across nodes without forcing full snapshot reloads on every request
 - `last_used_at_utc` updates are throttled to a short interval per key instead of writing synchronously on every successful request
@@ -165,6 +166,7 @@ Notes:
 - `CryptoApiSharedPersistence:ConnectionString` enables the shared state store. If omitted, the host still runs, but `/api/v1/shared-state` reports that shared persistence is not configured.
 - `CryptoApiSharedPersistence:AutoInitialize=true` creates the schema on startup/first use.
 - With `Provider=Postgres`, use a standard Npgsql/PostgreSQL connection string and prefer a dedicated database/role for the Crypto API control plane.
+- If the connection string does not specify `Maximum Pool Size` / `Max Pool Size`, the host applies a conservative default cap of `32` pooled Postgres connections per instance. Set an explicit pool size in the connection string if your deployment needs a different budget.
 - `CryptoApiRequestPathCaching:Redis:Enabled=true` turns on the optional Redis-backed hot-path accelerator.
 - `CryptoApiRequestPathCaching:Redis:Configuration` is a standard StackExchange.Redis configuration string.
 - `CryptoApiRequestPathCaching:Redis:InstanceName` prefixes cache/lease keys so multiple environments can share one Redis fleet safely.

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
@@ -4,17 +4,38 @@ using Pkcs11Wrapper.CryptoApi.Configuration;
 
 namespace Pkcs11Wrapper.CryptoApi.SharedState;
 
-public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiAuthoritativeSharedStateStore
+public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiAuthoritativeSharedStateStore, IAsyncDisposable
 {
     private const string AuthStateRevisionMetadataKey = "auth_state_revision";
+    private const string AuthStateRevisionNotificationChannelPrefix = "crypto_api_auth_state_";
+    private const int DefaultMaxPoolSize = 32;
     private const string SchemaVersionMetadataKey = "schema_version";
+    private static readonly TimeSpan AuthStateRevisionListenerReconnectDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan AuthStateRevisionListenerWaitTimeout = TimeSpan.FromSeconds(30);
 
     private readonly CryptoApiSharedPersistenceOptions _options = options.Value;
+    private readonly string? _pooledConnectionString = NormalizePooledConnectionString(options.Value.ConnectionString);
     private readonly SemaphoreSlim _initializationGate = new(1, 1);
+    private readonly SemaphoreSlim _authStateRevisionListenerGate = new(1, 1);
+    private readonly CancellationTokenSource _listenerCancellationSource = new();
+    private readonly string _authStateRevisionNotificationChannel = CreateAuthStateRevisionNotificationChannel(options.Value.ConnectionString);
     private volatile bool _databaseInitialized;
+    private volatile bool _authStateRevisionListenerStarted;
     private long _databaseInitializationCount;
+    private long _cachedAuthStateRevision;
+    private long _authStateRevisionDatabaseReadCount;
+    private int _disposeState;
+    private Task? _authStateRevisionListenerTask;
+    private TaskCompletionSource _authStateRevisionListenerReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     internal long DatabaseInitializationCount => Interlocked.Read(ref _databaseInitializationCount);
+
+    internal long AuthStateRevisionDatabaseReadCount => Interlocked.Read(ref _authStateRevisionDatabaseReadCount);
+
+    internal int EffectiveMaxPoolSize
+        => string.IsNullOrWhiteSpace(_pooledConnectionString)
+            ? 0
+            : new NpgsqlConnectionStringBuilder(_pooledConnectionString).MaxPoolSize;
 
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
@@ -89,9 +110,19 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
 
         await InitializeAsync(cancellationToken);
 
+        await EnsureAuthStateRevisionListenerStartedAsync(cancellationToken);
+
+        long cachedRevision = Interlocked.Read(ref _cachedAuthStateRevision);
+        if (cachedRevision > 0)
+        {
+            return cachedRevision;
+        }
+
         await using NpgsqlConnection connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
-        return await GetAuthStateRevisionCoreAsync(connection, cancellationToken);
+        long revision = await ReadAuthStateRevisionFromDatabaseAsync(connection, cancellationToken);
+        UpdateCachedAuthStateRevision(revision);
+        return revision;
     }
 
     public async Task<CryptoApiClientAuthenticationState?> GetClientAuthenticationStateAsync(string keyIdentifier, CancellationToken cancellationToken = default)
@@ -265,7 +296,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
         AddTimestamp(command, "@updatedAtUtc", client.UpdatedAtUtc);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
-        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        _ = await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -344,7 +375,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
         AddNullableTimestamp(command, "@lastUsedAtUtc", clientKey.LastUsedAtUtc);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
-        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        _ = await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -424,7 +455,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
         AddTimestamp(command, "@updatedAtUtc", keyAlias.UpdatedAtUtc);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
-        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        _ = await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -475,7 +506,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
         AddTimestamp(command, "@updatedAtUtc", policy.UpdatedAtUtc);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
-        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        _ = await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -502,7 +533,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
             await insert.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        _ = await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -529,7 +560,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
             await insert.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
+        _ = await IncrementAuthStateRevisionAsync(connection, transaction, cancellationToken);
         await transaction.CommitAsync(cancellationToken);
     }
 
@@ -547,6 +578,31 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
             Policies: await ReadPoliciesAsync(connection, cancellationToken),
             ClientPolicyBindings: await ReadClientPolicyBindingsAsync(connection, cancellationToken),
             KeyAliasPolicyBindings: await ReadKeyAliasPolicyBindingsAsync(connection, cancellationToken));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+        {
+            return;
+        }
+
+        _listenerCancellationSource.Cancel();
+
+        if (_authStateRevisionListenerTask is not null)
+        {
+            try
+            {
+                await _authStateRevisionListenerTask;
+            }
+            catch (OperationCanceledException) when (_listenerCancellationSource.IsCancellationRequested)
+            {
+            }
+        }
+
+        _listenerCancellationSource.Dispose();
+        _authStateRevisionListenerGate.Dispose();
+        _initializationGate.Dispose();
     }
 
     private bool IsConfigured()
@@ -576,8 +632,177 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
         await InitializeAsync(cancellationToken);
     }
 
+    private async Task EnsureAuthStateRevisionListenerStartedAsync(CancellationToken cancellationToken)
+    {
+        if (_authStateRevisionListenerStarted)
+        {
+            await WaitForAuthStateRevisionListenerReadyAsync(cancellationToken);
+            return;
+        }
+
+        await _authStateRevisionListenerGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_authStateRevisionListenerStarted)
+            {
+                return;
+            }
+
+            _authStateRevisionListenerReady = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _authStateRevisionListenerTask = Task.Run(() => ListenForAuthStateRevisionChangesAsync(_authStateRevisionListenerReady, _listenerCancellationSource.Token));
+            _authStateRevisionListenerStarted = true;
+        }
+        finally
+        {
+            _authStateRevisionListenerGate.Release();
+        }
+
+        await WaitForAuthStateRevisionListenerReadyAsync(cancellationToken);
+    }
+
+    private async Task WaitForAuthStateRevisionListenerReadyAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _authStateRevisionListenerReady.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+        }
+    }
+
+    private async Task ListenForAuthStateRevisionChangesAsync(TaskCompletionSource readySignal, CancellationToken cancellationToken)
+    {
+        bool readySignaled = false;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await InitializeAsync(cancellationToken);
+
+                await using NpgsqlConnection connection = CreateListenerConnection();
+                connection.Notification += HandleAuthStateRevisionNotification;
+
+                try
+                {
+                    await connection.OpenAsync(cancellationToken);
+
+                    await using NpgsqlCommand listen = connection.CreateCommand();
+                    listen.CommandText = $"LISTEN {_authStateRevisionNotificationChannel};";
+                    await listen.ExecuteNonQueryAsync(cancellationToken);
+
+                    long revision = await ReadAuthStateRevisionFromDatabaseAsync(connection, cancellationToken);
+                    UpdateCachedAuthStateRevision(revision);
+
+                    if (!readySignaled)
+                    {
+                        readySignal.TrySetResult();
+                        readySignaled = true;
+                    }
+
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        _ = await connection.WaitAsync(AuthStateRevisionListenerWaitTimeout, cancellationToken);
+                    }
+                }
+                finally
+                {
+                    connection.Notification -= HandleAuthStateRevisionNotification;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch
+            {
+                if (!readySignaled)
+                {
+                    readySignal.TrySetResult();
+                    readySignaled = true;
+                }
+
+                try
+                {
+                    await Task.Delay(AuthStateRevisionListenerReconnectDelay, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    private void HandleAuthStateRevisionNotification(object? sender, NpgsqlNotificationEventArgs args)
+    {
+        if (!string.Equals(args.Channel, _authStateRevisionNotificationChannel, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (long.TryParse(args.Payload, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out long revision))
+        {
+            UpdateCachedAuthStateRevision(revision);
+        }
+    }
+
     private NpgsqlConnection CreateConnection()
-        => new(_options.ConnectionString);
+        => new(_pooledConnectionString);
+
+    private NpgsqlConnection CreateListenerConnection()
+    {
+        NpgsqlConnectionStringBuilder builder = new(_options.ConnectionString)
+        {
+            Pooling = false
+        };
+
+        return new NpgsqlConnection(builder.ConnectionString);
+    }
+
+    private static string CreateAuthStateRevisionNotificationChannel(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return $"{AuthStateRevisionNotificationChannelPrefix}default";
+        }
+
+        NpgsqlConnectionStringBuilder builder = new(connectionString);
+        string scope = string.Join('|',
+            builder.Host ?? string.Empty,
+            builder.Port.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            builder.Database ?? string.Empty,
+            builder.SearchPath ?? string.Empty);
+        byte[] hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(scope));
+        string suffix = Convert.ToHexString(hash.AsSpan(0, 12)).ToLowerInvariant();
+        return $"{AuthStateRevisionNotificationChannelPrefix}{suffix}";
+    }
+
+    private static string? NormalizePooledConnectionString(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return connectionString;
+        }
+
+        NpgsqlConnectionStringBuilder builder = new(connectionString);
+        if (builder.Pooling && !SpecifiesMaxPoolSize(connectionString))
+        {
+            builder.MaxPoolSize = DefaultMaxPoolSize;
+        }
+
+        return builder.ConnectionString;
+    }
+
+    private static bool SpecifiesMaxPoolSize(string connectionString)
+    {
+        string compact = connectionString.Replace(" ", string.Empty, StringComparison.Ordinal);
+        return compact.Contains("maxpoolsize=", StringComparison.OrdinalIgnoreCase)
+            || compact.Contains("maximumpoolsize=", StringComparison.OrdinalIgnoreCase)
+            || connectionString.Contains("Max Pool Size=", StringComparison.OrdinalIgnoreCase)
+            || connectionString.Contains("Maximum Pool Size=", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static async Task EnsureSchemaAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
     {
@@ -725,8 +950,10 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
             : Convert.ToInt32(value, System.Globalization.CultureInfo.InvariantCulture);
     }
 
-    private static async Task<long> GetAuthStateRevisionCoreAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    private async Task<long> ReadAuthStateRevisionFromDatabaseAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
     {
+        Interlocked.Increment(ref _authStateRevisionDatabaseReadCount);
+
         await using NpgsqlCommand command = connection.CreateCommand();
         command.CommandText = "SELECT metadata_value FROM crypto_api_metadata WHERE metadata_key = @metadataKey;";
         AddText(command, "@metadataKey", AuthStateRevisionMetadataKey);
@@ -850,18 +1077,65 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
         return policies;
     }
 
-    private static async Task IncrementAuthStateRevisionAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
+    private async Task<long> IncrementAuthStateRevisionAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
     {
         await using NpgsqlCommand command = connection.CreateCommand();
         command.Transaction = transaction;
         command.CommandText = """
-            INSERT INTO crypto_api_metadata (metadata_key, metadata_value)
-            VALUES (@metadataKey, '2')
-            ON CONFLICT (metadata_key) DO UPDATE
-            SET metadata_value = CAST(CAST(crypto_api_metadata.metadata_value AS BIGINT) + 1 AS TEXT);
+            WITH next_revision AS (
+                INSERT INTO crypto_api_metadata (metadata_key, metadata_value)
+                VALUES (@metadataKey, '2')
+                ON CONFLICT (metadata_key) DO UPDATE
+                SET metadata_value = CAST(CAST(crypto_api_metadata.metadata_value AS BIGINT) + 1 AS TEXT)
+                RETURNING metadata_value)
+            SELECT CAST(metadata_value AS BIGINT)
+            FROM next_revision;
             """;
         AddText(command, "@metadataKey", AuthStateRevisionMetadataKey);
+        object? value = await command.ExecuteScalarAsync(cancellationToken);
+        long revision = value is null
+            ? 0
+            : Convert.ToInt64(value, System.Globalization.CultureInfo.InvariantCulture);
+
+        if (revision > 0)
+        {
+            UpdateCachedAuthStateRevision(revision);
+            await NotifyAuthStateRevisionChangedAsync(connection, transaction, _authStateRevisionNotificationChannel, revision, cancellationToken);
+        }
+
+        return revision;
+    }
+
+    private static async Task NotifyAuthStateRevisionChangedAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, string channel, long revision, CancellationToken cancellationToken)
+    {
+        await using NpgsqlCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "SELECT pg_notify(@channel, @payload);";
+        AddText(command, "@channel", channel);
+        AddText(command, "@payload", revision.ToString(System.Globalization.CultureInfo.InvariantCulture));
         await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private void UpdateCachedAuthStateRevision(long revision)
+    {
+        if (revision <= 0)
+        {
+            return;
+        }
+
+        while (true)
+        {
+            long currentRevision = Interlocked.Read(ref _cachedAuthStateRevision);
+            if (currentRevision >= revision)
+            {
+                return;
+            }
+
+            if (Interlocked.CompareExchange(ref _cachedAuthStateRevision, revision, currentRevision) == currentRevision)
+            {
+                return;
+            }
+        }
     }
 
     private string? GetConnectionTarget()

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiDistributedHotPathCacheTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiDistributedHotPathCacheTests.cs
@@ -11,6 +11,47 @@ namespace Pkcs11Wrapper.CryptoApi.Tests;
 public sealed class CryptoApiDistributedHotPathCacheTests
 {
     [PostgresFact]
+    public async Task PostgresOnlyWarmInstanceInvalidatesRevokedKeyAcrossInstancesWithoutRevisionDatabaseChurn()
+    {
+        await using PostgresTestScope scope = await CreateScopeAsync();
+        ServiceSet instanceA = CreateServiceSet(scope.Options, new NoOpCryptoApiDistributedHotPathCache(), DateTimeOffset.Parse("2026-04-04T12:00:00Z"));
+        ServiceSet instanceB = CreateServiceSet(scope.Options, new NoOpCryptoApiDistributedHotPathCache(), DateTimeOffset.Parse("2026-04-04T12:00:05Z"));
+
+        SeededAccess access = await SeedAuthorizedAccessAsync(instanceA);
+        instanceA.Store.ResetCounters();
+        instanceB.Store.ResetCounters();
+
+        CryptoApiRequestAuthorizationResult warm = await instanceB.Authorization.AuthorizeRequestAsync(
+            access.Key.KeyIdentifier,
+            access.Key.Secret,
+            access.Alias.AliasName,
+            "sign");
+
+        Assert.True(warm.Succeeded, warm.FailureReason);
+        Assert.Equal(1, instanceB.Store.AuthStateRevisionDatabaseReadCount);
+        Assert.Equal(1, instanceB.Store.AuthenticationStateReads);
+        Assert.Equal(1, instanceB.Store.AuthorizationStateReads);
+
+        await instanceA.ClientManagement.RevokeClientKeyAsync(access.Key.ClientKeyId, "rotation");
+
+        CryptoApiRequestAuthorizationResult afterRevocation = await WaitForAuthorizationResultAsync(
+            () => instanceB.Authorization.AuthorizeRequestAsync(
+                access.Key.KeyIdentifier,
+                access.Key.Secret,
+                access.Alias.AliasName,
+                "sign"),
+            result => !result.Succeeded,
+            TimeSpan.FromSeconds(5));
+
+        Assert.False(afterRevocation.Succeeded);
+        Assert.Equal(401, afterRevocation.FailureStatusCode);
+        Assert.Equal("API key has been revoked.", afterRevocation.FailureReason);
+        Assert.Equal(1, instanceB.Store.AuthStateRevisionDatabaseReadCount);
+        Assert.Equal(2, instanceB.Store.AuthenticationStateReads);
+        Assert.Equal(1, instanceB.Store.AuthorizationStateReads);
+    }
+
+    [PostgresFact]
     public async Task DistributedHotCacheSharesWarmAuthorizationAcrossInstances()
     {
         await using PostgresTestScope scope = await CreateScopeAsync();
@@ -131,6 +172,28 @@ public sealed class CryptoApiDistributedHotPathCacheTests
         return new SeededAccess(client, key, alias, policy);
     }
 
+    private static async Task<CryptoApiRequestAuthorizationResult> WaitForAuthorizationResultAsync(
+        Func<Task<CryptoApiRequestAuthorizationResult>> action,
+        Func<CryptoApiRequestAuthorizationResult, bool> predicate,
+        TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            CryptoApiRequestAuthorizationResult result = await action();
+            if (predicate(result))
+            {
+                return result;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        CryptoApiRequestAuthorizationResult finalResult = await action();
+        Assert.True(predicate(finalResult));
+        return finalResult;
+    }
+
     private sealed record ServiceSet(
         CountingAuthoritativeSharedStateStore Store,
         CryptoApiClientManagementService ClientManagement,
@@ -146,6 +209,8 @@ public sealed class CryptoApiDistributedHotPathCacheTests
 
     private sealed class CountingAuthoritativeSharedStateStore(PostgresCryptoApiSharedStateStore inner) : ICryptoApiAuthoritativeSharedStateStore
     {
+        public long AuthStateRevisionDatabaseReadCount => inner.AuthStateRevisionDatabaseReadCount;
+
         public int AuthStateRevisionReads { get; private set; }
 
         public int AuthenticationStateReads { get; private set; }

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
@@ -297,6 +297,7 @@ public sealed class CryptoApiRoutesTests
 
         SeededAccess access = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer");
         CountingSharedStateStore store = factory.Services.GetRequiredService<CountingSharedStateStore>();
+        long baselineAuthStateRevisionReads = store.AuthStateRevisionDatabaseReadCount;
         int baselineSnapshotReads = store.SnapshotReads;
         int baselineAuthenticationStateReads = store.AuthenticationStateReads;
         int baselineLastUsedTouches = store.LastUsedTouches;
@@ -312,6 +313,7 @@ public sealed class CryptoApiRoutesTests
             timeProvider.Advance(TimeSpan.FromSeconds(10));
         }
 
+        Assert.Equal(1L, store.AuthStateRevisionDatabaseReadCount - baselineAuthStateRevisionReads);
         Assert.Equal(0, store.SnapshotReads - baselineSnapshotReads);
         Assert.Equal(1, store.AuthenticationStateReads - baselineAuthenticationStateReads);
         Assert.Equal(1, store.LastUsedTouches - baselineLastUsedTouches);
@@ -320,6 +322,7 @@ public sealed class CryptoApiRoutesTests
         using HttpResponseMessage afterInterval = await httpClient.GetAsync("/api/v1/auth/self");
         Assert.Equal(HttpStatusCode.OK, afterInterval.StatusCode);
 
+        Assert.Equal(1L, store.AuthStateRevisionDatabaseReadCount - baselineAuthStateRevisionReads);
         Assert.Equal(0, store.SnapshotReads - baselineSnapshotReads);
         Assert.Equal(1, store.AuthenticationStateReads - baselineAuthenticationStateReads);
         Assert.Equal(2, store.LastUsedTouches - baselineLastUsedTouches);
@@ -346,6 +349,7 @@ public sealed class CryptoApiRoutesTests
 
         SeededAccess access = await SeedAuthorizedAccessAsync(factory, ["sign"], "payments-signer");
         CountingSharedStateStore store = factory.Services.GetRequiredService<CountingSharedStateStore>();
+        long baselineAuthStateRevisionReads = store.AuthStateRevisionDatabaseReadCount;
         int baselineSnapshotReads = store.SnapshotReads;
         int baselineAuthenticationStateReads = store.AuthenticationStateReads;
         int baselineAuthorizationStateReads = store.AuthorizationStateReads;
@@ -364,6 +368,7 @@ public sealed class CryptoApiRoutesTests
             timeProvider.Advance(TimeSpan.FromSeconds(5));
         }
 
+        Assert.Equal(1L, store.AuthStateRevisionDatabaseReadCount - baselineAuthStateRevisionReads);
         Assert.Equal(0, store.SnapshotReads - baselineSnapshotReads);
         Assert.Equal(1, store.AuthenticationStateReads - baselineAuthenticationStateReads);
         Assert.Equal(1, store.AuthorizationStateReads - baselineAuthorizationStateReads);
@@ -530,6 +535,10 @@ public sealed class CryptoApiRoutesTests
 
     private sealed class CountingSharedStateStore(PostgresCryptoApiSharedStateStore inner) : ICryptoApiSharedStateStore
     {
+        public long AuthStateRevisionDatabaseReadCount => inner.AuthStateRevisionDatabaseReadCount;
+
+        public int AuthStateRevisionReads { get; private set; }
+
         public int SnapshotReads { get; private set; }
 
         public int AuthenticationStateReads { get; private set; }
@@ -544,8 +553,11 @@ public sealed class CryptoApiRoutesTests
         public Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default)
             => inner.GetStatusAsync(cancellationToken);
 
-        public Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
-            => inner.GetAuthStateRevisionAsync(cancellationToken);
+        public async Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
+        {
+            AuthStateRevisionReads++;
+            return await inner.GetAuthStateRevisionAsync(cancellationToken);
+        }
 
         public async Task<CryptoApiClientAuthenticationState?> GetClientAuthenticationStateAsync(string keyIdentifier, CancellationToken cancellationToken = default)
         {

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiSharedStateStoreTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiSharedStateStoreTests.cs
@@ -7,6 +7,32 @@ namespace Pkcs11Wrapper.CryptoApi.Tests;
 
 public sealed class CryptoApiSharedStateStoreTests
 {
+    [Fact]
+    public void PostgresStoreAppliesConservativeDefaultMaxPoolSizeWhenConnectionStringDoesNotSpecifyOne()
+    {
+        PostgresCryptoApiSharedStateStore store = new(Options.Create(new CryptoApiSharedPersistenceOptions
+        {
+            Provider = CryptoApiSharedPersistenceDefaults.PostgresProvider,
+            ConnectionString = "Host=db.internal;Port=5432;Database=pkcs11wrapper;Username=cryptoapi;Password=secret;SSL Mode=Disable",
+            AutoInitialize = true
+        }));
+
+        Assert.Equal(32, store.EffectiveMaxPoolSize);
+    }
+
+    [Fact]
+    public void PostgresStoreRespectsExplicitMaxPoolSizeFromConnectionString()
+    {
+        PostgresCryptoApiSharedStateStore store = new(Options.Create(new CryptoApiSharedPersistenceOptions
+        {
+            Provider = CryptoApiSharedPersistenceDefaults.PostgresProvider,
+            ConnectionString = "Host=db.internal;Port=5432;Database=pkcs11wrapper;Username=cryptoapi;Password=secret;SSL Mode=Disable;Maximum Pool Size=48",
+            AutoInitialize = true
+        }));
+
+        Assert.Equal(48, store.EffectiveMaxPoolSize);
+    }
+
     [PostgresFact]
     public async Task SharedStateStoreSharesStateAcrossIndependentInstances()
     {
@@ -356,5 +382,66 @@ public sealed class CryptoApiSharedStateStoreTests
 
         Assert.Equal(1, afterWarmUp);
         Assert.Equal(afterWarmUp, reader.DatabaseInitializationCount);
+    }
+
+    [PostgresFact]
+    public async Task GetAuthStateRevisionWarmPathDoesNotRequeryDatabaseAfterInitialRead()
+    {
+        await using PostgresTestScope scope = await CreateScopeAsync();
+        PostgresCryptoApiSharedStateStore store = new(scope.AsOptions());
+
+        long firstRevision = await store.GetAuthStateRevisionAsync();
+        long databaseReadsAfterFirst = store.AuthStateRevisionDatabaseReadCount;
+        long secondRevision = await store.GetAuthStateRevisionAsync();
+
+        Assert.Equal(firstRevision, secondRevision);
+        Assert.Equal(1, databaseReadsAfterFirst);
+        Assert.Equal(databaseReadsAfterFirst, store.AuthStateRevisionDatabaseReadCount);
+    }
+
+    [PostgresFact]
+    public async Task GetAuthStateRevisionCacheRefreshesAcrossStoresViaPostgresNotify()
+    {
+        await using PostgresTestScope scope = await CreateScopeAsync();
+        PostgresCryptoApiSharedStateStore reader = new(scope.AsOptions());
+        PostgresCryptoApiSharedStateStore writer = new(scope.AsOptions());
+
+        long initialRevision = await reader.GetAuthStateRevisionAsync();
+        long baselineDatabaseReads = reader.AuthStateRevisionDatabaseReadCount;
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        await writer.UpsertClientAsync(new CryptoApiClientRecord(
+            Guid.NewGuid(),
+            $"notify-client-{Guid.NewGuid():N}",
+            "Notify Client",
+            "service",
+            "api-key",
+            true,
+            null,
+            now,
+            now));
+
+        long expectedRevision = await writer.GetAuthStateRevisionAsync();
+
+        await WaitUntilAsync(async () => await reader.GetAuthStateRevisionAsync() == expectedRevision, TimeSpan.FromSeconds(5));
+
+        Assert.True(expectedRevision > initialRevision);
+        Assert.Equal(baselineDatabaseReads, reader.AuthStateRevisionDatabaseReadCount);
+    }
+
+    private static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await condition())
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        Assert.True(await condition());
     }
 }


### PR DESCRIPTION
Fix Postgres-only multi-instance Crypto API connection exhaustion by adding a Postgres-native auth-state revision hint path (LISTEN/NOTIFY-backed local revision cache) and a conservative default Npgsql pool cap when the connection string does not set one explicitly. This keeps Postgres-only mode functional under load without making Redis required. Closes #148.