### PR TITLE
Add runtime observability metrics and dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 - stateless, machine-facing boundary separate from the admin dashboard
 - DI/config binding for service identity, API base path, PKCS#11 runtime, and shared persistence
 - health-aware/load-balanced ingress across multiple Crypto API instances, with correlation-id propagation and practical ingress request-body limits
+- OpenTelemetry-backed Prometheus scraping endpoints plus first-slice runtime metrics for auth/authz cache behavior, shared-state pressure, PKCS#11 latency, ingress health, and admin activity
 - `/health/live` + `/health/ready` endpoints, with readiness validating the configured PKCS#11 module and shared persistence when configured
 - `/api/v1`, `/api/v1/runtime`, `/api/v1/operations`, `POST /api/v1/operations/authorize`, `/api/v1/shared-state`, and `/api/v1/auth/self` route space for the emerging machine-facing contract
 - shared persistence for multi-instance API clients/keys, key aliases, policies, and policy bindings, with PostgreSQL as the supported shared backend across local/dev/lab and production-oriented deployments
@@ -94,6 +95,7 @@ PKCS#11 integrations are powerful, but they are often awkward to consume from mo
 - admin-panel/shared-store control-plane model for Crypto API applications, aliases, policies, and bindings without turning the machine-facing host into a tenant portal
 - intended deployment model: **one admin dashboard + many stateless crypto API instances**
 - committed local/manual perf-regression workflow for sign/random/mixed Crypto API traffic so service-level regressions are easier to catch before release
+- starter runtime observability guide + Grafana dashboard seed at [docs/runtime-observability.md](docs/runtime-observability.md)
 
 ## Platform & validation status
 

--- a/deploy/container/admin-panel.env.example
+++ b/deploy/container/admin-panel.env.example
@@ -41,3 +41,8 @@ AdminRuntime__DisableHttpsRedirection=true
 # AdminTelemetry__RetentionDays=14
 # AdminTelemetry__MaxArchivedFiles=8
 # AdminTelemetry__ExportMaxEntries=5000
+
+# Prometheus scraping endpoint. Publish this only on trusted operator networks
+# or behind an authenticated reverse proxy.
+Observability__EnablePrometheusScrapingEndpoint=true
+Observability__MetricsPath=/metrics

--- a/deploy/container/crypto-api-gateway.env.example
+++ b/deploy/container/crypto-api-gateway.env.example
@@ -38,3 +38,8 @@ CryptoApiGateway__Destinations__1__Name=crypto-api-b
 CryptoApiGateway__Destinations__1__Address=http://crypto-api-b.internal:8080/
 CryptoApiGateway__Destinations__1__Health=http://crypto-api-b.internal:8080/
 CryptoApiGateway__Destinations__1__Enabled=true
+
+# Prometheus scraping endpoint. Keep it private; it exposes backend inventory
+# and request-flow counters useful for operators.
+Observability__EnablePrometheusScrapingEndpoint=true
+Observability__MetricsPath=/metrics

--- a/deploy/container/crypto-api.env.example
+++ b/deploy/container/crypto-api.env.example
@@ -45,3 +45,8 @@ CryptoApiRequestPathCaching__Redis__AuthStateRevisionTtlSeconds=30
 # Enable only for tightly controlled internal troubleshooting.
 CryptoApiSecurity__ExposeDetailedErrors=false
 CryptoApiSecurity__ExposeSharedStateDetails=false
+
+# Prometheus scraping endpoint. Keep it on a private network segment or behind
+# an authenticated metrics gateway/reverse proxy.
+Observability__EnablePrometheusScrapingEndpoint=true
+Observability__MetricsPath=/metrics

--- a/docs/admin-container.md
+++ b/docs/admin-container.md
@@ -68,6 +68,7 @@ The admin image now exposes two unauthenticated health endpoints:
 
 - `/health/live` - lightweight liveness probe for process availability
 - `/health/ready` - readiness probe that verifies the admin storage root plus the app's writable runtime directories are present and writable
+- `/metrics` - Prometheus scraping endpoint when `Observability__EnablePrometheusScrapingEndpoint=true`
 
 The image also bakes in a Docker `HEALTHCHECK` that probes `http://127.0.0.1:8080/health/ready` from inside the container, so a plain `docker ps` / `docker inspect` workflow can see whether the container is healthy without extra operator wiring.
 
@@ -88,6 +89,8 @@ A starter env template for the standalone container path lives at:
 - `deploy/container/admin-panel.env.example`
 
 Copy it to an operator-controlled location, edit it, then pass it to `docker run --env-file ...` or your orchestrator's equivalent.
+
+The same env template now includes the optional `Observability__*` settings used to expose the Prometheus scrape endpoint on trusted operator networks.
 
 Example:
 
@@ -232,6 +235,8 @@ Why these flags are practical here:
 - `--pids-limit 256` adds a simple guardrail against runaway process creation without getting orchestration-specific
 
 If your vendor library requires additional writable client-side state, add a **separate** mount for that vendor path rather than making `/opt/pkcs11/lib` writable.
+
+For the metric catalogue and the starter Grafana dashboard, see [docs/runtime-observability.md](docs/runtime-observability.md).
 
 ## PKCS#11 library and client mount patterns
 

--- a/docs/crypto-api-gateway.md
+++ b/docs/crypto-api-gateway.md
@@ -145,6 +145,15 @@ Settings live under `CryptoApiGateway`.
 }
 ```
 
+Metrics endpoint configuration is shared with the other hosts:
+
+```json
+"Observability": {
+  "EnablePrometheusScrapingEndpoint": true,
+  "MetricsPath": "/metrics"
+}
+```
+
 Notes:
 
 - `ApiBasePath` should normally match the upstream Crypto API hosts' public base path.
@@ -175,6 +184,7 @@ Useful endpoints:
 - `/gateway/runtime`
 - `/health/live`
 - `/health/ready`
+- `/metrics` when `Observability:EnablePrometheusScrapingEndpoint=true`
 - `/api/v1/...` forwarded to healthy upstream Crypto API instances
 
 ## Deployment guidance
@@ -199,6 +209,8 @@ The gateway should **not** own:
 - alias/policy control-plane state
 - PKCS#11 execution semantics
 - tenant/global product policy beyond lightweight ingress concerns
+
+For the metric catalogue and the starter Grafana dashboard, see [docs/runtime-observability.md](docs/runtime-observability.md).
 
 ## Relationship to issue #150 HSM routing/dispatch groundwork
 

--- a/docs/crypto-api-host.md
+++ b/docs/crypto-api-host.md
@@ -178,6 +178,15 @@ Current settings live under three sections:
 }
 ```
 
+Observability settings now live under a fourth section:
+
+```json
+"Observability": {
+  "EnablePrometheusScrapingEndpoint": true,
+  "MetricsPath": "/metrics"
+}
+```
+
 Notes:
 
 - if `Backends` is omitted, the top-level `ModulePath` / `UserPin` pair is treated as the default backend runtime
@@ -209,6 +218,7 @@ Notes:
 
 For the full operator deployment model, see [docs/crypto-api-deployment.md](docs/crypto-api-deployment.md).
 If you are wrapping this host in your own container or supervisor, start from `deploy/container/crypto-api.env.example`.
+For the metric catalogue and Grafana starter dashboard, see [docs/runtime-observability.md](docs/runtime-observability.md).
 
 ## Local run example
 
@@ -236,6 +246,7 @@ Useful endpoints:
 - `POST /api/v1/operations/sign` using `X-Api-Key-Id` + `X-Api-Key-Secret` with `{ "keyAlias": "payments-signer", "algorithm": "RS256", "payloadBase64": "aGVsbG8=" }`
 - `POST /api/v1/operations/verify` using `X-Api-Key-Id` + `X-Api-Key-Secret` with `{ "keyAlias": "payments-signer", "algorithm": "RS256", "payloadBase64": "aGVsbG8=", "signatureBase64": "..." }`
 - `POST /api/v1/operations/random` using `X-Api-Key-Id` + `X-Api-Key-Secret` with `{ "keyAlias": "payments-signer", "length": 32 }`
+- `/metrics` when `Observability:EnablePrometheusScrapingEndpoint=true`
 
 `/api/v1/shared-state` returns a reduced public summary by default. Detailed connection-target and count metadata stay hidden unless you explicitly enable `CryptoApiSecurity:ExposeSharedStateDetails`.
 `/api/v1/auth/self` validates the hashed shared secret, enforces disabled / revoked / expired state, updates last-used metadata, and returns the authenticated client context that future crypto operations can reuse.

