### PR TITLE
Fix admin PKCS#11 module lifecycle race

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Application/Services/AdminPkcs11Runtime.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/AdminPkcs11Runtime.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Native;
+
+namespace Pkcs11Wrapper.Admin.Application.Services;
+
+public sealed class AdminPkcs11Runtime : IDisposable
+{
+    private readonly ConcurrentDictionary<string, SharedModuleOwner> _owners = new(StringComparer.Ordinal);
+    private int _disposed;
+
+    public AdminPkcs11ModuleLease Acquire(HsmDeviceProfile device, IPkcs11OperationTelemetryListener? telemetryListener = null)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        string modulePath = NormalizeModulePath(device.ModulePath);
+        SharedModuleOwner owner = _owners.GetOrAdd(modulePath, static path => new SharedModuleOwner(path));
+        owner.AcquireReference();
+
+        Pkcs11Module module = Pkcs11Module.Load(modulePath, telemetryListener);
+        try
+        {
+            module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+            return new AdminPkcs11ModuleLease(module, owner.ReleaseReference);
+        }
+        catch
+        {
+            module.Dispose();
+            owner.ReleaseReference();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        foreach (SharedModuleOwner owner in _owners.Values)
+        {
+            owner.Dispose();
+        }
+
+        _owners.Clear();
+    }
+
+    private static string NormalizeModulePath(string? modulePath)
+        => string.IsNullOrWhiteSpace(modulePath)
+            ? throw new ArgumentException("PKCS#11 module path is required.", nameof(modulePath))
+            : modulePath.Trim();
+
+    private sealed class SharedModuleOwner(string modulePath) : IDisposable
+    {
+        private readonly object _sync = new();
+        private Pkcs11Module? _ownerModule;
+        private int _leaseCount;
+        private bool _disposed;
+
+        public void AcquireReference()
+        {
+            lock (_sync)
+            {
+                ThrowIfDisposed();
+                _ownerModule ??= CreateOwnerModule(modulePath);
+                _leaseCount++;
+            }
+        }
+
+        public void ReleaseReference()
+        {
+            Pkcs11Module? ownerToDispose = null;
+            lock (_sync)
+            {
+                if (_leaseCount > 0)
+                {
+                    _leaseCount--;
+                }
+
+                if (_disposed && _leaseCount == 0)
+                {
+                    ownerToDispose = _ownerModule;
+                    _ownerModule = null;
+                }
+            }
+
+            ownerToDispose?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Pkcs11Module? ownerToDispose = null;
+            lock (_sync)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                if (_leaseCount == 0)
+                {
+                    ownerToDispose = _ownerModule;
+                    _ownerModule = null;
+                }
+            }
+
+            ownerToDispose?.Dispose();
+        }
+
+        private static Pkcs11Module CreateOwnerModule(string modulePath)
+        {
+            Pkcs11Module owner = Pkcs11Module.Load(modulePath);
+            try
+            {
+                owner.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+                return owner;
+            }
+            catch
+            {
+                owner.Dispose();
+                throw;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SharedModuleOwner));
+            }
+        }
+    }
+}
+
+public sealed class AdminPkcs11ModuleLease(Pkcs11Module module, Action releaseAction) : IDisposable
+{
+    private readonly Action _releaseAction = releaseAction ?? throw new ArgumentNullException(nameof(releaseAction));
+    private int _disposed;
+
+    public Pkcs11Module Module { get; } = module ?? throw new ArgumentNullException(nameof(module));
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            Module.Dispose();
+        }
+        finally
+        {
+            _releaseAction();
+        }
+    }
+}

