### PR TITLE
Harden Linux validation scripts on constrained hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ TestResults/
 *.cache
 *.tmp
 *.log
+.tmp-msbuild/
 BenchmarkDotNet.Artifacts/
 deploy/compose/softhsm-lab/.env

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -73,7 +73,7 @@ Ordered Linux steps:
 - mark engineering scripts executable
 - `dotnet restore Pkcs11Wrapper.sln`
 - `dotnet build Pkcs11Wrapper.sln -c Release --no-restore`
-- `./eng/run-regression-tests.sh` (this now also builds the Linux PKCS#11 v3 runtime shim before `dotnet test`)
+- `./eng/run-regression-tests.sh` (this now also builds the Linux PKCS#11 v3 runtime shim before `dotnet test`, and uses the repo-local `./.tmp-msbuild` temp root plus serialized/no-shared-compilation Linux defaults so local MSBuild-node instability does not hide real regression outcomes)
 - `./eng/run-smoke-aot.sh`
 - upload captured CI logs plus the Linux NativeAOT publish output as Actions artifacts
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,9 +29,10 @@ dotnet build Pkcs11Wrapper.sln -c Release --no-restore
 
 Notes:
 
-- `eng/run-regression-tests.sh` provisions its own temporary SoftHSM fixture, builds a tiny PKCS#11 v3 runtime shim plus a Luna `CA_GetFunctionList` bootstrap shim on Linux, validates the expected AES and RSA objects, then runs `dotnet test` on `Pkcs11Wrapper.sln`.
+- `eng/run-regression-tests.sh` provisions its own temporary SoftHSM fixture, builds a tiny PKCS#11 v3 runtime shim plus a Luna `CA_GetFunctionList` bootstrap shim on Linux, validates the expected AES and RSA objects, then runs `dotnet test` on `Pkcs11Wrapper.sln` with Linux-safe single-node / no-shared-compilation defaults so constrained local hosts surface real test outcomes instead of transient MSBuild node crashes.
 - `eng/run-regression-tests.sh --use-existing-env` skips fixture provisioning and uses existing `PKCS11_*` environment variables. This is intended for optional vendor-module validation and now supports the default `baseline-rsa-aes` profile plus the documented `luna-rsa-aes` Thales Luna profile in `docs/vendor-regression.md`.
-- `eng/run-smoke-aot.sh` provisions its own temporary fixture, publishes `samples/Pkcs11Wrapper.Smoke` with `/p:PublishAot=true`, then executes the produced binary with strict output validation.
+- `eng/run-regression-tests.sh` and `eng/run-smoke-aot.sh` both default Linux temp files under `./.tmp-msbuild` (override with `PKCS11_TEMP_ROOT`) and accept `--no-restore` / `--no-build` for pre-restored or prebuilt local/CI flows.
+- `eng/run-smoke-aot.sh` provisions its own temporary fixture, publishes `samples/Pkcs11Wrapper.Smoke` with `/p:PublishAot=true`, then executes the produced binary with strict output validation. Its Linux publish path uses the same safer temp-root and serialized-build defaults as the regression script.
 - `eng/run-benchmarks.sh` provisions its own temporary fixture, runs the `BenchmarkDotNet` suite, and writes the latest benchmark summary under `artifacts/benchmarks/latest/summary.md` plus machine-readable JSON.
 - `eng/run-benchmarks.sh --update-docs` additionally refreshes the committed Linux baseline files at `docs/benchmarks/latest-linux-softhsm.md` and `docs/benchmarks/latest-linux-softhsm.json` after a trustworthy rerun.
 - If you want to inspect behavior interactively, create a fixture with `eng/setup-softhsm-fixture.sh`, `source` the generated env file, and run the smoke sample or targeted `dotnet test` commands manually.

--- a/eng/run-regression-tests.sh
+++ b/eng/run-regression-tests.sh
@@ -7,14 +7,23 @@ repo_root="$(cd "$script_dir/.." && pwd)"
 setup_script="$script_dir/setup-softhsm-fixture.sh"
 build_v3_shim_script="$script_dir/build-pkcs11-v3-shim.sh"
 build_luna_shim_script="$script_dir/build-luna-extension-shim.sh"
+temp_root_default="$repo_root/.tmp-msbuild"
 fixture_root=""
 fixture_env=""
 use_existing_env=false
+no_restore=false
+no_build=false
 
 for arg in "$@"; do
   case "$arg" in
     --use-existing-env)
       use_existing_env=true
+      ;;
+    --no-restore)
+      no_restore=true
+      ;;
+    --no-build)
+      no_build=true
       ;;
     *)
       printf 'Unknown argument: %s\n' "$arg" >&2