--- a/docs/grafana/pkcs11wrapper-runtime-observability-dashboard.json
+++ b/docs/grafana/pkcs11wrapper-runtime-observability-dashboard.json
@@ -1,0 +1,150 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Crypto API authentication results / min",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "targets": [
+        {
+          "expr": "sum by (source, result) (rate(pkcs11wrapper_crypto_api_authentication_results_total[5m])) * 60",
+          "legendFormat": "{{source}} / {{result}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Request-path cache lookups / min",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "targets": [
+        {
+          "expr": "sum by (cache, layer, result) (rate(pkcs11wrapper_crypto_api_request_path_cache_lookups_total[5m])) * 60",
+          "legendFormat": "{{cache}} / {{layer}} / {{result}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Shared-state p95 latency (ms)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(pkcs11wrapper_crypto_api_shared_state_request_duration_seconds_bucket[5m]))) * 1000",
+          "legendFormat": "{{operation}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Redis hot-path p95 latency (ms)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(pkcs11wrapper_crypto_api_distributed_cache_request_duration_seconds_bucket[5m]))) * 1000",
+          "legendFormat": "{{operation}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "PKCS#11 operation p95 latency (ms)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, operation, backend) (rate(pkcs11wrapper_crypto_api_pkcs11_operation_duration_seconds_bucket[5m]))) * 1000",
+          "legendFormat": "{{operation}} / {{backend}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Rate-limit rejections / min",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+      "targets": [
+        {
+          "expr": "sum by (scope) (rate(pkcs11wrapper_crypto_api_rate_limit_rejections_total[5m])) * 60",
+          "legendFormat": "{{scope}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "PKCS#11 sessions",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
+      "targets": [
+        {
+          "expr": "pkcs11wrapper_crypto_api_pkcs11_sessions_in_use",
+          "legendFormat": "in-use / {{backend}} / slot {{slot}}"
+        },
+        {
+          "expr": "pkcs11wrapper_crypto_api_pkcs11_sessions_idle",
+          "legendFormat": "idle / {{backend}} / slot {{slot}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Gateway healthy destinations",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
+      "targets": [
+        {
+          "expr": "pkcs11wrapper_crypto_api_gateway_healthy_destinations",
+          "legendFormat": "healthy / {{cluster}}"
+        },
+        {
+          "expr": "pkcs11wrapper_crypto_api_gateway_configured_destinations",
+          "legendFormat": "configured / {{cluster}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Admin login attempts / min",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 32},
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(pkcs11wrapper_admin_login_attempts_total[5m])) * 60",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "style": "dark",
+  "tags": ["pkcs11wrapper", "crypto-api", "observability"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Prometheus"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "title": "Pkcs11Wrapper Runtime Observability",
+  "uid": "pkcs11wrapper-runtime-observability",
+  "version": 1
+}

--- a/docs/runtime-observability.md
+++ b/docs/runtime-observability.md
@@ -1,0 +1,156 @@
+# Runtime observability
+
+This repository now ships a practical first observability slice for the runtime topology:
+
+- `Pkcs11Wrapper.CryptoApi`
+- `Pkcs11Wrapper.CryptoApi.Gateway`
+- `Pkcs11Wrapper.Admin.Web`
+
+The goal is intentionally narrow: expose the metrics operators need to understand request flow, shared-state pressure, PKCS#11 execution latency, ingress health, and basic admin activity without trying to build a full observability platform inside the app itself.
+
+## Export model
+
+Each web host now exposes an OpenTelemetry-backed Prometheus scraping endpoint.
+
+Configuration lives under:
+
+```json
+"Observability": {
+  "EnablePrometheusScrapingEndpoint": true,
+  "MetricsPath": "/metrics"
+}
+```
+
+Environment-variable equivalents:
+
+```text
+Observability__EnablePrometheusScrapingEndpoint=true
+Observability__MetricsPath=/metrics
+```
+
+The endpoint is intentionally unauthenticated inside the app. Treat it as an operator-only surface:
+
+- keep it on a private network
+- or publish it only behind an authenticated reverse proxy / metrics gateway
+- do not expose it directly on the public internet
+
+## What gets emitted
+
+## Common host metrics
+
+All three hosts export the custom meters listed below plus the standard ASP.NET Core/Kestrel request metrics that OpenTelemetry can scrape from the running process.
+
+## Crypto API host metrics
+
+Custom Crypto API metrics focus on the hot path:
+
+- `pkcs11wrapper_crypto_api_authentication_results_total`
+  - labels: `result`, `source`
+- `pkcs11wrapper_crypto_api_authorization_results_total`
+  - labels: `result`, `source`
+- `pkcs11wrapper_crypto_api_request_path_cache_lookups_total`
+  - labels: `cache`, `layer`, `result`
+- `pkcs11wrapper_crypto_api_distributed_cache_requests_total`
+- `pkcs11wrapper_crypto_api_distributed_cache_request_duration_seconds`
+  - labels: `operation`, `result`
+- `pkcs11wrapper_crypto_api_shared_state_requests_total`
+- `pkcs11wrapper_crypto_api_shared_state_request_duration_seconds`
+  - labels: `operation`, `result`
+- `pkcs11wrapper_crypto_api_shared_state_database_reads_total`
+- `pkcs11wrapper_crypto_api_last_used_refresh_events_total`
+  - labels: `path`, `stage`, `result`
+- `pkcs11wrapper_crypto_api_rate_limit_rejections_total`
+  - labels: `scope`
+- `pkcs11wrapper_crypto_api_pkcs11_operations_total`
+- `pkcs11wrapper_crypto_api_pkcs11_operation_duration_seconds`
+  - labels: `operation`, `algorithm`, `backend`, `result`
+- `pkcs11wrapper_crypto_api_pkcs11_session_leases_total`
+- `pkcs11wrapper_crypto_api_pkcs11_session_returns_total`
+  - labels: `backend`, `slot`, `result`
+- `pkcs11wrapper_crypto_api_authentication_cache_entries`
+- `pkcs11wrapper_crypto_api_authentication_cache_utilization_ratio`
+- `pkcs11wrapper_crypto_api_authorization_cache_entries`
+- `pkcs11wrapper_crypto_api_authorization_cache_utilization_ratio`
+- `pkcs11wrapper_crypto_api_shared_state_pool_max_connections`
+  - labels: `provider`
+- `pkcs11wrapper_crypto_api_pkcs11_sessions_idle`
+- `pkcs11wrapper_crypto_api_pkcs11_sessions_in_use`
+- `pkcs11wrapper_crypto_api_pkcs11_sessions_max_retained`
+  - labels: `backend`, `slot`
+
+These cover the first slice requested for request rate/latency, sign/verify/random latency, auth/authz cache behavior, shared-state pressure, pool visibility, rate limits, and errors.
+
+## Gateway metrics
+
+Gateway-specific metrics focus on ingress health and operator-visible rejection behavior:
+
+- `pkcs11wrapper_crypto_api_gateway_backend_readiness_probes_total`
+- `pkcs11wrapper_crypto_api_gateway_backend_readiness_probe_duration_seconds`
+  - labels: `cluster`, `result`
+- `pkcs11wrapper_crypto_api_gateway_request_body_rejections_total`
+- `pkcs11wrapper_crypto_api_gateway_healthy_destinations`
+- `pkcs11wrapper_crypto_api_gateway_configured_destinations`
+  - labels: `cluster`
+
+## Admin metrics
+
+Admin-specific metrics stay intentionally small:
+
+- `pkcs11wrapper_admin_login_attempts_total`
+  - labels: `result`
+- `pkcs11wrapper_admin_logouts_total`
+  - labels: `result`
+- `pkcs11wrapper_admin_sessions`
+  - labels: `status`
+
+This gives operators a lightweight signal for login failures/throttling and current tracked-session health without turning the admin panel into a second telemetry system.
+
+## Prometheus scrape example
+
+```yaml
+scrape_configs:
+  - job_name: pkcs11wrapper-crypto-api
+    static_configs:
+      - targets:
+          - crypto-api-a.internal:8080
+          - crypto-api-b.internal:8080
+    metrics_path: /metrics
+
+  - job_name: pkcs11wrapper-crypto-api-gateway
+    static_configs:
+      - targets:
+          - crypto-gateway.internal:8090
+    metrics_path: /metrics
+
+  - job_name: pkcs11wrapper-admin
+    static_configs:
+      - targets:
+          - admin.internal:8080
+    metrics_path: /metrics
+```
+
+## Grafana starter
+
+A starter dashboard definition lives at:
+
+- `docs/grafana/pkcs11wrapper-runtime-observability-dashboard.json`
+
+It is intentionally a starting point, not a polished NOC wall. Expect to tune panel thresholds, labels, and datasource wiring for your environment.
+
+Suggested first panels:
+
+- authentication result rate by source
+- request-path cache hit vs miss
+- shared-state p95 latency by operation
+- Redis hot-path cache p95 latency by operation
+- PKCS#11 sign / verify / random p95 latency by backend
+- rate-limit rejections
+- PKCS#11 sessions in use vs idle per backend/slot
+- gateway healthy destination count
+- admin login failures over time
+
+## Notes and limits
+
+- This is a metrics-first slice only; it does not attempt to replace vendor-native HSM audit logs.
+- The Prometheus exporter package in the OpenTelemetry stack is still a pragmatic app-level scrape choice here, not a promise that the repo is standardizing on one exporter forever.
+- If you later need OTLP export, traces, or centralized exemplars, build on top of these meters rather than replacing the metric names casually.

--- a/src/Pkcs11Wrapper.Admin.Application/Observability/AdminMetrics.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Observability/AdminMetrics.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Pkcs11Wrapper.Admin.Application.Services;
+
+namespace Pkcs11Wrapper.Admin.Application.Observability;
+
+public sealed class AdminMetrics : IDisposable
+{
+    public const string MeterName = "Pkcs11Wrapper.Admin";
+
+    private readonly Meter _meter = new(MeterName);
+    private readonly Counter<long> _loginAttempts;
+    private readonly Counter<long> _logouts;
+    private readonly ObservableGauge<int> _sessions;
+    private AdminSessionRegistry? _sessionRegistry;
+
+    public AdminMetrics()
+    {
+        _loginAttempts = _meter.CreateCounter<long>("pkcs11wrapper_admin_login_attempts_total");
+        _logouts = _meter.CreateCounter<long>("pkcs11wrapper_admin_logouts_total");
+        _sessions = _meter.CreateObservableGauge<int>("pkcs11wrapper_admin_sessions", ObserveSessions);
+    }
+
+    public void RegisterSessionRegistry(AdminSessionRegistry sessionRegistry)
+        => _sessionRegistry = sessionRegistry;
+
+    public void RecordLoginAttempt(string result)
+        => _loginAttempts.Add(1, CreateTags(("result", result)));
+
+    public void RecordLogout(string result)
+        => _logouts.Add(1, CreateTags(("result", result)));
+
+    public void Dispose() => _meter.Dispose();
+
+    private IEnumerable<Measurement<int>> ObserveSessions()
+    {
+        AdminSessionRegistry.AdminSessionRegistryMetricsSnapshot? snapshot = _sessionRegistry?.GetMetricsSnapshot();
+        if (snapshot is null)
+        {
+            return [];
+        }
+
+        return
+        [
+            new Measurement<int>(snapshot.Healthy, CreateTags(("status", "healthy"))),
+            new Measurement<int>(snapshot.Broken, CreateTags(("status", "broken"))),
+            new Measurement<int>(snapshot.Expired, CreateTags(("status", "expired"))),
+            new Measurement<int>(snapshot.Invalidated, CreateTags(("status", "invalidated")))
+        ];
+    }
+
+    private static TagList CreateTags(params (string Key, string? Value)[] pairs)
+    {
+        TagList tags = new();
+        foreach ((string key, string? value) in pairs)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                tags.Add(key, value);
+            }
+        }
+
+        return tags;
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Application/Services/AdminSessionRegistry.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/AdminSessionRegistry.cs
@@ -40,6 +40,16 @@ public sealed class AdminSessionRegistry(AdminSessionRegistryOptions? options = 
             .ToArray();
     }
 
+    public AdminSessionRegistryMetricsSnapshot GetMetricsSnapshot()
+    {
+        IReadOnlyList<AdminSessionSnapshot> snapshots = GetSnapshots();
+        return new AdminSessionRegistryMetricsSnapshot(
+            Healthy: snapshots.Count(static snapshot => snapshot.IsHealthy && string.Equals(snapshot.HealthLabel, "Healthy", StringComparison.Ordinal)),
+            Broken: snapshots.Count(static snapshot => string.Equals(snapshot.HealthLabel, "Broken", StringComparison.Ordinal)),
+            Expired: snapshots.Count(static snapshot => string.Equals(snapshot.HealthLabel, "Expired", StringComparison.Ordinal)),
+            Invalidated: snapshots.Count(static snapshot => string.Equals(snapshot.HealthLabel, "Invalidated", StringComparison.Ordinal)));
+    }
+
     public bool TryTouch(Guid sessionId, string operation)
     {
         ExpireIdleSessions();
@@ -197,6 +207,12 @@ public sealed class AdminSessionRegistry(AdminSessionRegistryOptions? options = 
         string DeviceName,
         bool IsReadWrite,
         string Notes);
+
+    public sealed record AdminSessionRegistryMetricsSnapshot(
+        int Healthy,
+        int Broken,
+        int Expired,
+        int Invalidated);
 
     private sealed class TrackedSession(
         Guid id,

--- a/src/Pkcs11Wrapper.Admin.Web/Pkcs11Wrapper.Admin.Web.csproj
+++ b/src/Pkcs11Wrapper.Admin.Web/Pkcs11Wrapper.Admin.Web.csproj
@@ -3,6 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 
     <ProjectReference Include="..\Pkcs11Wrapper.Admin.Application\Pkcs11Wrapper.Admin.Application.csproj" />

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.Admin.Application.Abstractions;
 using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Application.Observability;
 using Pkcs11Wrapper.Admin.Application.Services;
 using Pkcs11Wrapper.Admin.Infrastructure;
 using Pkcs11Wrapper.Admin.Web.Components;
@@ -15,6 +16,8 @@ using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.SharedState;
+using Pkcs11Wrapper.Observability;
+using OpenTelemetry.Metrics;
 
 if (await AdminContainerHealthProbe.TryExecuteAsync(args))
 {
@@ -47,6 +50,11 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddHealthChecks()
     .AddCheck<AdminStorageHealthCheck>("admin-storage", tags: ["ready"]);
+builder.Services.AddOptions<ObservabilityOptions>()
+    .Bind(builder.Configuration.GetSection(ObservabilityOptions.SectionName))
+    .PostConfigure(ObservabilityOptions.Normalize)
+    .Validate(static options => options.MetricsPath.StartsWith("/", StringComparison.Ordinal), "Observability metrics path must start with '/'.")
+    .ValidateOnStart();
 builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
     .Bind(builder.Configuration.GetSection(CryptoApiSharedPersistenceOptions.SectionName))
     .PostConfigure(static options =>
@@ -85,6 +93,17 @@ builder.Services.AddSingleton(runtimeOptions);
 builder.Services.AddSingleton<IOptions<AdminRuntimeOptions>>(Options.Create(runtimeOptions));
 builder.Services.AddSingleton(telemetryOptions);
 builder.Services.AddSingleton<IOptions<AdminPkcs11TelemetryOptions>>(Options.Create(telemetryOptions));
+builder.Services.AddSingleton<AdminMetrics>();
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddPrometheusExporter()
+            .AddMeter(
+                "Microsoft.AspNetCore.Hosting",
+                "Microsoft.AspNetCore.Server.Kestrel",
+                AdminMetrics.MeterName);
+    });
 builder.Services.AddDataProtection()
     .PersistKeysToFileSystem(new DirectoryInfo(AdminHostDefaults.GetKeysRoot(adminStorage.DataRoot)));
 builder.Services.AddSingleton(TimeProvider.System);
@@ -114,6 +133,9 @@ builder.Services.AddScoped<LocalAdminLoginService>();
 builder.Services.AddScoped<HsmAdminService>();
 
 var app = builder.Build();
+ObservabilityOptions observabilityOptions = app.Services.GetRequiredService<IOptions<ObservabilityOptions>>().Value;
+AdminMetrics adminMetrics = app.Services.GetRequiredService<AdminMetrics>();
+adminMetrics.RegisterSessionRegistry(app.Services.GetRequiredService<AdminSessionRegistry>());
 
 await app.Services.GetRequiredService<LocalAdminUserStore>().EnsureSeedDataAsync();
 await app.Services.GetRequiredService<AdminBootstrapDeviceSeeder>().EnsureSeedDataAsync();
@@ -154,6 +176,12 @@ app.MapGet(AdminHostDefaults.HealthReadyPath, (Delegate)AdminHealthEndpoints.Rea
     .WithDescription("Returns the storage-focused readiness payload used by container and orchestrator probes.")
     .Produces<AdminHealthResponse>(StatusCodes.Status200OK, contentType: "application/json")
     .Produces<AdminHealthResponse>(StatusCodes.Status503ServiceUnavailable, contentType: "application/json");
+
+if (observabilityOptions.EnablePrometheusScrapingEndpoint)
+{
+    app.MapPrometheusScrapingEndpoint(observabilityOptions.MetricsPath);
+}
+
 app.MapStaticAssets();
 app.MapPost("/account/login", (Delegate)AccountEndpoints.LoginAsync)
     .AllowAnonymous()

--- a/src/Pkcs11Wrapper.Admin.Web/Security/LocalAdminLoginService.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Security/LocalAdminLoginService.cs
@@ -1,11 +1,13 @@
 using Pkcs11Wrapper.Admin.Application.Services;
+using Pkcs11Wrapper.Admin.Application.Observability;
 
 namespace Pkcs11Wrapper.Admin.Web.Security;
 
 public sealed class LocalAdminLoginService(
     LocalAdminUserStore userStore,
     AuditLogService auditLog,
-    LocalAdminLoginThrottleService throttle)
+    LocalAdminLoginThrottleService throttle,
+    AdminMetrics? metrics = null)
 {
     public async Task<LocalAdminLoginResult> AttemptLoginAsync(string? userName, string? password, string? remoteIp, CancellationToken cancellationToken = default)
     {
@@ -16,6 +18,7 @@ public sealed class LocalAdminLoginService(
         {
             string details = $"Login attempt throttled until {status.LockedUntilUtc:O}.";
             await auditLog.WriteAsync("Authentication", "Login", target, "Throttled", details, actor: target, cancellationToken: cancellationToken);
+            metrics?.RecordLoginAttempt("throttled");
             return new(false, true, "locked", details, null, status.LockedUntilUtc);
         }
 
@@ -27,16 +30,21 @@ public sealed class LocalAdminLoginService(
                 ? $"Invalid credentials. Lockout active until {failureStatus.LockedUntilUtc:O}."
                 : "Invalid username or password.";
             await auditLog.WriteAsync("Authentication", "Login", target, failureStatus.IsLocked ? "Throttled" : "Failure", details, actor: target, cancellationToken: cancellationToken);
+            metrics?.RecordLoginAttempt(failureStatus.IsLocked ? "throttled" : "failure");
             return new(false, failureStatus.IsLocked, failureStatus.IsLocked ? "locked" : "invalid", details, null, failureStatus.LockedUntilUtc);
         }
 
         throttle.RecordSuccess(user.UserName, remoteIp);
         await auditLog.WriteAsync("Authentication", "Login", user.UserName, "Success", "Local admin login succeeded.", actor: user.UserName, cancellationToken: cancellationToken);
+        metrics?.RecordLoginAttempt("success");
         return new(true, false, string.Empty, "Login succeeded.", user, null);
     }
 
     public Task WriteLogoutAsync(string? userName, CancellationToken cancellationToken = default)
-        => auditLog.WriteAsync("Authentication", "Logout", NormalizeTarget(userName), "Success", "Local admin logout succeeded.", actor: NormalizeTarget(userName), cancellationToken: cancellationToken);
+    {
+        metrics?.RecordLogout("success");
+        return auditLog.WriteAsync("Authentication", "Logout", NormalizeTarget(userName), "Success", "Local admin logout succeeded.", actor: NormalizeTarget(userName), cancellationToken: cancellationToken);
+    }
 
     private static string NormalizeTarget(string? userName)
         => string.IsNullOrWhiteSpace(userName) ? "anonymous" : userName.Trim();

--- a/src/Pkcs11Wrapper.Admin.Web/appsettings.json
+++ b/src/Pkcs11Wrapper.Admin.Web/appsettings.json
@@ -12,6 +12,10 @@
     "MaxArchivedFiles": 8,
     "ExportMaxEntries": 5000
   },
+  "Observability": {
+    "EnablePrometheusScrapingEndpoint": true,
+    "MetricsPath": "/metrics"
+  },
   "CryptoApiSharedPersistence": {
     "Provider": "Postgres",
     "ConnectionString": "",

--- a/src/Pkcs11Wrapper.CryptoApi.Gateway/Health/GatewayBackendReadinessProbe.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Gateway/Health/GatewayBackendReadinessProbe.cs
@@ -1,16 +1,20 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Gateway.Configuration;
+using Pkcs11Wrapper.CryptoApi.Gateway.Observability;
 
 namespace Pkcs11Wrapper.CryptoApi.Gateway.Health;
 
 public sealed class GatewayBackendReadinessProbe(
     IHttpClientFactory httpClientFactory,
-    IOptions<CryptoApiGatewayOptions> options)
+    IOptions<CryptoApiGatewayOptions> options,
+    GatewayMetrics? metrics = null)
 {
     public const string HttpClientName = "GatewayBackendReadinessProbe";
 
     public async Task<GatewayBackendReadinessResult> ProbeAsync(CancellationToken cancellationToken)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
         CryptoApiGatewayOptions gatewayOptions = options.Value;
         List<GatewayDestinationProbeResult> destinationResults = [];
         int healthyDestinationCount = 0;
@@ -21,7 +25,7 @@ public sealed class GatewayBackendReadinessProbe(
         foreach (GatewayDestinationOptions destination in gatewayOptions.Destinations.Where(static destination => destination.Enabled))
         {
             string probeUrl = BuildProbeUrl(destination, gatewayOptions.HealthChecks.Active.Path, gatewayOptions.HealthChecks.Active.Query);
-            GatewayDestinationProbeResult result;
+            GatewayDestinationProbeResult probeResult;
 
             try
             {
@@ -32,7 +36,7 @@ public sealed class GatewayBackendReadinessProbe(
                     healthyDestinationCount++;
                 }
 
-                result = new GatewayDestinationProbeResult(
+                probeResult = new GatewayDestinationProbeResult(
                     destination.Name,
                     destination.Address,
                     probeUrl,
@@ -42,7 +46,7 @@ public sealed class GatewayBackendReadinessProbe(
             }
             catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
             {
-                result = new GatewayDestinationProbeResult(
+                probeResult = new GatewayDestinationProbeResult(
                     destination.Name,
                     destination.Address,
                     probeUrl,
@@ -51,10 +55,10 @@ public sealed class GatewayBackendReadinessProbe(
                     ex.Message);
             }
 
-            destinationResults.Add(result);
+            destinationResults.Add(probeResult);
         }
 
-        return new GatewayBackendReadinessResult(
+        GatewayBackendReadinessResult result = new(
             gatewayOptions.ServiceName,
             gatewayOptions.ClusterId,
             healthyDestinationCount > 0,
@@ -62,6 +66,9 @@ public sealed class GatewayBackendReadinessProbe(
             destinationResults.Count,
             destinationResults,
             DateTimeOffset.UtcNow);
+
+        metrics?.RecordBackendReadinessProbe(result, stopwatch.Elapsed);
+        return result;
     }
 
     private static string BuildProbeUrl(GatewayDestinationOptions destination, string healthPath, string? query)

--- a/src/Pkcs11Wrapper.CryptoApi.Gateway/Observability/GatewayMetrics.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Gateway/Observability/GatewayMetrics.cs
@@ -1,0 +1,80 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Pkcs11Wrapper.CryptoApi.Gateway.Health;
+
+namespace Pkcs11Wrapper.CryptoApi.Gateway.Observability;
+
+public sealed class GatewayMetrics : IDisposable
+{
+    public const string MeterName = "Pkcs11Wrapper.CryptoApi.Gateway";
+
+    private readonly Meter _meter = new(MeterName);
+    private readonly Counter<long> _backendReadinessProbes;
+    private readonly Histogram<double> _backendReadinessProbeDuration;
+    private readonly Counter<long> _requestBodyRejections;
+    private readonly ObservableGauge<int> _healthyDestinations;
+    private readonly ObservableGauge<int> _configuredDestinations;
+    private GatewayBackendReadinessResult? _lastReadinessResult;
+
+    public GatewayMetrics()
+    {
+        _backendReadinessProbes = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_gateway_backend_readiness_probes_total");
+        _backendReadinessProbeDuration = _meter.CreateHistogram<double>("pkcs11wrapper_crypto_api_gateway_backend_readiness_probe_duration_seconds", unit: "s");
+        _requestBodyRejections = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_gateway_request_body_rejections_total");
+        _healthyDestinations = _meter.CreateObservableGauge<int>("pkcs11wrapper_crypto_api_gateway_healthy_destinations", ObserveHealthyDestinations);
+        _configuredDestinations = _meter.CreateObservableGauge<int>("pkcs11wrapper_crypto_api_gateway_configured_destinations", ObserveConfiguredDestinations);
+    }
+
+    public void RecordBackendReadinessProbe(GatewayBackendReadinessResult result, TimeSpan duration)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        _lastReadinessResult = result;
+        TagList tags = CreateTags(
+            ("result", result.Ready ? "ready" : "not_ready"),
+            ("cluster", result.ClusterId));
+        _backendReadinessProbes.Add(1, tags);
+        _backendReadinessProbeDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordRequestBodyRejected(long maxRequestBodySizeBytes)
+        => _requestBodyRejections.Add(1, CreateTags(("max_request_body_size_bytes", maxRequestBodySizeBytes.ToString(System.Globalization.CultureInfo.InvariantCulture))));
+
+    public void Dispose() => _meter.Dispose();
+
+    private IEnumerable<Measurement<int>> ObserveHealthyDestinations()
+    {
+        GatewayBackendReadinessResult? result = _lastReadinessResult;
+        if (result is null)
+        {
+            return [];
+        }
+
+        return [new Measurement<int>(result.HealthyDestinationCount, CreateTags(("cluster", result.ClusterId)))];
+    }
+
+    private IEnumerable<Measurement<int>> ObserveConfiguredDestinations()
+    {
+        GatewayBackendReadinessResult? result = _lastReadinessResult;
+        if (result is null)
+        {
+            return [];
+        }
+
+        return [new Measurement<int>(result.ConfiguredDestinationCount, CreateTags(("cluster", result.ClusterId)))];
+    }
+
+    private static TagList CreateTags(params (string Key, string? Value)[] pairs)
+    {
+        TagList tags = new();
+        foreach ((string key, string? value) in pairs)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                tags.Add(key, value);
+            }
+        }
+
+        return tags;
+    }
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Gateway/Pkcs11Wrapper.CryptoApi.Gateway.csproj
+++ b/src/Pkcs11Wrapper.CryptoApi.Gateway/Pkcs11Wrapper.CryptoApi.Gateway.csproj
@@ -12,7 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
+    <ProjectReference Include="..\Pkcs11Wrapper.CryptoApi.Shared\Pkcs11Wrapper.CryptoApi.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Pkcs11Wrapper.CryptoApi.Gateway/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Gateway/Program.cs
@@ -1,8 +1,11 @@
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Metrics;
 using Pkcs11Wrapper.CryptoApi.Gateway.Configuration;
 using Pkcs11Wrapper.CryptoApi.Gateway.Health;
+using Pkcs11Wrapper.CryptoApi.Gateway.Observability;
 using Pkcs11Wrapper.CryptoApi.Gateway.Runtime;
+using Pkcs11Wrapper.Observability;
 using Yarp.ReverseProxy.Transforms;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -15,7 +18,26 @@ builder.Services.AddOptions<CryptoApiGatewayOptions>()
 builder.Services.AddOptions<CryptoApiGatewayOptions>()
     .ValidateOnStart();
 
+builder.Services.AddOptions<ObservabilityOptions>()
+    .Bind(builder.Configuration.GetSection(ObservabilityOptions.SectionName))
+    .PostConfigure(ObservabilityOptions.Normalize)
+    .Validate(static options => options.MetricsPath.StartsWith("/", StringComparison.Ordinal), "Observability metrics path must start with '/'.")
+    .ValidateOnStart();
+
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<GatewayMetrics>();
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddPrometheusExporter()
+            .AddMeter(
+                "Microsoft.AspNetCore.Hosting",
+                "Microsoft.AspNetCore.Server.Kestrel",
+                "System.Net.Http",
+                "Yarp.ReverseProxy",
+                GatewayMetrics.MeterName);
+    });
 builder.Services.AddHttpClient(GatewayBackendReadinessProbe.HttpClientName);
 builder.Services.AddSingleton<CryptoApiGatewayRuntimeDescriptorProvider>();
 builder.Services.AddSingleton<GatewayBackendReadinessProbe>();
@@ -34,8 +56,10 @@ builder.Services.AddSingleton<Yarp.ReverseProxy.Configuration.IProxyConfigProvid
 
 WebApplication app = builder.Build();
 CryptoApiGatewayOptions gatewayOptions = app.Services.GetRequiredService<IOptions<CryptoApiGatewayOptions>>().Value;
+ObservabilityOptions observabilityOptions = app.Services.GetRequiredService<IOptions<ObservabilityOptions>>().Value;
 CryptoApiGatewayRuntimeDescriptorProvider descriptorProvider = app.Services.GetRequiredService<CryptoApiGatewayRuntimeDescriptorProvider>();
 GatewayBackendReadinessProbe readinessProbe = app.Services.GetRequiredService<GatewayBackendReadinessProbe>();
+GatewayMetrics gatewayMetrics = app.Services.GetRequiredService<GatewayMetrics>();
 
 if (!app.Environment.IsDevelopment())
 {
@@ -80,6 +104,7 @@ app.Use(async (context, next) =>
 
         if (context.Request.ContentLength is long contentLength && contentLength > maxRequestBodySize)
         {
+            gatewayMetrics.RecordRequestBodyRejected(maxRequestBodySize);
             context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
             await context.Response.WriteAsJsonAsync(new
             {
@@ -95,7 +120,27 @@ app.Use(async (context, next) =>
     await next(context);
 });
 
-app.MapGet("/", () => Results.Ok(descriptorProvider.Describe()));
+app.MapGet("/", () =>
+{
+    CryptoApiGatewayRuntimeDescriptor descriptor = descriptorProvider.Describe();
+    return Results.Ok(new
+    {
+        descriptor.ServiceName,
+        descriptor.InstanceId,
+        descriptor.ClusterId,
+        descriptor.ApiBasePath,
+        descriptor.DeploymentModel,
+        descriptor.LoadBalancingPolicy,
+        descriptor.CorrelationIdHeaderName,
+        descriptor.MaxRequestBodySizeBytes,
+        descriptor.ActiveHealthChecksEnabled,
+        descriptor.ConfiguredDestinationCount,
+        descriptor.StartedAtUtc,
+        descriptor.CurrentSurface,
+        descriptor.Notes,
+        Metrics = observabilityOptions.EnablePrometheusScrapingEndpoint ? observabilityOptions.MetricsPath : null
+    });
+});
 app.MapGet(CryptoApiGatewayDefaults.RuntimePath, () => Results.Ok(descriptorProvider.Describe()));
 app.MapGet(CryptoApiGatewayDefaults.HealthLivePath, () => Results.Ok(new
 {
@@ -120,6 +165,11 @@ app.MapGet(CryptoApiGatewayDefaults.HealthReadyPath, async (CancellationToken ca
 });
 
 app.MapReverseProxy();
+
+if (observabilityOptions.EnablePrometheusScrapingEndpoint)
+{
+    app.MapPrometheusScrapingEndpoint(observabilityOptions.MetricsPath);
+}
 
 app.Run();
 

--- a/src/Pkcs11Wrapper.CryptoApi.Gateway/appsettings.json
+++ b/src/Pkcs11Wrapper.CryptoApi.Gateway/appsettings.json
@@ -26,5 +26,9 @@
         "Path": "/health/ready"
       }
     }
+  },
+  "Observability": {
+    "EnablePrometheusScrapingEndpoint": true,
+    "MetricsPath": "/metrics"
   }
 }

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyOperationAuthorizationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Access/CryptoApiKeyOperationAuthorizationService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Clients;
+using Pkcs11Wrapper.CryptoApi.Observability;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
 namespace Pkcs11Wrapper.CryptoApi.Access;
@@ -13,6 +14,7 @@ public sealed class CryptoApiKeyOperationAuthorizationService
     private readonly CryptoApiClientSecretHasher _secretHasher;
     private readonly CryptoApiRequestPathCache _requestPathCache;
     private readonly ICryptoApiRouteRegistry _routeRegistry;
+    private readonly CryptoApiMetrics? _metrics;
 
     public CryptoApiKeyOperationAuthorizationService(
         ICryptoApiSharedStateStore sharedStateStore,
@@ -20,7 +22,8 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         TimeProvider timeProvider,
         CryptoApiClientSecretHasher? secretHasher = null,
         CryptoApiRequestPathCache? requestPathCache = null,
-        ICryptoApiRouteRegistry? routeRegistry = null)
+        ICryptoApiRouteRegistry? routeRegistry = null,
+        CryptoApiMetrics? metrics = null)
     {
         _sharedStateStore = sharedStateStore;
         _distributedHotPathCache = distributedHotPathCache;
@@ -28,6 +31,7 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         _secretHasher = secretHasher ?? new CryptoApiClientSecretHasher();
         _requestPathCache = requestPathCache ?? new CryptoApiRequestPathCache(timeProvider);
         _routeRegistry = routeRegistry ?? new CryptoApiLegacyRouteRegistry();
+        _metrics = metrics;
     }
 
     public async Task<CryptoApiRequestAuthorizationResult> AuthorizeRequestAsync(
@@ -39,6 +43,7 @@ public sealed class CryptoApiKeyOperationAuthorizationService
     {
         if (string.IsNullOrWhiteSpace(keyIdentifier) || string.IsNullOrWhiteSpace(secret))
         {
+            _metrics?.RecordAuthorizationResult("missing_credentials", "input_validation");
             return AuthenticationFailed("API key id and secret are required.");
         }
 
@@ -50,6 +55,7 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         long authStateRevision = await _sharedStateStore.GetAuthStateRevisionAsync(cancellationToken);
         if (authStateRevision <= 0)
         {
+            _metrics?.RecordAuthorizationResult("shared_state_unconfigured", "shared_state");
             return AuthenticationFailed("Shared persistence is not configured.");
         }
 
@@ -57,24 +63,49 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         string secretFingerprint = _requestPathCache.CreateSecretFingerprint(normalizedSecret);
         CryptoApiAuthenticatedClient authenticatedClient;
 
+        bool cacheEnabled = _requestPathCache.Enabled;
+        if (!cacheEnabled)
+        {
+            _metrics?.RecordRequestPathCacheLookup("authentication", "memory", "disabled");
+        }
+
         if (_requestPathCache.TryGetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now, out CryptoApiAuthenticatedClient cachedClient))
         {
+            _metrics?.RecordRequestPathCacheLookup("authentication", "memory", "hit");
             authenticatedClient = cachedClient;
         }
         else
         {
+            if (cacheEnabled)
+            {
+                _metrics?.RecordRequestPathCacheLookup("authentication", "memory", "miss");
+            }
+
             CryptoApiAuthenticatedClient? resolvedClient = await AuthenticateClientAsync(authStateRevision, normalizedKeyIdentifier, normalizedSecret, secretFingerprint, now, cancellationToken);
             if (resolvedClient is null)
             {
+                _metrics?.RecordAuthorizationResult("authentication_failed", "shared_state");
                 return AuthenticationFailed("API key id or secret is invalid.");
             }
 
             authenticatedClient = resolvedClient;
         }
 
+        if (!cacheEnabled)
+        {
+            _metrics?.RecordRequestPathCacheLookup("authorization", "memory", "disabled");
+        }
+
         if (_requestPathCache.TryGetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, normalizedAliasName, normalizedOperation, authenticatedClient, now, out CryptoApiAuthorizedKeyOperation cachedAuthorization))
         {
+            _metrics?.RecordRequestPathCacheLookup("authorization", "memory", "hit");
+            _metrics?.RecordAuthorizationResult("success", "memory_cache");
             return Success(cachedAuthorization);
+        }
+
+        if (cacheEnabled)
+        {
+            _metrics?.RecordRequestPathCacheLookup("authorization", "memory", "miss");
         }
 
         CryptoApiAuthorizedKeyOperation? distributedAuthorization = await _distributedHotPathCache.GetAuthorizedOperationAsync(
@@ -89,12 +120,14 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         if (distributedAuthorization is not null)
         {
             _requestPathCache.SetAuthorizedOperation(authStateRevision, authenticatedClient.ClientId, distributedAuthorization);
+            _metrics?.RecordAuthorizationResult("success", "redis_cache");
             return Success(distributedAuthorization);
         }
 
         CryptoApiKeyOperationAuthorizationResult authorization = await AuthorizeKeyOperationAsync(authenticatedClient, normalizedAliasName, normalizedOperation, cancellationToken);
         if (!authorization.Succeeded || authorization.Authorization is null)
         {
+            _metrics?.RecordAuthorizationResult("denied", "shared_state");
             return AuthorizationFailed(authorization.FailureReason ?? "Authorization failed.");
         }
 
@@ -104,6 +137,7 @@ public sealed class CryptoApiKeyOperationAuthorizationService
             authenticatedClient.ClientId,
             authorization.Authorization,
             cancellationToken);
+        _metrics?.RecordAuthorizationResult("success", "shared_state");
 
         return Success(authorization.Authorization);
     }
@@ -196,10 +230,15 @@ public sealed class CryptoApiKeyOperationAuthorizationService
         bool? leaseAcquired = await _distributedHotPathCache.TryAcquireLastUsedRefreshLeaseAsync(clientKeyId, now, minimumInterval, cancellationToken);
         if (leaseAcquired == false)
         {
+            _metrics?.RecordLastUsedRefreshEvent("authorization", "lease", "denied");
             return false;
         }
 
-        return await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, minimumInterval, cancellationToken);
+        _metrics?.RecordLastUsedRefreshEvent("authorization", "lease", leaseAcquired is true ? "acquired" : "unavailable");
+
+        bool updated = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, minimumInterval, cancellationToken);
+        _metrics?.RecordLastUsedRefreshEvent("authorization", "shared_state", updated ? "applied" : "skipped");
+        return updated;
     }
 
     public async Task<CryptoApiKeyOperationAuthorizationResult> AuthorizeKeyOperationAsync(

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/CryptoApiRequestPathCache.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/CryptoApiRequestPathCache.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Observability;
 
 namespace Pkcs11Wrapper.CryptoApi.Caching;
 
@@ -30,6 +31,14 @@ public sealed class CryptoApiRequestPathCache : IDisposable
 
     public TimeSpan LastUsedWriteInterval
         => _options.LastUsedWriteInterval;
+
+    public CryptoApiRequestPathCacheMetricsSnapshot GetMetricsSnapshot()
+        => new(
+            Enabled,
+            _authenticationCache.Count,
+            Math.Max(1, _options.AuthenticationEntryLimit),
+            _authorizationCache.Count,
+            Math.Max(1, _options.AuthorizationEntryLimit));
 
     public string CreateSecretFingerprint(string normalizedSecret)
     {

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/RedisCryptoApiDistributedHotPathCache.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Caching/RedisCryptoApiDistributedHotPathCache.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -6,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Observability;
 using StackExchange.Redis;
 
 namespace Pkcs11Wrapper.CryptoApi.Caching;
@@ -19,6 +21,7 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
     private readonly CryptoApiRequestPathCachingOptions _options;
     private readonly CryptoApiRequestPathRedisOptions _redisOptions;
     private readonly SemaphoreSlim _connectionGate = new(1, 1);
+    private readonly CryptoApiMetrics? _metrics;
 
     private IConnectionMultiplexer? _connection;
     private DateTimeOffset _nextConnectAttemptUtc;
@@ -26,12 +29,14 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
     public RedisCryptoApiDistributedHotPathCache(
         IOptions<CryptoApiRequestPathCachingOptions> options,
         TimeProvider timeProvider,
-        ILogger<RedisCryptoApiDistributedHotPathCache> logger)
+        ILogger<RedisCryptoApiDistributedHotPathCache> logger,
+        CryptoApiMetrics? metrics = null)
     {
         _timeProvider = timeProvider;
         _logger = logger;
         _options = options.Value;
         _redisOptions = _options.Redis ?? new CryptoApiRequestPathRedisOptions();
+        _metrics = metrics;
     }
 
     public bool Enabled
@@ -39,9 +44,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
 
     public async Task<long?> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "miss";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("get_auth_state_revision", "unavailable", stopwatch.Elapsed);
             return null;
         }
 
@@ -49,14 +57,24 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         {
             RedisValue value = await database.StringGetAsync(GetAuthStateRevisionKey()).WaitAsync(cancellationToken);
             string? text = value.IsNullOrEmpty ? null : value.ToString();
-            return string.IsNullOrWhiteSpace(text) || !long.TryParse(text, out long parsed)
-                ? null
-                : parsed;
+            if (string.IsNullOrWhiteSpace(text) || !long.TryParse(text, out long parsed))
+            {
+                result = "miss";
+                return null;
+            }
+
+            result = "hit";
+            return parsed;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "read auth-state revision");
             return null;
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("get_auth_state_revision", result, stopwatch.Elapsed);
         }
     }
 
@@ -67,9 +85,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
             return;
         }
 
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("set_auth_state_revision", "unavailable", stopwatch.Elapsed);
             return;
         }
 
@@ -83,7 +104,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "write auth-state revision");
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("set_auth_state_revision", result, stopwatch.Elapsed);
         }
     }
 
@@ -94,9 +120,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         DateTimeOffset now,
         CancellationToken cancellationToken = default)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "miss";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("get_authenticated_client", "unavailable", stopwatch.Elapsed);
             return null;
         }
 
@@ -105,26 +134,35 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
             RedisValue value = await database.StringGetAsync(GetAuthenticationKey(authStateRevision, keyIdentifier, secretFingerprint)).WaitAsync(cancellationToken);
             if (value.IsNullOrEmpty)
             {
+                result = "miss";
                 return null;
             }
 
             CryptoApiAuthenticatedClient? cached = JsonSerializer.Deserialize<CryptoApiAuthenticatedClient>(value.ToString()!, SerializerOptions);
             if (cached is null)
             {
+                result = "miss";
                 return null;
             }
 
             if (cached.ExpiresAtUtc is DateTimeOffset expiresAtUtc && expiresAtUtc <= now)
             {
+                result = "expired";
                 return null;
             }
 
+            result = "hit";
             return cached with { AuthenticatedAtUtc = now };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "read distributed authenticated-client entry");
             return null;
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("get_authenticated_client", result, stopwatch.Elapsed);
         }
     }
 
@@ -137,9 +175,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
     {
         ArgumentNullException.ThrowIfNull(authenticatedClient);
 
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("set_authenticated_client", "unavailable", stopwatch.Elapsed);
             return;
         }
 
@@ -153,7 +194,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "write distributed authenticated-client entry");
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("set_authenticated_client", result, stopwatch.Elapsed);
         }
     }
 