--- a/src/Pkcs11Wrapper.Admin.Application/Services/AdminSessionRegistry.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/AdminSessionRegistry.cs
@@ -9,15 +9,21 @@ public sealed class AdminSessionRegistry(AdminSessionRegistryOptions? options = 
     private readonly TimeSpan _idleTimeout = (options ?? new()).IdleTimeout <= TimeSpan.Zero ? TimeSpan.FromMinutes(20) : (options ?? new()).IdleTimeout;
     private readonly Func<DateTimeOffset> _clock = clock ?? (() => DateTimeOffset.UtcNow);
 
-    public AdminSessionSnapshot Register(Guid deviceId, string deviceName, Pkcs11Module module, Pkcs11Session session, bool isReadWrite, string notes)
+    public AdminSessionSnapshot Register(Guid deviceId, string deviceName, Pkcs11Module module, Pkcs11Session session, bool isReadWrite, string notes, Action? releaseAction = null)
     {
         DateTimeOffset now = _clock();
         Guid id = Guid.NewGuid();
-        TrackedSession tracked = new(id, deviceId, deviceName, session.SlotId.Value, module, session, isReadWrite, now, now, "Opened", notes, () =>
+        TrackedSession tracked = new(id, deviceId, deviceName, session.SlotId.Value, module, session, isReadWrite, now, now, "Opened", notes, releaseAction ?? (() =>
         {
-            session.Dispose();
-            module.Dispose();
-        });
+            try
+            {
+                session.Dispose();
+            }
+            finally
+            {
+                module.Dispose();
+            }
+        }));
         _sessions[id] = tracked;
         return UpdateSnapshot(tracked);
     }

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -9,7 +9,7 @@ using Pkcs11Wrapper.Native;
 
 namespace Pkcs11Wrapper.Admin.Application.Services;
 
-public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLogService auditLog, AdminSessionRegistry sessionRegistry, IAdminAuthorizationService authorization, IDeviceDependencyCleanupService? dependencyCleanup = null, Pkcs11TelemetryService? pkcs11Telemetry = null)
+public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLogService auditLog, AdminSessionRegistry sessionRegistry, IAdminAuthorizationService authorization, AdminPkcs11Runtime pkcs11Runtime, IDeviceDependencyCleanupService? dependencyCleanup = null, Pkcs11TelemetryService? pkcs11Telemetry = null)
 {
     private const string DestroyConfirmationPrefix = "DESTROY ";
     private const string ConfigurationFormat = "Pkcs11Wrapper.Admin.Configuration";
@@ -318,7 +318,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         try
         {
-            using Pkcs11Module module = CreateInitializedModule(device);
+            using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+            Pkcs11Module module = moduleLease.Module;
             LabExecutionPayload execution = request.Operation switch
             {
                 Pkcs11LabOperation.ModuleInfo => ExecuteModuleInfoLab(module),
@@ -376,7 +377,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
 
         try
         {
-            using Pkcs11Module module = CreateInitializedModule(device);
+            using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+            Pkcs11Module module = moduleLease.Module;
             Pkcs11ModuleInfo info = module.GetInfo();
             int slotCount = module.GetSlotCount();
             HsmConnectionTestResult result = new(true, $"Connected. Slots discovered: {slotCount}.", slotCount, module.SupportsInterfaceDiscovery, info.LibraryDescription, info.ManufacturerId);
@@ -394,7 +396,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandViewer();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
 
         int slotCount = module.GetSlotCount();
         if (slotCount == 0)
@@ -449,7 +452,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandViewer();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWriteRequested: false);
         using Pkcs11Session session = sessionOpen.Session;
 
@@ -467,7 +471,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ValidateKeyObjectPageRequest(request);
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWriteRequested: false);
         using Pkcs11Session session = sessionOpen.Session;
         string pinNote = LoginIfProvided(session, userPin);
@@ -484,7 +489,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandViewer();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWriteRequested: false);
         using Pkcs11Session session = sessionOpen.Session;
         string pinNote = LoginIfProvided(session, userPin);
@@ -498,7 +504,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandViewer();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
 
         bool tokenPresent = module.TryGetTokenInfo(new Pkcs11SlotId(slotIdValue), out _);
         List<string> warnings = [];
@@ -586,7 +593,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         byte[] label = Encoding.UTF8.GetBytes(request.Label.Trim());
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "generate AES keys");
         LoginUserToleratingAlreadyLoggedIn(session, userPin);
@@ -607,7 +615,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         byte[] value = ParseRequiredHex(request.ValueHex, nameof(request.ValueHex));
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "import AES keys");
         LoginUserToleratingAlreadyLoggedIn(session, userPin);
@@ -628,7 +637,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         byte[] exponent = ParseRequiredHex(request.PublicExponentHex, nameof(request.PublicExponentHex));
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "generate RSA key pairs");
         LoginUserToleratingAlreadyLoggedIn(session, userPin);