@@ -48,6 +57,21 @@ require_env() {
     printf 'Required PKCS#11 environment variable is missing: %s\n' "$name" >&2
     exit 1
   fi
+}
+
+configure_temp_root() {
+  local resolved_temp_root="${PKCS11_TEMP_ROOT:-$temp_root_default}"
+
+  export TMPDIR="$resolved_temp_root"
+  export TMP="$resolved_temp_root"
+  export TEMP="$resolved_temp_root"
+  mkdir -p "$resolved_temp_root"
+}
+
+append_safe_dotnet_args() {
+  local -n args_ref=$1
+
+  args_ref+=(--disable-build-servers -m:1 -nr:false /p:UseSharedCompilation=false /p:BuildInParallel=false)
 }
 
 apply_rsa_aes_profile_defaults() {
@@ -109,6 +133,8 @@ print_existing_env_summary() {
 require_command dotnet
 require_command pkcs11-tool
 
+configure_temp_root
+
 if [[ "$(uname -s)" == "Linux" ]]; then
   chmod +x "$build_v3_shim_script" "$build_luna_shim_script"
   export PKCS11_V3_SHIM_PATH="$($build_v3_shim_script)"
@@ -165,5 +191,14 @@ if [[ "$PKCS11_PROVISIONING_REGRESSION" == "1" ]]; then
 fi
 
 printf 'Running regression test suite with PKCS#11-backed environment\n'
-dotnet test "$repo_root/Pkcs11Wrapper.sln" -c Release --nologo --logger "console;verbosity=minimal"
+test_args=(test "$repo_root/Pkcs11Wrapper.sln" -c Release --nologo --logger "console;verbosity=minimal")
+append_safe_dotnet_args test_args
+
+if [[ "$no_build" == "true" ]]; then
+  test_args+=(--no-build)
+elif [[ "$no_restore" == "true" ]]; then
+  test_args+=(--no-restore)
+fi
+
+dotnet "${test_args[@]}"
 printf 'Regression test suite completed successfully\n'

--- a/eng/run-smoke-aot.sh
+++ b/eng/run-smoke-aot.sh
@@ -6,13 +6,33 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 setup_script="$script_dir/setup-softhsm-fixture.sh"
 validator_script="$script_dir/validate-smoke-output.py"
-fixture_root="$(mktemp -d -t pkcs11wrapper-smoke-XXXXXX)"
-fixture_env="$fixture_root/pkcs11-fixture.env"
+temp_root_default="$repo_root/.tmp-msbuild"
+fixture_root=""
+fixture_env=""
 publish_dir="$repo_root/artifacts/smoke-aot/linux-x64"
 smoke_log="$publish_dir/smoke.log"
+no_restore=false
+no_build=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-restore)
+      no_restore=true
+      ;;
+    --no-build)
+      no_build=true
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$arg" >&2
+      exit 1
+      ;;
+  esac
+done
 
 cleanup() {
-  rm -rf "$fixture_root"
+  if [[ -n "$fixture_root" && -d "$fixture_root" ]]; then
+    rm -rf "$fixture_root"
+  fi
 }
 
 trap cleanup EXIT
@@ -24,9 +44,29 @@ require_command() {
   fi
 }
 
+configure_temp_root() {
+  local resolved_temp_root="${PKCS11_TEMP_ROOT:-$temp_root_default}"
+
+  export TMPDIR="$resolved_temp_root"
+  export TMP="$resolved_temp_root"
+  export TEMP="$resolved_temp_root"
+  mkdir -p "$resolved_temp_root"
+}
+
+append_safe_dotnet_args() {
+  local -n args_ref=$1
+
+  args_ref+=(--disable-build-servers -m:1 -nr:false /p:UseSharedCompilation=false /p:BuildInParallel=false)
+}
+
 require_command dotnet
 require_command file
 require_command python3
+
+configure_temp_root
+
+fixture_root="$(mktemp -d -t pkcs11wrapper-smoke-XXXXXX)"
+fixture_env="$fixture_root/pkcs11-fixture.env"
 
 "$setup_script" "$fixture_env"
 source "$fixture_env"
@@ -38,7 +78,16 @@ rm -rf "$publish_dir"
 mkdir -p "$publish_dir"
 
 printf 'Publishing native AOT smoke binary\n'
-dotnet publish "$repo_root/samples/Pkcs11Wrapper.Smoke/Pkcs11Wrapper.Smoke.csproj" -c Release -r linux-x64 /p:PublishAot=true --self-contained true -o "$publish_dir"
+publish_args=(publish "$repo_root/samples/Pkcs11Wrapper.Smoke/Pkcs11Wrapper.Smoke.csproj" -c Release -r linux-x64 /p:PublishAot=true --self-contained true -o "$publish_dir")
+append_safe_dotnet_args publish_args
+
+if [[ "$no_build" == "true" ]]; then
+  publish_args+=(--no-build)
+elif [[ "$no_restore" == "true" ]]; then
+  publish_args+=(--no-restore)
+fi
+
+dotnet "${publish_args[@]}"
 
 smoke_binary="$publish_dir/Pkcs11Wrapper.Smoke"
 if [[ ! -x "$smoke_binary" ]]; then


### PR DESCRIPTION
Harden the Linux validation scripts for constrained or MSBuild-sensitive hosts by defaulting them to a repo-local temp root, using safer single-node/no-shared-compilation dotnet settings, and allowing no-restore/no-build flows where appropriate. This improves local validation reliability without claiming the same cause for CI failures. Closes #166.