@@ -168,9 +214,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
     {
         ArgumentNullException.ThrowIfNull(client);
 
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "miss";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("get_authorized_operation", "unavailable", stopwatch.Elapsed);
             return null;
         }
 
@@ -179,15 +228,18 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
             RedisValue value = await database.StringGetAsync(GetAuthorizationKey(authStateRevision, clientId, aliasName, operation)).WaitAsync(cancellationToken);
             if (value.IsNullOrEmpty)
             {
+                result = "miss";
                 return null;
             }
 
             AuthorizationCachePayload? payload = JsonSerializer.Deserialize<AuthorizationCachePayload>(value.ToString()!, SerializerOptions);
             if (payload is null)
             {
+                result = "miss";
                 return null;
             }
 
+            result = "hit";
             return new CryptoApiAuthorizedKeyOperation(
                 Client: client,
                 Operation: payload.Operation,
@@ -199,8 +251,13 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "read distributed authorization entry");
             return null;
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("get_authorized_operation", result, stopwatch.Elapsed);
         }
     }
 
@@ -212,9 +269,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
     {
         ArgumentNullException.ThrowIfNull(authorization);
 
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("set_authorized_operation", "unavailable", stopwatch.Elapsed);
             return;
         }
 
@@ -235,7 +295,12 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "write distributed authorization entry");
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("set_authorized_operation", result, stopwatch.Elapsed);
         }
     }
 
