### PR TITLE
Gate admin SoftHSM runtime tests on hosted Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           ### Windows hosted SoftHSM coverage note
           GitHub-hosted `windows-latest` with SoftHSM-for-Windows currently crashes in native `C_Initialize` for some fixture-backed runtime paths.
 
-          This CI lane therefore validates fixture provisioning, restore/build, managed/admin regression coverage, and the safe Windows regression subset. The native SoftHSM runtime suites (`SoftHsmCryptRegressionTests`, `TelemetryRegressionTests`) plus smoke runtime and win-x64 NativeAOT smoke remain local/manual validation paths until the backend is stable enough for hosted CI.
+          This CI lane therefore validates fixture provisioning, restore/build, the safe managed/admin regression subset, and the safe Windows regression subset. The native SoftHSM runtime suites (`SoftHsmCryptRegressionTests`, `TelemetryRegressionTests`), the admin SoftHSM runtime integration suite (`AdminPkcs11RuntimeIntegrationTests`), plus smoke runtime and win-x64 NativeAOT smoke remain local/manual validation paths until the backend is stable enough for hosted CI.
           "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
       - name: Windows smoke runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,8 @@ jobs:
           # Windows release readiness
 
           - Version: `${{ needs.preflight.outputs.version }}`
-          - Validation: fixture provisioning + restore/build + managed/admin regression subset on `windows-latest`
-          - Note: hosted Windows currently excludes the crash-prone SoftHSM fixture native suites (`SoftHsmCryptRegressionTests`, `TelemetryRegressionTests`), and hosted smoke / win-x64 NativeAOT smoke remain manual until the backend is stable enough for GitHub-hosted runtime execution.
+          - Validation: fixture provisioning + restore/build + safe managed/admin regression subset on `windows-latest`
+          - Note: hosted Windows currently excludes the crash-prone SoftHSM fixture native suites (`SoftHsmCryptRegressionTests`, `TelemetryRegressionTests`), self-skips the admin SoftHSM runtime integration suite (`AdminPkcs11RuntimeIntegrationTests`) unless explicitly re-enabled, and leaves hosted smoke / win-x64 NativeAOT smoke as manual validation until the backend is stable enough for GitHub-hosted runtime execution.
           "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
   publish-release:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -145,8 +145,8 @@ Windows runtime coverage from `build-test-windows` guarantees that:
 
 - the solution still restores/builds on `windows-latest`
 - a real SoftHSM-for-Windows fixture can be provisioned in CI
-- the Windows lane still runs managed/admin regression coverage, while the crash-prone SoftHSM fixture native suites (`SoftHsmCryptRegressionTests` and `TelemetryRegressionTests`) are excluded from hosted Windows CI
-- GitHub-hosted Windows CI currently skips those native fixture suites plus smoke and `win-x64` NativeAOT smoke because SoftHSM-for-Windows can crash during native `C_Initialize`; those remain local/manual Windows validation paths for now
+- the Windows lane still runs the safe managed/admin regression subset on `windows-latest`, while the crash-prone SoftHSM fixture native suites (`SoftHsmCryptRegressionTests` and `TelemetryRegressionTests`) are excluded from hosted Windows CI
+- GitHub-hosted Windows CI currently also self-skips the admin SoftHSM runtime integration suite (`AdminPkcs11RuntimeIntegrationTests`) unless `WINDOWS_CI_SOFTHSM_RUNTIME_ENABLED=true`, because the same hosted SoftHSM-for-Windows backend can still crash during native `C_Initialize` in admin runtime paths; those remain local/manual Windows validation paths for now alongside smoke and `win-x64` NativeAOT smoke
 - fixture/regression/smoke console logs are captured as downloadable Actions artifacts
 
 Benchmark coverage from `benchmarks.yml` guarantees that, whenever the workflow runs:

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -32,5 +32,6 @@
 
 - PKCS#11 v3 runtime validation now uses a deterministic Linux-built shim rather than a vendor module, so it validates marshalling/runtime behavior but not vendor-specific semantics.
 - Windows NativeAOT validation now exists, but Linux still remains the deepest day-to-day validation environment because it is the primary benchmark baseline and the most feature-complete local automation path.
+- GitHub-hosted Windows CI still scopes out the crash-prone SoftHSM fixture native suites and self-skips the admin SoftHSM runtime integration suite unless `WINDOWS_CI_SOFTHSM_RUNTIME_ENABLED=true`; those runtime paths remain local/manual Windows validation until SoftHSM-for-Windows is stable enough for hosted `C_Initialize` coverage.
 - Mechanism parameter helpers are intentionally selective; uncommon mechanisms may still require raw parameter bytes.
 - Packaging discipline is defined in `docs/release.md`, and tagged releases now automate GitHub release asset publication plus optional NuGet publication when repository credentials are configured.

--- a/eng/run-regression-tests.ps1
+++ b/eng/run-regression-tests.ps1
@@ -44,7 +44,7 @@ if ($IsWindows) {
         'FullyQualifiedName!~TelemetryRegressionTests'
     ) -join '&'
 