@@ -648,7 +658,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandOperator();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        Pkcs11Module module = CreateInitializedModule(device);
+        AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         try
         {
             SessionOpenResult sessionOpen = OpenCompatibleSession(module, new Pkcs11SlotId(slotIdValue), readWrite);
@@ -665,7 +676,24 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
                 notes += " (opened as read-write after the module rejected a read-only session request)";
             }
 
-            AdminSessionSnapshot snapshot = sessionRegistry.Register(device.Id, device.Name, module, session, sessionOpen.OpenedReadWrite, notes);
+            AdminSessionSnapshot snapshot = sessionRegistry.Register(
+                device.Id,
+                device.Name,
+                module,
+                session,
+                sessionOpen.OpenedReadWrite,
+                notes,
+                releaseAction: () =>
+                {
+                    try
+                    {
+                        session.Dispose();
+                    }
+                    finally
+                    {
+                        moduleLease.Dispose();
+                    }
+                });
             string auditDetail = sessionOpen.EscalatedToReadWrite
                 ? "Opened read-write session after the module rejected a read-only session request."
                 : $"Opened {(sessionOpen.OpenedReadWrite ? "read-write" : "read-only")} session.";
@@ -674,7 +702,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         }
         catch
         {
-            module.Dispose();
+            moduleLease.Dispose();
             throw;
         }
     }
@@ -728,7 +756,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
     {
         authorization.DemandOperator();
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         module.CloseAllSessions(new Pkcs11SlotId(slotIdValue));
         sessionRegistry.MarkInvalidatedForSlot(deviceId, slotIdValue, "Invalidated by CloseAllSessions on the same slot.", "CloseAllSessions");
         await auditLog.WriteAsync("Session", "CloseAll", $"{device.Name}/slot-{slotIdValue}", "Success", "Invoked CloseAllSessions on slot.", cancellationToken: cancellationToken);
@@ -740,7 +769,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ValidateDestroyRequest(request);
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         LoginUserToleratingAlreadyLoggedIn(session, request.UserPin);
         session.DestroyObject(new Pkcs11ObjectHandle(request.Handle));
@@ -753,7 +783,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ValidateUpdateObjectAttributesRequest(request);
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "update object attributes");
         LoginUserToleratingAlreadyLoggedIn(session, userPin);
@@ -772,7 +803,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         ValidateCopyObjectRequest(request);
 
         HsmDeviceProfile device = await RequireDeviceAsync(deviceId, cancellationToken);
-        using Pkcs11Module module = CreateInitializedModule(device);
+        using AdminPkcs11ModuleLease moduleLease = CreateInitializedModuleLease(device);
+        Pkcs11Module module = moduleLease.Module;
         using Pkcs11Session session = module.OpenSession(new Pkcs11SlotId(slotIdValue), readWrite: true);
         RequireUserPin(userPin, "copy objects");
         LoginUserToleratingAlreadyLoggedIn(session, userPin);
@@ -2695,12 +2727,8 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
             Pkcs11ObjectAttribute.Bytes(Pkcs11AttributeTypes.Id, id)
         ];
 
-    private Pkcs11Module CreateInitializedModule(HsmDeviceProfile device)
-    {
-        Pkcs11Module module = Pkcs11Module.Load(device.ModulePath, pkcs11Telemetry?.CreateListener(device));
-        module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
-        return module;
-    }
+    private AdminPkcs11ModuleLease CreateInitializedModuleLease(HsmDeviceProfile device)
+        => pkcs11Runtime.Acquire(device, pkcs11Telemetry?.CreateListener(device));
 
     private static bool RequiresDependentStateReconciliation(HsmDeviceProfile? existing, HsmDeviceProfile updated)
         => existing is not null && (!string.Equals(existing.ModulePath, updated.ModulePath, StringComparison.Ordinal) || existing.IsEnabled != updated.IsEnabled);

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -120,6 +120,7 @@ builder.Services.AddSingleton<ProtectedPinStore>();
 builder.Services.AddSingleton<Pkcs11LabTemplateStore>();
 builder.Services.AddSingleton<IDeviceDependencyCleanupService, DeviceDependencyCleanupService>();
 builder.Services.AddSingleton<DeviceProfileService>();