@@ -245,25 +310,35 @@ public sealed class RedisCryptoApiDistributedHotPathCache : ICryptoApiDistribute
         TimeSpan minimumInterval,
         CancellationToken cancellationToken = default)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "unavailable";
         IDatabase? database = await TryGetDatabaseAsync(cancellationToken);
         if (database is null)
         {
+            _metrics?.RecordDistributedCacheRequest("acquire_last_used_refresh_lease", "unavailable", stopwatch.Elapsed);
             return null;
         }
 
         try
         {
-            return await database.StringSetAsync(
+            bool acquired = await database.StringSetAsync(
                     GetLastUsedLeaseKey(clientKeyId),
                     now.ToUnixTimeMilliseconds().ToString(System.Globalization.CultureInfo.InvariantCulture),
                     minimumInterval,
                     when: When.NotExists)
                 .WaitAsync(cancellationToken);
+            result = acquired ? "acquired" : "denied";
+            return acquired;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            result = "error";
             LogRedisFailure(ex, "acquire last-used refresh lease");
             return null;
+        }
+        finally
+        {
+            _metrics?.RecordDistributedCacheRequest("acquire_last_used_refresh_lease", result, stopwatch.Elapsed);
         }
     }
 

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Clients/CryptoApiClientAuthenticationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Clients/CryptoApiClientAuthenticationService.cs
@@ -1,4 +1,5 @@
 using Pkcs11Wrapper.CryptoApi.Caching;
+using Pkcs11Wrapper.CryptoApi.Observability;
 using Pkcs11Wrapper.CryptoApi.SharedState;
 
 namespace Pkcs11Wrapper.CryptoApi.Clients;
@@ -10,25 +11,29 @@ public sealed class CryptoApiClientAuthenticationService
     private readonly CryptoApiClientSecretHasher _secretHasher;
     private readonly TimeProvider _timeProvider;
     private readonly CryptoApiRequestPathCache _requestPathCache;
+    private readonly CryptoApiMetrics? _metrics;
 
     public CryptoApiClientAuthenticationService(
         ICryptoApiSharedStateStore sharedStateStore,
         ICryptoApiDistributedHotPathCache distributedHotPathCache,
         CryptoApiClientSecretHasher secretHasher,
         TimeProvider timeProvider,
-        CryptoApiRequestPathCache? requestPathCache = null)
+        CryptoApiRequestPathCache? requestPathCache = null,
+        CryptoApiMetrics? metrics = null)
     {
         _sharedStateStore = sharedStateStore;
         _distributedHotPathCache = distributedHotPathCache;
         _secretHasher = secretHasher;
         _timeProvider = timeProvider;
         _requestPathCache = requestPathCache ?? new CryptoApiRequestPathCache(timeProvider);
+        _metrics = metrics;
     }
 
     public async Task<CryptoApiClientAuthenticationResult> AuthenticateAsync(string? keyIdentifier, string? secret, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(keyIdentifier) || string.IsNullOrWhiteSpace(secret))
         {
+            _metrics?.RecordAuthenticationResult("missing_credentials", "input_validation");
             return Failed("API key id and secret are required.");
         }
 
@@ -38,18 +43,32 @@ public sealed class CryptoApiClientAuthenticationService
         long authStateRevision = await _sharedStateStore.GetAuthStateRevisionAsync(cancellationToken);
         if (authStateRevision <= 0)
         {
+            _metrics?.RecordAuthenticationResult("shared_state_unconfigured", "shared_state");
             return Failed("Shared persistence is not configured.");
         }
 
         DateTimeOffset now = _timeProvider.GetUtcNow();
         string secretFingerprint = _requestPathCache.CreateSecretFingerprint(normalizedSecret);