-    Write-Host 'Windows regression lane: excluding SoftHsmCryptRegressionTests and TelemetryRegressionTests from dotnet test because the current SoftHSM-for-Windows fixture can crash the native test host during C_Initialize; fixture provisioning plus managed/admin regression coverage still run.'
+    Write-Host 'Windows regression lane: excluding SoftHsmCryptRegressionTests and TelemetryRegressionTests from dotnet test because the current SoftHSM-for-Windows fixture can crash the native test host during C_Initialize; AdminPkcs11RuntimeIntegrationTests also self-skip on GitHub-hosted Windows unless WINDOWS_CI_SOFTHSM_RUNTIME_ENABLED=true so the hosted lane stays explicit about its safe coverage subset.'
 
     dotnet test (Join-Path $repoRoot 'tests/Pkcs11Wrapper.Native.Tests/Pkcs11Wrapper.Native.Tests.csproj') -c Release --no-build --nologo --filter $nativeTestFilter
     dotnet test (Join-Path $repoRoot 'tests/Pkcs11Wrapper.ThalesLuna.Tests/Pkcs11Wrapper.ThalesLuna.Tests.csproj') -c Release --no-build --nologo

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminPkcs11RuntimeIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminPkcs11RuntimeIntegrationTests.cs
@@ -8,7 +8,7 @@ namespace Pkcs11Wrapper.Admin.Tests;
 
 public sealed class AdminPkcs11RuntimeIntegrationTests
 {
-    [Fact]
+    [HostedWindowsSoftHsmRuntimeFact]
     public void RawPerOperationModuleLifecycleCanInvalidateAnotherSoftHsmSession()
     {
         if (!TryCreateFixture(out FixtureContext? fixture) || fixture is null)
@@ -46,7 +46,7 @@ public sealed class AdminPkcs11RuntimeIntegrationTests
         }
     }
 
-    [Fact]
+    [HostedWindowsSoftHsmRuntimeFact]
     public async Task HsmAdminServiceKeepsTrackedSessionsStableWhileKeysPageLoads()
     {
         if (!TryCreateFixture(out FixtureContext? fixture) || fixture is null)
@@ -86,7 +86,7 @@ public sealed class AdminPkcs11RuntimeIntegrationTests
         }
     }
 
-    [Fact]
+    [HostedWindowsSoftHsmRuntimeFact]
     public void AdminPkcs11RuntimeKeepsSecondLeaseSessionClosableAfterFirstLeaseEnds()
     {
         if (!TryCreateFixture(out FixtureContext? fixture) || fixture is null)

--- a/tests/Pkcs11Wrapper.Admin.Tests/HostedWindowsSoftHsmRuntimeFactAttribute.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/HostedWindowsSoftHsmRuntimeFactAttribute.cs
@@ -1,0 +1,34 @@
+namespace Pkcs11Wrapper.Admin.Tests;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+internal sealed class HostedWindowsSoftHsmRuntimeFactAttribute : FactAttribute
+{
+    internal const string SkipReason = "GitHub-hosted Windows SoftHSM runtime coverage is disabled because SoftHSM-for-Windows can still crash native C_Initialize in admin runtime integration paths. Re-enable with WINDOWS_CI_SOFTHSM_RUNTIME_ENABLED=true once hosted Windows is stable enough.";
+
+    public HostedWindowsSoftHsmRuntimeFactAttribute()
+    {
+        if (HostedWindowsSoftHsmRuntimeGuard.ShouldSkip())
+        {
+            Skip = SkipReason;
+        }
+    }
+}
+
+internal static class HostedWindowsSoftHsmRuntimeGuard
+{
+    public static bool ShouldSkip()
+        => ShouldSkip(
+            OperatingSystem.IsWindows(),
+            Environment.GetEnvironmentVariable("GITHUB_ACTIONS"),
+            Environment.GetEnvironmentVariable("RUNNER_ENVIRONMENT"),
+            Environment.GetEnvironmentVariable("WINDOWS_CI_SOFTHSM_RUNTIME_ENABLED"));
+
+    internal static bool ShouldSkip(bool isWindows, string? githubActions, string? runnerEnvironment, string? runtimeEnabled)
+        => isWindows
+            && IsTrue(githubActions)
+            && !string.Equals(runnerEnvironment, "self-hosted", StringComparison.OrdinalIgnoreCase)
+            && !IsTrue(runtimeEnabled);
+
+    private static bool IsTrue(string? value)
+        => string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/Pkcs11Wrapper.Admin.Tests/HostedWindowsSoftHsmRuntimeGuardTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/HostedWindowsSoftHsmRuntimeGuardTests.cs
@@ -1,0 +1,20 @@
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class HostedWindowsSoftHsmRuntimeGuardTests
+{
+    [Theory]
+    [InlineData(true, "true", "github-hosted", null, true)]
+    [InlineData(true, "true", "github-hosted", "false", true)]
+    [InlineData(true, "true", "github-hosted", "true", false)]
+    [InlineData(true, "true", "self-hosted", "false", false)]
+    [InlineData(true, "false", "github-hosted", "false", false)]
+    [InlineData(false, "true", "github-hosted", "false", false)]
+    [InlineData(true, null, "github-hosted", "false", false)]
+    [InlineData(true, "true", null, "false", true)]
+    public void ShouldSkipOnlyForDisabledGitHubHostedWindowsSoftHsmRuntime(bool isWindows, string? githubActions, string? runnerEnvironment, string? runtimeEnabled, bool expected)
+    {
+        bool shouldSkip = HostedWindowsSoftHsmRuntimeGuard.ShouldSkip(isWindows, githubActions, runnerEnvironment, runtimeEnabled);
+
+        Assert.Equal(expected, shouldSkip);
+    }
+}


### PR DESCRIPTION
Stabilize the hosted Windows regression lane by explicitly gating the new fixture-backed admin SoftHSM runtime integration tests on GitHub-hosted Windows. This keeps Linux/local coverage intact, adds guard-policy tests, aligns the PowerShell regression lane with the policy, updates CI/release/docs to reflect the true support boundary, and closes #165.