+builder.Services.AddSingleton<AdminPkcs11Runtime>();
 builder.Services.AddSingleton<AdminBootstrapDeviceSeeder>();
 builder.Services.AddSingleton(sp => new AdminSessionRegistry(sp.GetRequiredService<AdminSessionRegistryOptions>()));
 builder.Services.AddSingleton<LocalAdminUserStore>();

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminPkcs11RuntimeIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminPkcs11RuntimeIntegrationTests.cs
@@ -1,0 +1,237 @@
+using Pkcs11Wrapper.Admin.Application.Abstractions;
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Application.Services;
+using Pkcs11Wrapper.Native;
+using Pkcs11Wrapper.Native.Interop;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class AdminPkcs11RuntimeIntegrationTests
+{
+    [Fact]
+    public void RawPerOperationModuleLifecycleCanInvalidateAnotherSoftHsmSession()
+    {
+        if (!TryCreateFixture(out FixtureContext? fixture) || fixture is null)
+        {
+            return;
+        }
+
+        using FixtureContext context = fixture;
+        Pkcs11Module? owner = null;
+        Pkcs11Module? transient = null;
+        Pkcs11Session? session = null;
+
+        try
+        {
+            owner = Pkcs11Module.Load(context.Device.ModulePath);
+            owner.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+            transient = Pkcs11Module.Load(context.Device.ModulePath);
+            transient.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+            session = transient.OpenSession(context.SlotId);
+
+            owner.Dispose();
+            owner = null;
+
+            Pkcs11Exception exception = Assert.Throws<Pkcs11Exception>(() => session!.Dispose());
+            session = null;
+            Assert.Equal((nuint)0x190u, exception.Result.Value);
+            Assert.Equal("C_CloseSession", exception.Operation);
+        }
+        finally
+        {
+            session?.Dispose();
+            transient?.Dispose();
+            owner?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task HsmAdminServiceKeepsTrackedSessionsStableWhileKeysPageLoads()
+    {
+        if (!TryCreateFixture(out FixtureContext? fixture) || fixture is null)
+        {
+            return;
+        }
+
+        await using FixtureContext context = fixture;
+        using AdminPkcs11Runtime runtime = new();
+        await using AdminSessionRegistry registry = new(new AdminSessionRegistryOptions { IdleTimeout = TimeSpan.FromHours(1) });
+        HsmAdminService service = CreateService(context.Device, runtime, registry);
+
+        AdminSessionSnapshot tracked = await service.OpenSessionAsync(context.Device.Id, context.SlotId.Value, readWrite: false, context.UserPin);
+        try
+        {
+            HsmKeyObjectPage page = await service.GetKeyPageAsync(
+                context.Device.Id,
+                context.SlotId.Value,
+                new KeyObjectPageRequest
+                {
+                    SortMode = "handle",
+                    PageSize = 10
+                },
+                context.UserPin);
+
+            Assert.NotEmpty(page.Items);
+            HsmKeyObjectSummary first = page.Items.First();
+            HsmObjectDetail detail = await service.GetObjectDetailAsync(context.Device.Id, context.SlotId.Value, first.Handle, context.UserPin);
+
+            Assert.Equal(first.Handle, detail.Handle);
+            Assert.Contains(service.GetSessions(), snapshot => snapshot.SessionId == tracked.SessionId && snapshot.IsHealthy);
+        }
+        finally
+        {
+            bool closed = await service.CloseSessionAsync(tracked.SessionId);
+            Assert.True(closed);
+        }
+    }
+
+    [Fact]
+    public void AdminPkcs11RuntimeKeepsSecondLeaseSessionClosableAfterFirstLeaseEnds()
+    {
+        if (!TryCreateFixture(out FixtureContext? fixture) || fixture is null)
+        {
+            return;
+        }
+
+        using FixtureContext context = fixture;
+        using AdminPkcs11Runtime runtime = new();
+
+        AdminPkcs11ModuleLease? firstLease = null;
+        AdminPkcs11ModuleLease? secondLease = null;
+        Pkcs11Session? firstSession = null;
+        Pkcs11Session? secondSession = null;
+
+        try
+        {
+            firstLease = runtime.Acquire(context.Device);
+            firstSession = firstLease.Module.OpenSession(context.SlotId);
+
+            secondLease = runtime.Acquire(context.Device);
+            secondSession = secondLease.Module.OpenSession(context.SlotId);
+
+            firstSession.Dispose();
+            firstSession = null;
+            firstLease.Dispose();
+            firstLease = null;
+
+            Exception? closeException = Record.Exception(() => secondSession!.Dispose());
+            secondSession = null;
+            Assert.Null(closeException);
+        }
+        finally
+        {
+            secondSession?.Dispose();
+            secondLease?.Dispose();
+            firstSession?.Dispose();
+            firstLease?.Dispose();
+        }
+    }
+
+    private static HsmAdminService CreateService(HsmDeviceProfile device, AdminPkcs11Runtime runtime, AdminSessionRegistry registry)
+        => new(
+            new DeviceProfileService(new InMemoryDeviceProfileStore([device])),
+            new AuditLogService(new InMemoryAuditLogStore(), new TestActorContext()),
+            registry,
+            new AllowAllAuthorizationService(),
+            runtime);
+
+    private static bool TryCreateFixture(out FixtureContext? fixture)
+    {
+        string? modulePath = Environment.GetEnvironmentVariable("PKCS11_MODULE_PATH");
+        string? tokenLabel = Environment.GetEnvironmentVariable("PKCS11_TOKEN_LABEL");
+        string? userPin = Environment.GetEnvironmentVariable("PKCS11_USER_PIN");
+        if (string.IsNullOrWhiteSpace(modulePath) || string.IsNullOrWhiteSpace(tokenLabel) || string.IsNullOrWhiteSpace(userPin))
+        {
+            fixture = null;
+            return false;
+        }
+
+        using Pkcs11Module module = Pkcs11Module.Load(modulePath);
+        module.Initialize(new Pkcs11InitializeOptions(Pkcs11InitializeFlags.UseOperatingSystemLocking));
+
+        int slotCount = module.GetSlotCount(tokenPresentOnly: false);
+        Pkcs11SlotId[] slots = new Pkcs11SlotId[slotCount];
+        if (!module.TryGetSlots(slots, out int written, tokenPresentOnly: false))
+        {
+            throw new InvalidOperationException("Failed to enumerate SoftHSM fixture slots for admin runtime tests.");
+        }
+
+        for (int i = 0; i < written; i++)
+        {
+            if (module.TryGetTokenInfo(slots[i], out Pkcs11TokenInfo tokenInfo)
+                && string.Equals(tokenInfo.Label.Trim(), tokenLabel, StringComparison.Ordinal))
+            {
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+                fixture = new FixtureContext(
+                    new HsmDeviceProfile(Guid.NewGuid(), "Fixture SoftHSM", modulePath, tokenLabel, null, true, now, now),
+                    slots[i],
+                    userPin);
+                return true;
+            }
+        }
+
+        throw new InvalidOperationException($"SoftHSM fixture token '{tokenLabel}' was not found.");
+    }
+
+    private sealed class FixtureContext(HsmDeviceProfile device, Pkcs11SlotId slotId, string userPin) : IAsyncDisposable, IDisposable
+    {
+        public HsmDeviceProfile Device { get; } = device;
+        public Pkcs11SlotId SlotId { get; } = slotId;
+        public string UserPin { get; } = userPin;
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryDeviceProfileStore(IReadOnlyList<HsmDeviceProfile> seed) : IDeviceProfileStore
+    {
+        private List<HsmDeviceProfile> _devices = [.. seed];
+
+        public Task<IReadOnlyList<HsmDeviceProfile>> GetAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<HsmDeviceProfile>>([.. _devices]);
+
+        public Task SaveAllAsync(IReadOnlyList<HsmDeviceProfile> devices, CancellationToken cancellationToken = default)
+        {
+            _devices = [.. devices];
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryAuditLogStore : IAuditLogStore
+    {
+        private readonly List<AdminAuditLogEntry> _entries = [];
+
+        public Task AppendAsync(AdminAuditLogEntry entry, CancellationToken cancellationToken = default)
+        {
+            _entries.Add(entry);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<AdminAuditLogEntry>> ReadRecentAsync(int take, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<AdminAuditLogEntry>>(_entries.TakeLast(take).Reverse().ToArray());
+
+        public Task<AuditIntegrityStatus> VerifyIntegrityAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new AuditIntegrityStatus(true, _entries.Count, null, "ok", null));
+    }
+
+    private sealed class TestActorContext : IAdminActorContext
+    {
+        public AdminActorInfo GetCurrent()
+            => new("tester", "cookie", true, [AdminRoles.Admin], "127.0.0.1", "session-1", "tests");
+    }
+
+    private sealed class AllowAllAuthorizationService : IAdminAuthorizationService
+    {
+        public void DemandAdmin() { }
+        public void DemandOperator() { }
+        public void DemandViewer() { }
+    }
+}

--- a/tests/Pkcs11Wrapper.Admin.Tests/ConfigurationTransferTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/ConfigurationTransferTests.cs
@@ -109,7 +109,7 @@ public sealed class ConfigurationTransferTests
         InMemoryDeviceProfileStore deviceStore = new(devices);
         DeviceProfileService deviceProfiles = new(deviceStore);
         AuditLogService auditLog = new(new InMemoryAuditLogStore(), new TestActorContext());
-        return new HsmAdminService(deviceProfiles, auditLog, new AdminSessionRegistry(), new AllowAllAuthorizationService());
+        return new HsmAdminService(deviceProfiles, auditLog, new AdminSessionRegistry(), new AllowAllAuthorizationService(), new AdminPkcs11Runtime());
     }
 
     private static HsmDeviceProfile CreateProfile(Guid id, string name, string modulePath, HsmDeviceVendorMetadata? vendor = null)

--- a/tests/Pkcs11Wrapper.Admin.Tests/DashboardSummaryTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/DashboardSummaryTests.cs
@@ -40,7 +40,7 @@ public sealed class DashboardSummaryTests
     {
         DeviceProfileService deviceProfiles = new(new InMemoryDeviceProfileStore(devices));
         AuditLogService auditLog = new(new InMemoryAuditLogStore(auditEntries, integrity), new TestActorContext());
-        return new HsmAdminService(deviceProfiles, auditLog, new AdminSessionRegistry(), new AllowAllAuthorizationService());
+        return new HsmAdminService(deviceProfiles, auditLog, new AdminSessionRegistry(), new AllowAllAuthorizationService(), new AdminPkcs11Runtime());
     }
 
     private static HsmDeviceProfile CreateProfile(Guid id, string name, string modulePath, bool isEnabled)

--- a/tests/Pkcs11Wrapper.Admin.Tests/HsmAdminServiceReconciliationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/HsmAdminServiceReconciliationTests.cs
@@ -19,7 +19,7 @@ public sealed class HsmAdminServiceReconciliationTests
         AdminSessionRegistry registry = new(new AdminSessionRegistryOptions { IdleTimeout = TimeSpan.FromHours(1) });
         AdminSessionSnapshot tracked = registry.RegisterSyntheticForTesting(deviceId, existing.Name, 1, isReadWrite: true, notes: "tracked");
         FakeDependencyCleanupService cleanup = new();
-        HsmAdminService service = new(deviceProfiles, new AuditLogService(auditStore, new TestActorContext()), registry, new AllowAllAuthorizationService(), cleanup);
+        HsmAdminService service = new(deviceProfiles, new AuditLogService(auditStore, new TestActorContext()), registry, new AllowAllAuthorizationService(), new AdminPkcs11Runtime(), cleanup);
 
         await service.SaveDeviceAsync(deviceId, new HsmDeviceProfileInput
         {
@@ -63,7 +63,7 @@ public sealed class HsmAdminServiceReconciliationTests
     {
         cleanup = new FakeDependencyCleanupService();
         registry = new AdminSessionRegistry(new AdminSessionRegistryOptions { IdleTimeout = TimeSpan.FromHours(1) });
-        return new HsmAdminService(new DeviceProfileService(new InMemoryDeviceProfileStore(devices)), new AuditLogService(new InMemoryAuditLogStore(), new TestActorContext()), registry, new AllowAllAuthorizationService(), cleanup);
+        return new HsmAdminService(new DeviceProfileService(new InMemoryDeviceProfileStore(devices)), new AuditLogService(new InMemoryAuditLogStore(), new TestActorContext()), registry, new AllowAllAuthorizationService(), new AdminPkcs11Runtime(), cleanup);
     }
 
     private static HsmDeviceProfile CreateProfile(Guid id, string name, string modulePath, bool isEnabled)


### PR DESCRIPTION
Fix the remaining admin-side PKCS#11 lifecycle race behind issue #161. This introduces an admin-scoped PKCS#11 runtime that keeps a single initialized owner module alive per library path, switches admin operations to leased modules, hardens tracked-session cleanup, and adds focused SoftHSM-backed admin tests plus real admin E2E validation. Closes #161.