+        bool cacheEnabled = _requestPathCache.Enabled;
+        if (!cacheEnabled)
+        {
+            _metrics?.RecordRequestPathCacheLookup("authentication", "memory", "disabled");
+        }
+
         if (_requestPathCache.TryGetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now, out CryptoApiAuthenticatedClient cachedClient))
         {
+            _metrics?.RecordRequestPathCacheLookup("authentication", "memory", "hit");
             await RefreshLastUsedIfNeededAsync(authStateRevision, cachedClient.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+            _metrics?.RecordAuthenticationResult("success", "memory_cache");
             return new CryptoApiClientAuthenticationResult(
                 Succeeded: true,
                 FailureReason: null,
                 Client: cachedClient);
+        }
+
+        if (cacheEnabled)
+        {
+            _metrics?.RecordRequestPathCacheLookup("authentication", "memory", "miss");
         }
 
         CryptoApiAuthenticatedClient? distributedClient = await _distributedHotPathCache.GetAuthenticatedClientAsync(
@@ -62,6 +81,7 @@ public sealed class CryptoApiClientAuthenticationService
         {
             _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, distributedClient, now);
             await RefreshLastUsedIfNeededAsync(authStateRevision, distributedClient.ClientKeyId, normalizedKeyIdentifier, secretFingerprint, now, cancellationToken);
+            _metrics?.RecordAuthenticationResult("success", "redis_cache");
             return new CryptoApiClientAuthenticationResult(
                 Succeeded: true,
                 FailureReason: null,
@@ -71,6 +91,7 @@ public sealed class CryptoApiClientAuthenticationService
         CryptoApiClientAuthenticationState? authenticationState = await _sharedStateStore.GetClientAuthenticationStateAsync(normalizedKeyIdentifier, cancellationToken);
         if (authenticationState is null)
         {
+            _metrics?.RecordAuthenticationResult("key_not_found", "shared_state");
             return Failed("API key was not found.");
         }
 
@@ -79,26 +100,31 @@ public sealed class CryptoApiClientAuthenticationService
 
         if (!client.IsEnabled)
         {
+            _metrics?.RecordAuthenticationResult("client_disabled", "shared_state");
             return Failed("API client is disabled.");
         }
 
         if (key.RevokedAtUtc is not null)
         {
+            _metrics?.RecordAuthenticationResult("key_revoked", "shared_state");
             return Failed("API key has been revoked.");
         }
 
         if (!key.IsEnabled)
         {
+            _metrics?.RecordAuthenticationResult("key_disabled", "shared_state");
             return Failed("API key is disabled.");
         }
 
         if (key.ExpiresAtUtc is DateTimeOffset expiresAtUtc && expiresAtUtc <= now)
         {
+            _metrics?.RecordAuthenticationResult("key_expired", "shared_state");
             return Failed("API key has expired.");
         }
 
         if (!_secretHasher.VerifySecret(normalizedSecret, key.SecretHash))
         {
+            _metrics?.RecordAuthenticationResult("secret_invalid", "shared_state");
             return Failed("API key secret is invalid.");
         }
 
@@ -119,6 +145,7 @@ public sealed class CryptoApiClientAuthenticationService
 
         _requestPathCache.SetAuthenticatedClient(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, now);
         await _distributedHotPathCache.SetAuthenticatedClientAsync(authStateRevision, normalizedKeyIdentifier, secretFingerprint, authenticatedClient, cancellationToken);
+        _metrics?.RecordAuthenticationResult("success", "shared_state");
 
         return new CryptoApiClientAuthenticationResult(
             Succeeded: true,
@@ -151,6 +178,7 @@ public sealed class CryptoApiClientAuthenticationService
 
         if (!shouldRefresh)
         {
+            _metrics?.RecordLastUsedRefreshEvent("authentication", "decision", "not_needed");
             return;
         }
 
@@ -160,11 +188,15 @@ public sealed class CryptoApiClientAuthenticationService
             if (leaseAcquired is false)
             {
                 _requestPathCache.RecordLastUsedRefresh(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
+                _metrics?.RecordLastUsedRefreshEvent("authentication", "lease", "denied");
                 return;
             }
+
+            _metrics?.RecordLastUsedRefreshEvent("authentication", "lease", leaseAcquired is true ? "acquired" : "unavailable");
         }
 
-        _ = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, minimumInterval, cancellationToken);
+        bool updated = await _sharedStateStore.TryTouchClientKeyLastUsedAsync(clientKeyId, now, minimumInterval, cancellationToken);
+        _metrics?.RecordLastUsedRefreshEvent("authentication", "shared_state", updated ? "applied" : "skipped");
         _requestPathCache.RecordLastUsedRefresh(authStateRevision, normalizedKeyIdentifier, secretFingerprint, now);
     }
     private static CryptoApiClientAuthenticationResult Failed(string reason)

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Observability/CryptoApiMetrics.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Observability/CryptoApiMetrics.cs
@@ -1,0 +1,271 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Pkcs11Wrapper.CryptoApi.Caching;
+
+namespace Pkcs11Wrapper.CryptoApi.Observability;
+
+public interface ICryptoApiSharedStateMetricsSource
+{
+    CryptoApiSharedStateMetricsSnapshot GetMetricsSnapshot();
+}
+
+public interface ICryptoApiPkcs11RuntimeMetricsSource
+{
+    IReadOnlyList<CryptoApiPkcs11SessionPoolMetricsSnapshot> GetSessionPoolMetricsSnapshots();
+}
+
+public sealed record CryptoApiRequestPathCacheMetricsSnapshot(
+    bool Enabled,
+    int AuthenticationEntryCount,
+    int AuthenticationEntryLimit,
+    int AuthorizationEntryCount,
+    int AuthorizationEntryLimit);
+
+public sealed record CryptoApiSharedStateMetricsSnapshot(
+    bool Configured,
+    string Provider,
+    int EffectiveMaxPoolSize);
+
+public sealed record CryptoApiPkcs11SessionPoolMetricsSnapshot(
+    string Backend,
+    ulong SlotId,
+    int IdleSessions,
+    int InUseSessions,
+    int MaxRetainedSessions);
+
+public sealed class CryptoApiMetrics : IDisposable
+{
+    public const string MeterName = "Pkcs11Wrapper.CryptoApi";
+
+    private readonly Meter _meter = new(MeterName);
+    private readonly Counter<long> _authenticationResults;
+    private readonly Counter<long> _authorizationResults;
+    private readonly Counter<long> _requestPathCacheLookups;
+    private readonly Counter<long> _distributedCacheRequests;
+    private readonly Histogram<double> _distributedCacheRequestDuration;
+    private readonly Counter<long> _sharedStateRequests;
+    private readonly Histogram<double> _sharedStateRequestDuration;
+    private readonly Counter<long> _sharedStateDatabaseReads;
+    private readonly Counter<long> _lastUsedRefreshEvents;
+    private readonly Counter<long> _rateLimitRejections;
+    private readonly Counter<long> _pkcs11Operations;
+    private readonly Histogram<double> _pkcs11OperationDuration;
+    private readonly Counter<long> _pkcs11SessionLeases;
+    private readonly Counter<long> _pkcs11SessionReturns;
+    private readonly ObservableGauge<int> _authenticationCacheEntries;
+    private readonly ObservableGauge<double> _authenticationCacheUtilization;
+    private readonly ObservableGauge<int> _authorizationCacheEntries;
+    private readonly ObservableGauge<double> _authorizationCacheUtilization;
+    private readonly ObservableGauge<int> _sharedStatePoolMaxConnections;
+    private readonly ObservableGauge<int> _pkcs11SessionsIdle;
+    private readonly ObservableGauge<int> _pkcs11SessionsInUse;
+    private readonly ObservableGauge<int> _pkcs11SessionsMaxRetained;
+
+    private CryptoApiRequestPathCache? _requestPathCache;
+    private ICryptoApiSharedStateMetricsSource? _sharedStateMetricsSource;
+    private ICryptoApiPkcs11RuntimeMetricsSource? _pkcs11RuntimeMetricsSource;
+
+    public CryptoApiMetrics()
+    {
+        _authenticationResults = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_authentication_results_total");
+        _authorizationResults = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_authorization_results_total");
+        _requestPathCacheLookups = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_request_path_cache_lookups_total");
+        _distributedCacheRequests = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_distributed_cache_requests_total");
+        _distributedCacheRequestDuration = _meter.CreateHistogram<double>("pkcs11wrapper_crypto_api_distributed_cache_request_duration_seconds", unit: "s");
+        _sharedStateRequests = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_shared_state_requests_total");
+        _sharedStateRequestDuration = _meter.CreateHistogram<double>("pkcs11wrapper_crypto_api_shared_state_request_duration_seconds", unit: "s");
+        _sharedStateDatabaseReads = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_shared_state_database_reads_total");
+        _lastUsedRefreshEvents = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_last_used_refresh_events_total");
+        _rateLimitRejections = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_rate_limit_rejections_total");
+        _pkcs11Operations = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_pkcs11_operations_total");
+        _pkcs11OperationDuration = _meter.CreateHistogram<double>("pkcs11wrapper_crypto_api_pkcs11_operation_duration_seconds", unit: "s");
+        _pkcs11SessionLeases = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_pkcs11_session_leases_total");
+        _pkcs11SessionReturns = _meter.CreateCounter<long>("pkcs11wrapper_crypto_api_pkcs11_session_returns_total");
+
+        _authenticationCacheEntries = _meter.CreateObservableGauge<int>(
+            "pkcs11wrapper_crypto_api_authentication_cache_entries",
+            ObserveAuthenticationCacheEntries);
+        _authenticationCacheUtilization = _meter.CreateObservableGauge<double>(
+            "pkcs11wrapper_crypto_api_authentication_cache_utilization_ratio",
+            ObserveAuthenticationCacheUtilization);
+        _authorizationCacheEntries = _meter.CreateObservableGauge<int>(
+            "pkcs11wrapper_crypto_api_authorization_cache_entries",
+            ObserveAuthorizationCacheEntries);
+        _authorizationCacheUtilization = _meter.CreateObservableGauge<double>(
+            "pkcs11wrapper_crypto_api_authorization_cache_utilization_ratio",
+            ObserveAuthorizationCacheUtilization);
+        _sharedStatePoolMaxConnections = _meter.CreateObservableGauge<int>(
+            "pkcs11wrapper_crypto_api_shared_state_pool_max_connections",
+            ObserveSharedStatePoolMaxConnections);
+        _pkcs11SessionsIdle = _meter.CreateObservableGauge<int>(
+            "pkcs11wrapper_crypto_api_pkcs11_sessions_idle",
+            ObservePkcs11IdleSessions);
+        _pkcs11SessionsInUse = _meter.CreateObservableGauge<int>(
+            "pkcs11wrapper_crypto_api_pkcs11_sessions_in_use",
+            ObservePkcs11InUseSessions);
+        _pkcs11SessionsMaxRetained = _meter.CreateObservableGauge<int>(
+            "pkcs11wrapper_crypto_api_pkcs11_sessions_max_retained",
+            ObservePkcs11MaxRetainedSessions);
+    }
+
+    public void RegisterRequestPathCache(CryptoApiRequestPathCache requestPathCache)
+        => _requestPathCache = requestPathCache;
+
+    public void RegisterSharedStateSource(ICryptoApiSharedStateMetricsSource sharedStateMetricsSource)
+        => _sharedStateMetricsSource = sharedStateMetricsSource;
+
+    public void RegisterRuntimeSource(ICryptoApiPkcs11RuntimeMetricsSource runtimeMetricsSource)
+        => _pkcs11RuntimeMetricsSource = runtimeMetricsSource;
+
+    public void RecordAuthenticationResult(string result, string source)
+        => _authenticationResults.Add(1, CreateTags(("result", result), ("source", source)));
+
+    public void RecordAuthorizationResult(string result, string source)
+        => _authorizationResults.Add(1, CreateTags(("result", result), ("source", source)));
+
+    public void RecordRequestPathCacheLookup(string cache, string layer, string result)
+        => _requestPathCacheLookups.Add(1, CreateTags(("cache", cache), ("layer", layer), ("result", result)));
+
+    public void RecordDistributedCacheRequest(string operation, string result, TimeSpan duration)
+    {
+        TagList tags = CreateTags(("operation", operation), ("result", result));
+        _distributedCacheRequests.Add(1, tags);
+        _distributedCacheRequestDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordSharedStateRequest(string operation, string result, TimeSpan duration)
+    {
+        TagList tags = CreateTags(("operation", operation), ("result", result));
+        _sharedStateRequests.Add(1, tags);
+        _sharedStateRequestDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordSharedStateDatabaseRead(string operation)
+        => _sharedStateDatabaseReads.Add(1, CreateTags(("operation", operation)));
+
+    public void RecordLastUsedRefreshEvent(string path, string stage, string result)
+        => _lastUsedRefreshEvents.Add(1, CreateTags(("path", path), ("stage", stage), ("result", result)));
+
+    public void RecordRateLimitRejection(string scope)
+        => _rateLimitRejections.Add(1, CreateTags(("scope", scope)));
+
+    public void RecordPkcs11Operation(string operation, string algorithm, string backend, string result, TimeSpan duration)
+    {
+        TagList tags = CreateTags(("operation", operation), ("algorithm", algorithm), ("backend", backend), ("result", result));
+        _pkcs11Operations.Add(1, tags);
+        _pkcs11OperationDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordPkcs11SessionLease(string backend, ulong slotId, string result)
+        => _pkcs11SessionLeases.Add(1, CreateTags(("backend", backend), ("slot", slotId.ToString(System.Globalization.CultureInfo.InvariantCulture)), ("result", result)));
+
+    public void RecordPkcs11SessionReturn(string backend, ulong slotId, string result)
+        => _pkcs11SessionReturns.Add(1, CreateTags(("backend", backend), ("slot", slotId.ToString(System.Globalization.CultureInfo.InvariantCulture)), ("result", result)));
+
+    public void Dispose() => _meter.Dispose();
+
+    private IEnumerable<Measurement<int>> ObserveAuthenticationCacheEntries()
+    {
+        CryptoApiRequestPathCacheMetricsSnapshot? snapshot = _requestPathCache?.GetMetricsSnapshot();
+        if (snapshot is null)
+        {
+            return [];
+        }
+
+        return [new Measurement<int>(snapshot.AuthenticationEntryCount)];
+    }
+
+    private IEnumerable<Measurement<double>> ObserveAuthenticationCacheUtilization()
+    {
+        CryptoApiRequestPathCacheMetricsSnapshot? snapshot = _requestPathCache?.GetMetricsSnapshot();
+        if (snapshot is null)
+        {
+            return [];
+        }
+
+        double utilization = snapshot.AuthenticationEntryLimit <= 0
+            ? 0
+            : (double)snapshot.AuthenticationEntryCount / snapshot.AuthenticationEntryLimit;
+        return [new Measurement<double>(utilization)];
+    }
+
+    private IEnumerable<Measurement<int>> ObserveAuthorizationCacheEntries()
+    {
+        CryptoApiRequestPathCacheMetricsSnapshot? snapshot = _requestPathCache?.GetMetricsSnapshot();
+        if (snapshot is null)
+        {
+            return [];
+        }
+
+        return [new Measurement<int>(snapshot.AuthorizationEntryCount)];
+    }
+
+    private IEnumerable<Measurement<double>> ObserveAuthorizationCacheUtilization()
+    {
+        CryptoApiRequestPathCacheMetricsSnapshot? snapshot = _requestPathCache?.GetMetricsSnapshot();
+        if (snapshot is null)
+        {
+            return [];
+        }
+
+        double utilization = snapshot.AuthorizationEntryLimit <= 0
+            ? 0
+            : (double)snapshot.AuthorizationEntryCount / snapshot.AuthorizationEntryLimit;
+        return [new Measurement<double>(utilization)];
+    }
+
+    private IEnumerable<Measurement<int>> ObserveSharedStatePoolMaxConnections()
+    {
+        CryptoApiSharedStateMetricsSnapshot? snapshot = _sharedStateMetricsSource?.GetMetricsSnapshot();
+        if (snapshot is null || !snapshot.Configured)
+        {
+            return [];
+        }
+
+        return [new Measurement<int>(snapshot.EffectiveMaxPoolSize, CreateTags(("provider", snapshot.Provider)))];
+    }
+
+    private IEnumerable<Measurement<int>> ObservePkcs11IdleSessions()
+        => ObservePkcs11Sessions(static snapshot => snapshot.IdleSessions);
+
+    private IEnumerable<Measurement<int>> ObservePkcs11InUseSessions()
+        => ObservePkcs11Sessions(static snapshot => snapshot.InUseSessions);
+
+    private IEnumerable<Measurement<int>> ObservePkcs11MaxRetainedSessions()
+        => ObservePkcs11Sessions(static snapshot => snapshot.MaxRetainedSessions);
+
+    private IEnumerable<Measurement<int>> ObservePkcs11Sessions(Func<CryptoApiPkcs11SessionPoolMetricsSnapshot, int> selector)
+    {
+        IReadOnlyList<CryptoApiPkcs11SessionPoolMetricsSnapshot>? snapshots = _pkcs11RuntimeMetricsSource?.GetSessionPoolMetricsSnapshots();
+        if (snapshots is null || snapshots.Count == 0)
+        {
+            return [];
+        }
+
+        List<Measurement<int>> measurements = new(snapshots.Count);
+        foreach (CryptoApiPkcs11SessionPoolMetricsSnapshot snapshot in snapshots)
+        {
+            measurements.Add(new Measurement<int>(
+                selector(snapshot),
+                CreateTags(
+                    ("backend", snapshot.Backend),
+                    ("slot", snapshot.SlotId.ToString(System.Globalization.CultureInfo.InvariantCulture)))));
+        }
+
+        return measurements;
+    }
+
+    private static TagList CreateTags(params (string Key, string? Value)[] pairs)
+    {
+        TagList tags = new();
+        foreach ((string key, string? value) in pairs)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                tags.Add(key, value);
+            }
+        }
+
+        return tags;
+    }
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/Observability/ObservabilityOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/Observability/ObservabilityOptions.cs
@@ -1,0 +1,26 @@
+namespace Pkcs11Wrapper.Observability;
+
+public sealed class ObservabilityOptions
+{
+    public const string SectionName = "Observability";
+
+    public bool EnablePrometheusScrapingEndpoint { get; set; } = true;
+
+    public string MetricsPath { get; set; } = "/metrics";
+
+    public static void Normalize(ObservabilityOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        string path = string.IsNullOrWhiteSpace(options.MetricsPath)
+            ? "/metrics"
+            : options.MetricsPath.Trim();
+
+        if (!path.StartsWith("/", StringComparison.Ordinal))
+        {
+            path = "/" + path;
+        }
+
+        options.MetricsPath = path;
+    }
+}

--- a/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
+++ b/src/Pkcs11Wrapper.CryptoApi.Shared/SharedState/PostgresCryptoApiSharedStateStore.cs
@@ -1,10 +1,12 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Observability;
 
 namespace Pkcs11Wrapper.CryptoApi.SharedState;
 
-public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options) : ICryptoApiAuthoritativeSharedStateStore, IAsyncDisposable
+public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPersistenceOptions> options, CryptoApiMetrics? metrics = null) : ICryptoApiAuthoritativeSharedStateStore, ICryptoApiSharedStateMetricsSource, IAsyncDisposable
 {
     private const string AuthStateRevisionMetadataKey = "auth_state_revision";
     private const string AuthStateRevisionNotificationChannelPrefix = "crypto_api_auth_state_";
@@ -19,6 +21,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
     private readonly SemaphoreSlim _authStateRevisionListenerGate = new(1, 1);
     private readonly CancellationTokenSource _listenerCancellationSource = new();
     private readonly string _authStateRevisionNotificationChannel = CreateAuthStateRevisionNotificationChannel(options.Value.ConnectionString);
+    private readonly CryptoApiMetrics? _metrics = metrics;
     private volatile bool _databaseInitialized;
     private volatile bool _authStateRevisionListenerStarted;
     private long _databaseInitializationCount;
@@ -37,110 +40,175 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
             ? 0
             : new NpgsqlConnectionStringBuilder(_pooledConnectionString).MaxPoolSize;
 
+    public CryptoApiSharedStateMetricsSnapshot GetMetricsSnapshot()
+        => new(
+            Configured: IsConfigured(),
+            Provider: CryptoApiSharedPersistenceDefaults.PostgresProvider,
+            EffectiveMaxPoolSize: EffectiveMaxPoolSize);
+
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
+
         if (!IsConfigured())
         {
+            _metrics?.RecordSharedStateRequest("initialize", "unconfigured", stopwatch.Elapsed);
             return;
         }
 
         if (_databaseInitialized)
         {
+            _metrics?.RecordSharedStateRequest("initialize", "already_initialized", stopwatch.Elapsed);
             return;
         }
 
-        await _initializationGate.WaitAsync(cancellationToken);
         try
         {
-            if (_databaseInitialized)
+            await _initializationGate.WaitAsync(cancellationToken);
+            try
             {
-                return;
+                if (_databaseInitialized)
+                {
+                    result = "already_initialized";
+                    return;
+                }
+
+                await using NpgsqlConnection connection = CreateConnection();
+                await connection.OpenAsync(cancellationToken);
+
+                if (_options.AutoInitialize)
+                {
+                    await EnsureSchemaAsync(connection, cancellationToken);
+                }
+
+                _databaseInitialized = true;
+                Interlocked.Increment(ref _databaseInitializationCount);
+                result = "initialized";
             }
-
-            await using NpgsqlConnection connection = CreateConnection();
-            await connection.OpenAsync(cancellationToken);
-
-            if (_options.AutoInitialize)
+            finally
             {
-                await EnsureSchemaAsync(connection, cancellationToken);
+                _initializationGate.Release();
             }
-
-            _databaseInitialized = true;
-            Interlocked.Increment(ref _databaseInitializationCount);
+        }
+        catch
+        {
+            result = "error";
+            throw;
         }
         finally
         {
-            _initializationGate.Release();
+            _metrics?.RecordSharedStateRequest("initialize", result, stopwatch.Elapsed);
         }
     }
 
     public async Task<CryptoApiSharedStateStatus> GetStatusAsync(CancellationToken cancellationToken = default)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
+
         if (!IsConfigured())
         {
+            _metrics?.RecordSharedStateRequest("get_status", "unconfigured", stopwatch.Elapsed);
             return CreateUnconfiguredStatus();
         }
 
-        await InitializeAsync(cancellationToken);
+        try
+        {
+            await InitializeAsync(cancellationToken);
 
-        await using NpgsqlConnection connection = CreateConnection();
-        await connection.OpenAsync(cancellationToken);
-        await EnsureSchemaAsync(connection, cancellationToken);
+            await using NpgsqlConnection connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+            await EnsureSchemaAsync(connection, cancellationToken);
 
-        return new CryptoApiSharedStateStatus(
-            Configured: true,
-            Provider: CryptoApiSharedPersistenceDefaults.PostgresProvider,
-            ConnectionTarget: GetConnectionTarget(),
-            SchemaVersion: await GetSchemaVersionAsync(connection, cancellationToken),
-            ApiClientCount: await CountRowsAsync(connection, "crypto_api_clients", cancellationToken),
-            ApiClientKeyCount: await CountRowsAsync(connection, "crypto_api_client_keys", cancellationToken),
-            KeyAliasCount: await CountRowsAsync(connection, "crypto_api_key_aliases", cancellationToken),
-            PolicyCount: await CountRowsAsync(connection, "crypto_api_policies", cancellationToken),
-            ClientPolicyBindingCount: await CountRowsAsync(connection, "crypto_api_client_policy_bindings", cancellationToken),
-            KeyAliasPolicyBindingCount: await CountRowsAsync(connection, "crypto_api_key_alias_policy_bindings", cancellationToken),
-            SharedReadyAreas: CryptoApiSharedStateConstants.SharedReadyAreas);
+            return new CryptoApiSharedStateStatus(
+                Configured: true,
+                Provider: CryptoApiSharedPersistenceDefaults.PostgresProvider,
+                ConnectionTarget: GetConnectionTarget(),
+                SchemaVersion: await GetSchemaVersionAsync(connection, cancellationToken),
+                ApiClientCount: await CountRowsAsync(connection, "crypto_api_clients", cancellationToken),
+                ApiClientKeyCount: await CountRowsAsync(connection, "crypto_api_client_keys", cancellationToken),
+                KeyAliasCount: await CountRowsAsync(connection, "crypto_api_key_aliases", cancellationToken),
+                PolicyCount: await CountRowsAsync(connection, "crypto_api_policies", cancellationToken),
+                ClientPolicyBindingCount: await CountRowsAsync(connection, "crypto_api_client_policy_bindings", cancellationToken),
+                KeyAliasPolicyBindingCount: await CountRowsAsync(connection, "crypto_api_key_alias_policy_bindings", cancellationToken),
+                SharedReadyAreas: CryptoApiSharedStateConstants.SharedReadyAreas);
+        }
+        catch
+        {
+            result = "error";
+            throw;
+        }
+        finally
+        {
+            _metrics?.RecordSharedStateRequest("get_status", result, stopwatch.Elapsed);
+        }
     }
 
     public async Task<long> GetAuthStateRevisionAsync(CancellationToken cancellationToken = default)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
+
         if (!IsConfigured())
         {
+            _metrics?.RecordSharedStateRequest("get_auth_state_revision", "unconfigured", stopwatch.Elapsed);
             return 0;
         }
 
-        await InitializeAsync(cancellationToken);
-
-        await EnsureAuthStateRevisionListenerStartedAsync(cancellationToken);
-
-        long cachedRevision = Interlocked.Read(ref _cachedAuthStateRevision);
-        if (cachedRevision > 0)
+        try
         {
-            return cachedRevision;
-        }
+            await InitializeAsync(cancellationToken);
 
-        await using NpgsqlConnection connection = CreateConnection();
-        await connection.OpenAsync(cancellationToken);
-        long revision = await ReadAuthStateRevisionFromDatabaseAsync(connection, cancellationToken);
-        UpdateCachedAuthStateRevision(revision);
-        return revision;
+            await EnsureAuthStateRevisionListenerStartedAsync(cancellationToken);
+
+            long cachedRevision = Interlocked.Read(ref _cachedAuthStateRevision);
+            if (cachedRevision > 0)
+            {
+                result = "cached";
+                return cachedRevision;
+            }
+
+            await using NpgsqlConnection connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+            long revision = await ReadAuthStateRevisionFromDatabaseAsync(connection, cancellationToken);
+            UpdateCachedAuthStateRevision(revision);
+            result = "database";
+            return revision;
+        }
+        catch
+        {
+            result = "error";
+            throw;
+        }
+        finally
+        {
+            _metrics?.RecordSharedStateRequest("get_auth_state_revision", result, stopwatch.Elapsed);
+        }
     }
 
     public async Task<CryptoApiClientAuthenticationState?> GetClientAuthenticationStateAsync(string keyIdentifier, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(keyIdentifier);
 
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "found";
+
         if (!IsConfigured())
         {
+            _metrics?.RecordSharedStateRequest("get_client_authentication_state", "unconfigured", stopwatch.Elapsed);
             return null;
         }
 
-        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+        try
+        {
+            await EnsureConfiguredAndInitializedAsync(cancellationToken);
 
-        await using NpgsqlConnection connection = CreateConnection();
-        await connection.OpenAsync(cancellationToken);
+            await using NpgsqlConnection connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
 
-        await using NpgsqlCommand command = connection.CreateCommand();
-        command.CommandText = """
+            await using NpgsqlCommand command = connection.CreateCommand();
+            command.CommandText = """
             SELECT
                 c.client_id,
                 c.client_name,
@@ -170,79 +238,108 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
             WHERE k.key_identifier = @keyIdentifier
             LIMIT 1;
             """;
-        AddText(command, "@keyIdentifier", keyIdentifier);
+            AddText(command, "@keyIdentifier", keyIdentifier);
 
-        CryptoApiClientRecord client;
-        CryptoApiClientKeyRecord key;
+            CryptoApiClientRecord client;
+            CryptoApiClientKeyRecord key;
 
-        await using (NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken))
-        {
-            if (!await reader.ReadAsync(cancellationToken))
+            await using (NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken))
             {
-                return null;
+                if (!await reader.ReadAsync(cancellationToken))
+                {
+                    result = "not_found";
+                    return null;
+                }
+
+                client = new CryptoApiClientRecord(
+                    ClientId: reader.GetGuid(0),
+                    ClientName: reader.GetString(1),
+                    DisplayName: reader.GetString(2),
+                    ApplicationType: reader.GetString(3),
+                    AuthenticationMode: reader.GetString(4),
+                    IsEnabled: reader.GetBoolean(5),
+                    Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
+                    CreatedAtUtc: ReadTimestamp(reader, 7),
+                    UpdatedAtUtc: ReadTimestamp(reader, 8));
+
+                key = new CryptoApiClientKeyRecord(
+                    ClientKeyId: reader.GetGuid(9),
+                    ClientId: client.ClientId,
+                    KeyName: reader.GetString(10),
+                    KeyIdentifier: reader.GetString(11),
+                    CredentialType: reader.GetString(12),
+                    SecretHashAlgorithm: reader.GetString(13),
+                    SecretHash: reader.GetString(14),
+                    SecretHint: reader.IsDBNull(15) ? null : reader.GetString(15),
+                    IsEnabled: reader.GetBoolean(16),
+                    CreatedAtUtc: ReadTimestamp(reader, 17),
+                    UpdatedAtUtc: ReadTimestamp(reader, 18),
+                    ExpiresAtUtc: ReadNullableTimestamp(reader, 19),
+                    RevokedAtUtc: ReadNullableTimestamp(reader, 20),
+                    RevokedReason: reader.IsDBNull(21) ? null : reader.GetString(21),
+                    LastUsedAtUtc: ReadNullableTimestamp(reader, 22));
             }
 
-            client = new CryptoApiClientRecord(
-                ClientId: reader.GetGuid(0),
-                ClientName: reader.GetString(1),
-                DisplayName: reader.GetString(2),
-                ApplicationType: reader.GetString(3),
-                AuthenticationMode: reader.GetString(4),
-                IsEnabled: reader.GetBoolean(5),
-                Notes: reader.IsDBNull(6) ? null : reader.GetString(6),
-                CreatedAtUtc: ReadTimestamp(reader, 7),
-                UpdatedAtUtc: ReadTimestamp(reader, 8));
-
-            key = new CryptoApiClientKeyRecord(
-                ClientKeyId: reader.GetGuid(9),
-                ClientId: client.ClientId,
-                KeyName: reader.GetString(10),
-                KeyIdentifier: reader.GetString(11),
-                CredentialType: reader.GetString(12),
-                SecretHashAlgorithm: reader.GetString(13),
-                SecretHash: reader.GetString(14),
-                SecretHint: reader.IsDBNull(15) ? null : reader.GetString(15),
-                IsEnabled: reader.GetBoolean(16),
-                CreatedAtUtc: ReadTimestamp(reader, 17),
-                UpdatedAtUtc: ReadTimestamp(reader, 18),
-                ExpiresAtUtc: ReadNullableTimestamp(reader, 19),
-                RevokedAtUtc: ReadNullableTimestamp(reader, 20),
-                RevokedReason: reader.IsDBNull(21) ? null : reader.GetString(21),
-                LastUsedAtUtc: ReadNullableTimestamp(reader, 22));
+            Guid[] boundPolicyIds = await ReadClientBoundPolicyIdsAsync(connection, client.ClientId, cancellationToken);
+            return new CryptoApiClientAuthenticationState(client, key, boundPolicyIds);
         }
-
-        Guid[] boundPolicyIds = await ReadClientBoundPolicyIdsAsync(connection, client.ClientId, cancellationToken);
-        return new CryptoApiClientAuthenticationState(client, key, boundPolicyIds);
+        catch
+        {
+            result = "error";
+            throw;
+        }
+        finally
+        {
+            _metrics?.RecordSharedStateRequest("get_client_authentication_state", result, stopwatch.Elapsed);
+        }
     }
 
     public async Task<CryptoApiKeyAuthorizationState> GetKeyAuthorizationStateAsync(Guid clientId, string aliasName, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(aliasName);
 
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "success";
+
         if (!IsConfigured())
         {
+            _metrics?.RecordSharedStateRequest("get_key_authorization_state", "unconfigured", stopwatch.Elapsed);
             return new CryptoApiKeyAuthorizationState(null, null, []);
         }
 
-        await EnsureConfiguredAndInitializedAsync(cancellationToken);
-
-        await using NpgsqlConnection connection = CreateConnection();
-        await connection.OpenAsync(cancellationToken);
-
-        CryptoApiClientRecord? client = await ReadClientByIdAsync(connection, clientId, cancellationToken);
-        if (client is null)
+        try
         {
-            return new CryptoApiKeyAuthorizationState(null, null, []);
-        }
+            await EnsureConfiguredAndInitializedAsync(cancellationToken);
 
-        CryptoApiKeyAliasRecord? alias = await ReadKeyAliasByNameAsync(connection, aliasName, cancellationToken);
-        if (alias is null)
+            await using NpgsqlConnection connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
+
+            CryptoApiClientRecord? client = await ReadClientByIdAsync(connection, clientId, cancellationToken);
+            if (client is null)
+            {
+                result = "client_not_found";
+                return new CryptoApiKeyAuthorizationState(null, null, []);
+            }
+
+            CryptoApiKeyAliasRecord? alias = await ReadKeyAliasByNameAsync(connection, aliasName, cancellationToken);
+            if (alias is null)
+            {
+                result = "alias_not_found";
+                return new CryptoApiKeyAuthorizationState(client, null, []);
+            }
+
+            IReadOnlyList<CryptoApiPolicyRecord> sharedPolicies = await ReadSharedPoliciesAsync(connection, clientId, alias.AliasId, cancellationToken);
+            return new CryptoApiKeyAuthorizationState(client, alias, sharedPolicies);
+        }
+        catch
         {
-            return new CryptoApiKeyAuthorizationState(client, null, []);
+            result = "error";
+            throw;
         }
-
-        IReadOnlyList<CryptoApiPolicyRecord> sharedPolicies = await ReadSharedPoliciesAsync(connection, clientId, alias.AliasId, cancellationToken);
-        return new CryptoApiKeyAuthorizationState(client, alias, sharedPolicies);
+        finally
+        {
+            _metrics?.RecordSharedStateRequest("get_key_authorization_state", result, stopwatch.Elapsed);
+        }
     }
 
     public async Task UpsertClientAsync(CryptoApiClientRecord client, CancellationToken cancellationToken = default)
@@ -381,23 +478,40 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
 
     public async Task<bool> TryTouchClientKeyLastUsedAsync(Guid clientKeyId, DateTimeOffset lastUsedAtUtc, TimeSpan minimumInterval, CancellationToken cancellationToken = default)
     {
-        await EnsureConfiguredAndInitializedAsync(cancellationToken);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string result = "skipped";
 
-        await using NpgsqlConnection connection = CreateConnection();
-        await connection.OpenAsync(cancellationToken);
+        try
+        {
+            await EnsureConfiguredAndInitializedAsync(cancellationToken);
 
-        await using NpgsqlCommand command = connection.CreateCommand();
-        command.CommandText = """
-            UPDATE crypto_api_client_keys
-            SET last_used_at_utc = @lastUsedAtUtc
-            WHERE client_key_id = @clientKeyId
-              AND (last_used_at_utc IS NULL OR last_used_at_utc < @minimumLastUsedAtUtc);
-            """;
-        AddGuid(command, "@clientKeyId", clientKeyId);
-        AddTimestamp(command, "@lastUsedAtUtc", lastUsedAtUtc);
-        AddTimestamp(command, "@minimumLastUsedAtUtc", lastUsedAtUtc - minimumInterval);
+            await using NpgsqlConnection connection = CreateConnection();
+            await connection.OpenAsync(cancellationToken);
 
-        return await command.ExecuteNonQueryAsync(cancellationToken) > 0;
+            await using NpgsqlCommand command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE crypto_api_client_keys
+                SET last_used_at_utc = @lastUsedAtUtc
+                WHERE client_key_id = @clientKeyId
+                  AND (last_used_at_utc IS NULL OR last_used_at_utc < @minimumLastUsedAtUtc);
+                """;
+            AddGuid(command, "@clientKeyId", clientKeyId);
+            AddTimestamp(command, "@lastUsedAtUtc", lastUsedAtUtc);
+            AddTimestamp(command, "@minimumLastUsedAtUtc", lastUsedAtUtc - minimumInterval);
+
+            bool applied = await command.ExecuteNonQueryAsync(cancellationToken) > 0;
+            result = applied ? "applied" : "skipped";
+            return applied;
+        }
+        catch
+        {
+            result = "error";
+            throw;
+        }
+        finally
+        {
+            _metrics?.RecordSharedStateRequest("touch_client_key_last_used", result, stopwatch.Elapsed);
+        }
     }
 
     public async Task UpsertKeyAliasAsync(CryptoApiKeyAliasRecord keyAlias, CancellationToken cancellationToken = default)
@@ -959,6 +1073,7 @@ public sealed class PostgresCryptoApiSharedStateStore(IOptions<CryptoApiSharedPe
     private async Task<long> ReadAuthStateRevisionFromDatabaseAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
     {
         Interlocked.Increment(ref _authStateRevisionDatabaseReadCount);
+        _metrics?.RecordSharedStateDatabaseRead("auth_state_revision");
 
         await using NpgsqlCommand command = connection.CreateCommand();
         command.CommandText = "SELECT metadata_value FROM crypto_api_metadata WHERE metadata_key = @metadataKey;";

--- a/src/Pkcs11Wrapper.CryptoApi/Operations/CryptoApiCustomerOperationService.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Operations/CryptoApiCustomerOperationService.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Observability;
 using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.Native;
 
@@ -32,7 +34,8 @@ public sealed record CryptoApiRandomOperationResult(
 public sealed class CryptoApiPkcs11CustomerOperationService(
     CryptoApiPkcs11Runtime pkcs11Runtime,
     CryptoApiRouteDispatchService routeDispatchService,
-    TimeProvider timeProvider) : ICryptoApiCustomerOperationService
+    TimeProvider timeProvider,
+    CryptoApiMetrics? metrics = null) : ICryptoApiCustomerOperationService
 {
     private const int MaxPayloadBytes = 1024 * 1024;
     private const int MaxRandomLength = 4096;
@@ -79,6 +82,8 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         SignatureAlgorithmProfile profile,
         byte[] payload)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string backend = route.DeviceRoute ?? "default";
         Pkcs11SlotId slotId = new((nuint)route.SlotId);
         using CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease = RentCandidateSession(route, slotId);
         Pkcs11Session session = sessionLease.Session;
@@ -96,11 +101,13 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
                     return SignWithRetry(session, keyHandle, mechanism, payload);
                 });
 
+            metrics?.RecordPkcs11Operation("sign", profile.Name, backend, "success", stopwatch.Elapsed);
             return new CryptoApiSignOperationResult(profile.Name, signature, timeProvider.GetUtcNow());
         }
         catch (Exception ex) when (IsRecoverableCandidateFailure(ex))
         {
             sessionLease.MarkBroken();
+            metrics?.RecordPkcs11Operation("sign", profile.Name, backend, "failure", stopwatch.Elapsed);
             throw CreateRouteCandidateUnavailable(route, authorization, ex);
         }
     }
@@ -113,6 +120,8 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         byte[] payload,
         byte[] signature)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string backend = route.DeviceRoute ?? "default";
         Pkcs11SlotId slotId = new((nuint)route.SlotId);
         using CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease = RentCandidateSession(route, slotId);
         Pkcs11Session session = sessionLease.Session;
@@ -130,17 +139,21 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
                     return session.Verify(keyHandle, mechanism, payload, signature);
                 });
 
+            metrics?.RecordPkcs11Operation("verify", profile.Name, backend, verified ? "verified" : "invalid", stopwatch.Elapsed);
             return new CryptoApiVerifyOperationResult(profile.Name, verified, timeProvider.GetUtcNow());
         }
         catch (Exception ex) when (IsRecoverableCandidateFailure(ex))
         {
             sessionLease.MarkBroken();
+            metrics?.RecordPkcs11Operation("verify", profile.Name, backend, "failure", stopwatch.Elapsed);
             throw CreateRouteCandidateUnavailable(route, authorization, ex);
         }
     }
 
     private CryptoApiRandomOperationResult GenerateRandomOnRoute(CryptoApiAuthorizedKeyOperation authorization, CryptoApiResolvedKeyRoute route, int length)
     {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        string backend = route.DeviceRoute ?? "default";
         Pkcs11SlotId slotId = new((nuint)route.SlotId);
         using CryptoApiPkcs11Runtime.CryptoApiPooledSessionLease sessionLease = RentCandidateSession(route, slotId);
 
@@ -148,11 +161,13 @@ public sealed class CryptoApiPkcs11CustomerOperationService(
         {
             byte[] buffer = new byte[length];
             sessionLease.Session.GenerateRandom(buffer);
+            metrics?.RecordPkcs11Operation("random", "RANDOM", backend, "success", stopwatch.Elapsed);
             return new CryptoApiRandomOperationResult(buffer, timeProvider.GetUtcNow());
         }
         catch (Exception ex) when (IsRecoverableCandidateFailure(ex))
         {
             sessionLease.MarkBroken();
+            metrics?.RecordPkcs11Operation("random", "RANDOM", backend, "failure", stopwatch.Elapsed);
             throw CreateRouteCandidateUnavailable(route, authorization, ex);
         }
     }

--- a/src/Pkcs11Wrapper.CryptoApi/Pkcs11Wrapper.CryptoApi.csproj
+++ b/src/Pkcs11Wrapper.CryptoApi/Pkcs11Wrapper.CryptoApi.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
     <ProjectReference Include="..\Pkcs11Wrapper.CryptoApi.Shared\Pkcs11Wrapper.CryptoApi.Shared.csproj" />
     <ProjectReference Include="..\Pkcs11Wrapper\Pkcs11Wrapper.csproj" />
   </ItemGroup>

--- a/src/Pkcs11Wrapper.CryptoApi/Program.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Program.cs
@@ -1,16 +1,19 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Metrics;
 using Pkcs11Wrapper.CryptoApi.Access;
 using Pkcs11Wrapper.CryptoApi.Caching;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
 using Pkcs11Wrapper.CryptoApi.Endpoints;
 using Pkcs11Wrapper.CryptoApi.Health;
+using Pkcs11Wrapper.CryptoApi.Observability;
 using Pkcs11Wrapper.CryptoApi.Operations;
 using Pkcs11Wrapper.CryptoApi.RateLimiting;
 using Pkcs11Wrapper.CryptoApi.Runtime;
 using Pkcs11Wrapper.CryptoApi.SharedState;
+using Pkcs11Wrapper.Observability;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -85,6 +88,25 @@ builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
         $"Crypto API shared persistence supports '{CryptoApiSharedPersistenceDefaults.PostgresProvider}' only.")
     .ValidateOnStart();
 
+builder.Services.AddOptions<ObservabilityOptions>()
+    .Bind(builder.Configuration.GetSection(ObservabilityOptions.SectionName))
+    .PostConfigure(ObservabilityOptions.Normalize)
+    .Validate(static options => options.MetricsPath.StartsWith("/", StringComparison.Ordinal), "Observability metrics path must start with '/'.")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<CryptoApiMetrics>();
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddPrometheusExporter()
+            .AddMeter(
+                "Microsoft.AspNetCore.Hosting",
+                "Microsoft.AspNetCore.Server.Kestrel",
+                "System.Net.Http",
+                CryptoApiMetrics.MeterName);
+    });
+
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton(sp => new CryptoApiRequestPathCache(
     sp.GetRequiredService<TimeProvider>(),
@@ -131,6 +153,16 @@ CryptoApiRuntimeOptions runtimeOptions = app.Services.GetRequiredService<IOption
 CryptoApiSecurityOptions securityOptions = app.Services.GetRequiredService<IOptions<CryptoApiSecurityOptions>>().Value;
 CryptoApiRateLimitingOptions rateLimitingOptions = app.Services.GetRequiredService<IOptions<CryptoApiRateLimitingOptions>>().Value;
 CryptoApiSharedPersistenceOptions sharedPersistenceOptions = app.Services.GetRequiredService<IOptions<CryptoApiSharedPersistenceOptions>>().Value;
+ObservabilityOptions observabilityOptions = app.Services.GetRequiredService<IOptions<ObservabilityOptions>>().Value;
+CryptoApiMetrics cryptoApiMetrics = app.Services.GetRequiredService<CryptoApiMetrics>();
+
+cryptoApiMetrics.RegisterRequestPathCache(app.Services.GetRequiredService<CryptoApiRequestPathCache>());
+if (app.Services.GetRequiredService<ICryptoApiAuthoritativeSharedStateStore>() is ICryptoApiSharedStateMetricsSource sharedStateMetricsSource)
+{
+    cryptoApiMetrics.RegisterSharedStateSource(sharedStateMetricsSource);
+}
+
+cryptoApiMetrics.RegisterRuntimeSource(app.Services.GetRequiredService<CryptoApiPkcs11Runtime>());
 
 if (!app.Environment.IsDevelopment())
 {
@@ -151,7 +183,7 @@ if (!string.IsNullOrWhiteSpace(sharedPersistenceOptions.ConnectionString) && sha
     await sharedStateStore.InitializeAsync();
 }
 
-app.MapGet("/", static (CryptoApiRuntimeDescriptorProvider descriptorProvider) =>
+app.MapGet("/", (CryptoApiRuntimeDescriptorProvider descriptorProvider) =>
 {
     CryptoApiRuntimeDescriptor descriptor = descriptorProvider.Describe();
     return TypedResults.Ok(new
@@ -167,7 +199,8 @@ app.MapGet("/", static (CryptoApiRuntimeDescriptorProvider descriptorProvider) =
         {
             Live = CryptoApiHostDefaults.HealthLivePath,
             Ready = CryptoApiHostDefaults.HealthReadyPath
-        }
+        },
+        Metrics = observabilityOptions.EnablePrometheusScrapingEndpoint ? observabilityOptions.MetricsPath : null
     });
 });
 app.MapHealthChecks(CryptoApiHostDefaults.HealthLivePath, new HealthCheckOptions
@@ -180,6 +213,12 @@ app.MapHealthChecks(CryptoApiHostDefaults.HealthReadyPath, new HealthCheckOption
     Predicate = static registration => registration.Tags.Contains("ready", StringComparer.Ordinal),
     ResponseWriter = CryptoApiHealthResponseWriter.WriteAsync
 });
+
+if (observabilityOptions.EnablePrometheusScrapingEndpoint)
+{
+    app.MapPrometheusScrapingEndpoint(observabilityOptions.MetricsPath);
+}
+
 app.MapCryptoApiRoutes(hostOptions, securityOptions, rateLimitingOptions);
 
 app.Run();

--- a/src/Pkcs11Wrapper.CryptoApi/RateLimiting/ConfigureCryptoApiRateLimiterOptions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/RateLimiting/ConfigureCryptoApiRateLimiterOptions.cs
@@ -1,12 +1,14 @@
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Observability;
 
 namespace Pkcs11Wrapper.CryptoApi.RateLimiting;
 
 internal sealed class ConfigureCryptoApiRateLimiterOptions(
-    IOptions<CryptoApiRateLimitingOptions> settings) : IConfigureOptions<RateLimiterOptions>
+    IOptions<CryptoApiRateLimitingOptions> settings,
+    CryptoApiMetrics? metrics = null) : IConfigureOptions<RateLimiterOptions>
 {
     public void Configure(RateLimiterOptions options)
-        => options.ConfigureCryptoApiPolicies(settings.Value);
+        => options.ConfigureCryptoApiPolicies(settings.Value, metrics);
 }

--- a/src/Pkcs11Wrapper.CryptoApi/RateLimiting/CryptoApiRateLimitingExtensions.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/RateLimiting/CryptoApiRateLimitingExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.RateLimiting;
 using Pkcs11Wrapper.CryptoApi.Clients;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Observability;
 
 namespace Pkcs11Wrapper.CryptoApi.RateLimiting;
 
@@ -14,15 +15,17 @@ public static class CryptoApiRateLimitingExtensions
     public const string OperationsPolicyName = "crypto-api-operations";
     public const string InstanceLocalMode = "instance-local";
 
-    public static RateLimiterOptions ConfigureCryptoApiPolicies(this RateLimiterOptions options, CryptoApiRateLimitingOptions settings)
+    public static RateLimiterOptions ConfigureCryptoApiPolicies(this RateLimiterOptions options, CryptoApiRateLimitingOptions settings, CryptoApiMetrics? metrics = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(settings);
 
-        options.OnRejected = static async (context, cancellationToken) =>
+        options.OnRejected = async (context, cancellationToken) =>
         {
             CryptoApiRateLimitScopeMetadata metadata = context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<CryptoApiRateLimitScopeMetadata>()
                 ?? new CryptoApiRateLimitScopeMetadata("customer-api", 1L);
+
+            metrics?.RecordRateLimitRejection(metadata.Scope);
 
             Dictionary<string, object?> extensions = new(StringComparer.Ordinal)
             {

--- a/src/Pkcs11Wrapper.CryptoApi/Runtime/CryptoApiPkcs11Runtime.cs
+++ b/src/Pkcs11Wrapper.CryptoApi/Runtime/CryptoApiPkcs11Runtime.cs
@@ -3,21 +3,24 @@ using System.Text;
 using Microsoft.Extensions.Options;
 using Pkcs11Wrapper;
 using Pkcs11Wrapper.CryptoApi.Configuration;
+using Pkcs11Wrapper.CryptoApi.Observability;
 using Pkcs11Wrapper.CryptoApi.Operations;
 using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.CryptoApi.Runtime;
 
-public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> runtimeOptions) : IDisposable
+public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> runtimeOptions, CryptoApiMetrics? metrics = null) : ICryptoApiPkcs11RuntimeMetricsSource, IDisposable
 {
     private static readonly nuint CkrFunctionFailed = 0x00000006u;
     private static readonly nuint CkrUserAlreadyLoggedIn = 0x00000100u;
     private readonly ConcurrentDictionary<string, BackendRuntime> _namedBackends = new(StringComparer.OrdinalIgnoreCase);
+    private readonly CryptoApiMetrics? _metrics = metrics;
     private readonly BackendRuntime _defaultBackend = new(new BackendConfiguration(
         Name: "default",
         ModulePath: runtimeOptions.Value.ModulePath?.Trim(),
         UserPin: runtimeOptions.Value.UserPin?.Trim(),
-        MaxRetainedSessionsPerSlot: Math.Max(runtimeOptions.Value.MaxRetainedSessionsPerSlot, 0)));
+        MaxRetainedSessionsPerSlot: Math.Max(runtimeOptions.Value.MaxRetainedSessionsPerSlot, 0)),
+        metrics);
     private bool _disposed;
 
     public bool HasNamedBackends
@@ -38,6 +41,19 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
     {
         ThrowIfDisposed();
         return ResolveBackend(deviceRoute).RentSession(slotId);
+    }
+
+    public IReadOnlyList<CryptoApiPkcs11SessionPoolMetricsSnapshot> GetSessionPoolMetricsSnapshots()
+    {
+        List<CryptoApiPkcs11SessionPoolMetricsSnapshot> snapshots = [];
+        snapshots.AddRange(_defaultBackend.GetSessionPoolMetricsSnapshots());
+
+        foreach (BackendRuntime backend in _namedBackends.Values.OrderBy(static backend => backend.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            snapshots.AddRange(backend.GetSessionPoolMetricsSnapshots());
+        }
+
+        return snapshots;
     }
 
     public void Dispose()
@@ -78,7 +94,8 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
                 Name: name,
                 ModulePath: string.IsNullOrWhiteSpace(backendOptions.ModulePath) ? runtimeOptions.Value.ModulePath?.Trim() : backendOptions.ModulePath.Trim(),
                 UserPin: string.IsNullOrWhiteSpace(backendOptions.UserPin) ? runtimeOptions.Value.UserPin?.Trim() : backendOptions.UserPin.Trim(),
-                MaxRetainedSessionsPerSlot: Math.Max(backendOptions.MaxRetainedSessionsPerSlot ?? runtimeOptions.Value.MaxRetainedSessionsPerSlot, 0)));
+                MaxRetainedSessionsPerSlot: Math.Max(backendOptions.MaxRetainedSessionsPerSlot ?? runtimeOptions.Value.MaxRetainedSessionsPerSlot, 0)),
+                _metrics);
         });
     }
 
@@ -96,12 +113,15 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
         string? UserPin,
         int MaxRetainedSessionsPerSlot);
 
-    private sealed class BackendRuntime(BackendConfiguration configuration) : IDisposable
+    private sealed class BackendRuntime(BackendConfiguration configuration, CryptoApiMetrics? metrics) : IDisposable
     {
         private readonly object _sync = new();
         private readonly ConcurrentDictionary<Pkcs11SlotId, SlotSessionPool> _sessionPools = new();
+        private readonly CryptoApiMetrics? _metrics = metrics;
         private Pkcs11Module? _module;
         private bool _disposed;
+
+        public string Name => configuration.Name;
 
         public Pkcs11Module GetInitializedModule()
         {
@@ -147,11 +167,28 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
             SlotSessionPool pool = _sessionPools.GetOrAdd(slotId, static _ => new SlotSessionPool());
             if (pool.TryRent(out Pkcs11Session? existingSession) && existingSession is not null)
             {
+                _metrics?.RecordPkcs11SessionLease(configuration.Name, (ulong)slotId.Value, "reused");
                 return CreateLease(slotId, existingSession);
             }
 
-            return CreateLease(slotId, CreateAuthenticatedSession(slotId));
+            pool.RecordNewLease();
+            try
+            {
+                _metrics?.RecordPkcs11SessionLease(configuration.Name, (ulong)slotId.Value, "created");
+                return CreateLease(slotId, CreateAuthenticatedSession(slotId));
+            }
+            catch
+            {
+                pool.AbortLease();
+                throw;
+            }
         }
+
+        public IReadOnlyList<CryptoApiPkcs11SessionPoolMetricsSnapshot> GetSessionPoolMetricsSnapshots()
+            => _sessionPools
+                .OrderBy(static pair => pair.Key.Value)
+                .Select(pair => pair.Value.CreateMetricsSnapshot(configuration.Name, (ulong)pair.Key.Value, configuration.MaxRetainedSessionsPerSlot))
+                .ToArray();
 
         public void Dispose()
         {
@@ -206,17 +243,24 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
 
         private void ReturnSession(Pkcs11SlotId slotId, Pkcs11Session session, bool broken)
         {
+            SlotSessionPool pool = _sessionPools.GetOrAdd(slotId, static _ => new SlotSessionPool());
+
             if (_disposed || broken)
             {
+                pool.AbortLease();
+                _metrics?.RecordPkcs11SessionReturn(configuration.Name, (ulong)slotId.Value, broken ? "broken" : "disposed");
                 session.Dispose();
                 return;
             }
 
-            SlotSessionPool pool = _sessionPools.GetOrAdd(slotId, static _ => new SlotSessionPool());
             if (!pool.TryReturn(session, configuration.MaxRetainedSessionsPerSlot))
             {
+                _metrics?.RecordPkcs11SessionReturn(configuration.Name, (ulong)slotId.Value, "disposed");
                 session.Dispose();
+                return;
             }
+
+            _metrics?.RecordPkcs11SessionReturn(configuration.Name, (ulong)slotId.Value, "pooled");
         }
 
         private CryptoApiPooledSessionLease CreateLease(Pkcs11SlotId slotId, Pkcs11Session session)
@@ -279,12 +323,14 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
     {
         private readonly ConcurrentQueue<Pkcs11Session> _idleSessions = new();
         private int _idleCount;
+        private int _inUseCount;
 
         public bool TryRent(out Pkcs11Session? session)
         {
             while (_idleSessions.TryDequeue(out session))
             {
                 _ = Interlocked.Decrement(ref _idleCount);
+                _ = Interlocked.Increment(ref _inUseCount);
                 return true;
             }
 
@@ -292,8 +338,16 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
             return false;
         }
 
+        public void RecordNewLease()
+            => _ = Interlocked.Increment(ref _inUseCount);
+
+        public void AbortLease()
+            => _ = Interlocked.Decrement(ref _inUseCount);
+
         public bool TryReturn(Pkcs11Session session, int maxRetainedSessions)
         {
+            _ = Interlocked.Decrement(ref _inUseCount);
+
             if (maxRetainedSessions <= 0)
             {
                 return false;
@@ -309,6 +363,14 @@ public sealed class CryptoApiPkcs11Runtime(IOptions<CryptoApiRuntimeOptions> run
             _idleSessions.Enqueue(session);
             return true;
         }
+
+        public CryptoApiPkcs11SessionPoolMetricsSnapshot CreateMetricsSnapshot(string backend, ulong slotId, int maxRetainedSessions)
+            => new(
+                Backend: backend,
+                SlotId: slotId,
+                IdleSessions: Math.Max(0, Volatile.Read(ref _idleCount)),
+                InUseSessions: Math.Max(0, Volatile.Read(ref _inUseCount)),
+                MaxRetainedSessions: Math.Max(0, maxRetainedSessions));
 
         public void Dispose()
         {

--- a/src/Pkcs11Wrapper.CryptoApi/appsettings.json
+++ b/src/Pkcs11Wrapper.CryptoApi/appsettings.json
@@ -53,5 +53,9 @@
     "Provider": "Postgres",
     "ConnectionString": "",
     "AutoInitialize": true
+  },
+  "Observability": {
+    "EnablePrometheusScrapingEndpoint": true,
+    "MetricsPath": "/metrics"
   }
 }

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminSecurityIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminSecurityIntegrationTests.cs
@@ -3,7 +3,9 @@ using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Pkcs11Wrapper.Admin.Web.Components;
+using Pkcs11Wrapper.Admin.Web.Security;
 
 namespace Pkcs11Wrapper.Admin.Tests;
 
@@ -53,6 +55,36 @@ public sealed class AdminSecurityIntegrationTests
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.Contains("missing a valid antiforgery token", body, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteDirectory(rootPath);
+        }
+    }
+
+    [Fact]
+    public async Task MetricsEndpointPublishesAdminLoginAndSessionMetrics()
+    {
+        string rootPath = CreateTempDirectory();
+        await using WebApplicationFactory<App> factory = CreateFactory(rootPath);
+
+        try
+        {
+            using (IServiceScope scope = factory.Services.CreateScope())
+            {
+                LocalAdminLoginService loginService = scope.ServiceProvider.GetRequiredService<LocalAdminLoginService>();
+                _ = await loginService.AttemptLoginAsync("admin", "wrong-password", "127.0.0.1");
+            }
+
+            using HttpClient client = factory.CreateClient();
+            using HttpResponseMessage response = await client.GetAsync("/metrics");
+            string metrics = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("pkcs11wrapper_admin_login_attempts_total", metrics, StringComparison.Ordinal);
+            Assert.Contains("result=\"failure\"", metrics, StringComparison.Ordinal);
+            Assert.Contains("pkcs11wrapper_admin_sessions", metrics, StringComparison.Ordinal);
+            Assert.Contains("status=\"healthy\"", metrics, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/Pkcs11Wrapper.CryptoApi.Gateway.Tests/CryptoApiGatewayRoutingTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Gateway.Tests/CryptoApiGatewayRoutingTests.cs
@@ -140,6 +140,42 @@ public sealed class CryptoApiGatewayRoutingTests
         Assert.Equal(1, backend.EchoRequestCount);
     }
 
+    [Fact]
+    public async Task MetricsEndpointPublishesGatewayReadinessAndIngressCounters()
+    {
+        await using TestBackendHost backend = await TestBackendHost.StartAsync("crypto-a", HttpStatusCode.OK);
+        await using WebApplicationFactory<Program> factory = CreateFactory(
+            [backend],
+            new Dictionary<string, string?>
+            {
+                ["CryptoApiGateway:MaxRequestBodySizeBytes"] = "8"
+            });
+
+        using HttpClient client = factory.CreateClient();
+
+        using (HttpResponseMessage readyResponse = await client.GetAsync("/health/ready"))
+        {
+            Assert.Equal(HttpStatusCode.OK, readyResponse.StatusCode);
+        }
+
+        using (HttpResponseMessage rejected = await client.PostAsync(
+                   "/api/v1/echo",
+                   new StringContent("0123456789", Encoding.UTF8, "text/plain")))
+        {
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, rejected.StatusCode);
+        }
+
+        using HttpResponseMessage metricsResponse = await client.GetAsync("/metrics");
+        string metrics = await metricsResponse.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, metricsResponse.StatusCode);
+        Assert.Contains("pkcs11wrapper_crypto_api_gateway_backend_readiness_probes_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_gateway_backend_readiness_probe_duration_seconds", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_gateway_request_body_rejections_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_gateway_healthy_destinations", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_gateway_configured_destinations", metrics, StringComparison.Ordinal);
+    }
+
     private static WebApplicationFactory<Program> CreateFactory(IReadOnlyList<TestBackendHost> backends, IReadOnlyDictionary<string, string?>? additionalConfiguration = null)
         => new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiCustomerOperationIntegrationTests.cs
@@ -175,6 +175,67 @@ public sealed class CryptoApiCustomerOperationIntegrationTests
         Assert.Equal(3, telemetry.GetCount("C_GenerateRandom"));
     }
 
+    [PostgresFact]
+    public async Task MetricsEndpointPublishesHotPathAndPkcs11Measurements()
+    {
+        if (!SoftHsmTestContext.IsSupported())
+        {
+            return;
+        }
+
+        await using SoftHsmTestContext context = await SoftHsmTestContext.CreateAsync();
+        if (!context.CanExecuteInProcess)
+        {
+            return;
+        }
+
+        await using PostgresTestScope scope = await CreateScopeAsync();
+        await using WebApplicationFactory<Program> factory = CreateFactory(context, scope.Options);
+
+        SeededAccess access = await SeedAuthorizedAccessAsync(factory, context);
+
+        using HttpClient httpClient = factory.CreateClient();
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key-Id", access.Key.KeyIdentifier);
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key-Secret", access.Key.Secret);
+
+        string payloadBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("metrics smoke"));
+
+        using (HttpResponseMessage signResponse = await httpClient.PostAsync(
+                   "/api/v1/operations/sign",
+                   CreateJsonContent($"{{\"keyAlias\":\"{context.AliasName}\",\"algorithm\":\"RS256\",\"payloadBase64\":\"{payloadBase64}\"}}")))
+        {
+            Assert.Equal(HttpStatusCode.OK, signResponse.StatusCode);
+        }
+
+        using (HttpResponseMessage secondSignResponse = await httpClient.PostAsync(
+                   "/api/v1/operations/sign",
+                   CreateJsonContent($"{{\"keyAlias\":\"{context.AliasName}\",\"algorithm\":\"RS256\",\"payloadBase64\":\"{payloadBase64}\"}}")))
+        {
+            Assert.Equal(HttpStatusCode.OK, secondSignResponse.StatusCode);
+        }
+
+        using (HttpResponseMessage randomResponse = await httpClient.PostAsync(
+                   "/api/v1/operations/random",
+                   CreateJsonContent($"{{\"keyAlias\":\"{context.AliasName}\",\"length\":32}}")))
+        {
+            Assert.Equal(HttpStatusCode.OK, randomResponse.StatusCode);
+        }
+
+        using HttpResponseMessage metricsResponse = await httpClient.GetAsync("/metrics");
+        string metrics = await metricsResponse.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, metricsResponse.StatusCode);
+        Assert.Contains("pkcs11wrapper_crypto_api_authentication_results_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("source=\"shared_state\"", metrics, StringComparison.Ordinal);
+        Assert.Contains("source=\"memory_cache\"", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_authorization_results_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_request_path_cache_lookups_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_shared_state_requests_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_pkcs11_operation_duration_seconds", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_pkcs11_sessions_idle", metrics, StringComparison.Ordinal);
+        Assert.Contains("pkcs11wrapper_crypto_api_shared_state_pool_max_connections", metrics, StringComparison.Ordinal);
+    }
+
     private static async Task<SeededAccess> SeedAuthorizedAccessAsync(WebApplicationFactory<Program> factory, SoftHsmTestContext context)
     {
         using IServiceScope serviceScope = factory.Services.CreateScope();

--- a/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
+++ b/tests/Pkcs11Wrapper.CryptoApi.Tests/CryptoApiRoutesTests.cs
@@ -275,7 +275,13 @@ public sealed class CryptoApiRoutesTests
             "/api/v1/operations/sign",
             CreateJsonContent("{\"keyAlias\":\"payments-signer-2\",\"algorithm\":\"RS256\",\"payloadBase64\":\"aGVsbG8=\"}"));
 
+        using HttpResponseMessage metricsResponse = await secondClient.GetAsync("/metrics");
+        string metrics = await metricsResponse.Content.ReadAsStringAsync();
+
         Assert.Equal(HttpStatusCode.OK, secondAllowed.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, metricsResponse.StatusCode);
+        Assert.Contains("pkcs11wrapper_crypto_api_rate_limit_rejections_total", metrics, StringComparison.Ordinal);
+        Assert.Contains("scope=\"customer-operations\"", metrics, StringComparison.Ordinal);
         Assert.Equal(2, fakeOperations.Calls.Count);
         Assert.Equal("payments-signer", fakeOperations.Calls[0].AliasName);
         Assert.Equal("payments-signer-2", fakeOperations.Calls[1].AliasName);


### PR DESCRIPTION
Add first-class runtime observability metrics across Crypto API, the YARP gateway, and the admin host. This introduces OpenTelemetry metrics wiring, Prometheus-compatible /metrics exposure, custom meters for auth/authz/cache/shared-state/PKCS11/gateway/admin behavior, and starter Grafana dashboard/docs so runtime bottlenecks are visible in a structured way. Closes #153.