### PR TITLE
Add Crypto API access readiness diagnostics

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccess.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccess.razor
@@ -1,11 +1,14 @@
 @page "/crypto-api-access"
 @using System.Globalization
+@using Microsoft.Extensions.Options
+@using Pkcs11Wrapper.Admin.Web.Configuration
 @using Pkcs11Wrapper.Admin.Web.Security
 @using Pkcs11Wrapper.CryptoApi.Access
 @using Pkcs11Wrapper.CryptoApi.Clients
 @attribute [Authorize(Policy = AdminRoles.Admin)]
 @inject CryptoApiClientManagementService ClientAccess
 @inject CryptoApiKeyAccessManagementService KeyAccess
+@inject IOptions<AdminCryptoApiRouteRuntimeOptions> RuntimeOptions
 
 <PageTitle>Crypto API Access</PageTitle>
 
@@ -108,6 +111,11 @@ else
             </div>
         </div>
     </div>
+
+    @if (_readiness is not null)
+    {
+        <div class="alert alert-light border small text-muted mb-4" data-testid="crypto-api-readiness-runtime-summary">@_readiness.RuntimeInspectionSummary</div>
+    }
 
     <div class="row g-4">
         <div class="col-xxl-4">
@@ -372,6 +380,36 @@ else
                             <div><strong>Bound clients:</strong> @_selectedPolicy.BoundClientIds.Count</div>
                             <div><strong>Bound aliases:</strong> @_selectedPolicy.BoundAliasIds.Count</div>
                         </div>
+                        @{
+                            CryptoApiPolicyReadinessViewItem? selectedPolicyReadiness = GetPolicyReadiness(_selectedPolicy.PolicyId);
+                        }
+                        @if (selectedPolicyReadiness is not null)
+                        {
+                            <div class="col-12">
+                                <div class="border rounded p-3 small">
+                                    <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
+                                        <span class="fw-semibold">Policy readiness</span>
+                                        <span class="badge @GetReadinessBadgeClass(selectedPolicyReadiness.Level)">@GetReadinessLabel(selectedPolicyReadiness.Level)</span>
+                                    </div>
+                                    <div class="text-muted mb-2">@selectedPolicyReadiness.Summary</div>
+                                    @if (selectedPolicyReadiness.Issues.Count > 0)
+                                    {
+                                        <ul class="mb-0 ps-3">
+                                            @foreach (CryptoApiAccessReadinessIssue issue in selectedPolicyReadiness.Issues)
+                                            {
+                                                <li class="mb-2">
+                                                    <span class="@(issue.Severity == CryptoApiAccessIssueSeverity.Blocker ? "text-danger" : "text-warning-emphasis")">@issue.Message</span>
+                                                    @if (issue.TargetId is not null && !string.IsNullOrWhiteSpace(issue.ActionLabel))
+                                                    {
+                                                        <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => SelectReadinessTarget(issue)">@issue.ActionLabel</button>
+                                                    }
+                                                </li>
+                                            }
+                                        </ul>
+                                    }
+                                </div>
+                            </div>
+                        }
                         <div class="col-12 d-flex gap-2 flex-wrap">
                             <button class="btn btn-outline-primary" @onclick="UpdatePolicyAsync">Save policy</button>
                             <button class="btn btn-outline-secondary" @onclick="TogglePolicyAsync">@(_selectedPolicy.IsEnabled ? "Disable policy" : "Enable policy")</button>
@@ -399,6 +437,7 @@ else
                                         <th>Type</th>
                                         <th>Policies</th>
                                         <th>Keys</th>
+                                        <th>Readiness</th>
                                         <th>Status</th>
                                         <th></th>
                                     </tr>
@@ -406,6 +445,7 @@ else
                                 <tbody>
                                     @foreach (CryptoApiManagedClient client in _clientSnapshot.Clients)
                                     {
+                                        CryptoApiClientReadinessViewItem? clientReadiness = GetClientReadiness(client.ClientId);
                                         <tr class="@(ReferenceEquals(client, _selectedClient) ? "table-active" : null)">
                                             <td>
                                                 <div class="fw-semibold">@client.DisplayName</div>
@@ -414,6 +454,15 @@ else
                                             <td class="small">@client.ApplicationType</td>
                                             <td class="small text-muted">@(FormatBoundPolicySummary(client.BoundPolicyIds))</td>
                                             <td class="small">@client.Keys.Count</td>
+                                            <td>
+                                                @if (clientReadiness is not null)
+                                                {
+                                                    <div class="d-flex flex-column gap-1">
+                                                        <span class="badge @GetReadinessBadgeClass(clientReadiness.Level)">@GetReadinessLabel(clientReadiness.Level)</span>
+                                                        <div class="small text-muted">@clientReadiness.Summary</div>
+                                                    </div>
+                                                }
+                                            </td>
                                             <td>
                                                 <span class="badge @(client.IsEnabled ? "text-bg-success" : "text-bg-secondary")">@(client.IsEnabled ? "Enabled" : "Disabled")</span>
                                             </td>
@@ -431,6 +480,97 @@ else
 
             @if (_selectedClient is not null)
             {
+                CryptoApiClientReadinessViewItem? selectedClientReadiness = GetClientReadiness(_selectedClient.ClientId);
+                IReadOnlyList<CryptoApiClientAliasReadinessViewItem> selectedClientRoutes = GetRoutesForClient(_selectedClient.ClientId);
+
+                <div class="card shadow-sm feature-card mb-4" data-testid="crypto-api-client-readiness-panel">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span>Route readiness for @_selectedClient.DisplayName</span>
+                        @if (selectedClientReadiness is not null)
+                        {
+                            <span class="badge @GetReadinessBadgeClass(selectedClientReadiness.Level)">@GetReadinessLabel(selectedClientReadiness.Level)</span>
+                        }
+                    </div>
+                    <div class="card-body">
+                        @if (selectedClientReadiness is not null)
+                        {
+                            <div class="small text-muted mb-3">@selectedClientReadiness.Summary</div>
+                            <div class="small text-muted mb-3">Active keys: @selectedClientReadiness.ActiveKeyCount · Ready aliases: @selectedClientReadiness.ReadyRouteCount · Needs attention: @selectedClientReadiness.NeedsAttentionRouteCount · Blocked: @selectedClientReadiness.BlockedRouteCount</div>
+                            @if (selectedClientReadiness.Issues.Count > 0)
+                            {
+                                <ul class="small mb-3 ps-3">
+                                    @foreach (CryptoApiAccessReadinessIssue issue in selectedClientReadiness.Issues)
+                                    {
+                                        <li class="mb-2">
+                                            <span class="@(issue.Severity == CryptoApiAccessIssueSeverity.Blocker ? "text-danger" : "text-warning-emphasis")">@issue.Message</span>
+                                            @if (issue.TargetId is not null && !string.IsNullOrWhiteSpace(issue.ActionLabel))
+                                            {
+                                                <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => SelectReadinessTarget(issue)">@issue.ActionLabel</button>
+                                            }
+                                        </li>
+                                    }
+                                </ul>
+                            }
+                        }
+
+                        @if (selectedClientRoutes.Count == 0)
+                        {
+                            <div class="empty-state">No alias routes exist for this client yet.</div>
+                        }
+                        else
+                        {
+                            <div class="table-responsive table-shell" data-testid="crypto-api-client-route-matrix">
+                                <table class="table table-hover align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Alias</th>
+                                            <th>Shared policies</th>
+                                            <th>Allowed operations</th>
+                                            <th>Route</th>
+                                            <th>Readiness</th>
+                                            <th>Fix</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (CryptoApiClientAliasReadinessViewItem route in selectedClientRoutes)
+                                        {
+                                            <tr>
+                                                <td>
+                                                    <div class="fw-semibold">@route.AliasName</div>
+                                                </td>
+                                                <td class="small text-muted">@(route.SharedPolicyNames.Count == 0 ? "None" : string.Join(", ", route.SharedPolicyNames))</td>
+                                                <td class="small text-muted">@(route.AllowedOperations.Count == 0 ? "None" : string.Join(", ", route.AllowedOperations))</td>
+                                                <td class="small text-muted">@route.RouteSummary</td>
+                                                <td>
+                                                    <div class="d-flex flex-column gap-1">
+                                                        <span class="badge @GetReadinessBadgeClass(route.Level)">@GetReadinessLabel(route.Level)</span>
+                                                        <div class="small text-muted">@route.Summary</div>
+                                                        @if (route.Issues.Count > 0)
+                                                        {
+                                                            <ul class="small mb-0 ps-3 text-muted">
+                                                                @foreach (CryptoApiAccessReadinessIssue issue in route.Issues.Take(3))
+                                                                {
+                                                                    <li>@issue.Message</li>
+                                                                }
+                                                            </ul>
+                                                        }
+                                                    </div>
+                                                </td>
+                                                <td class="text-end">
+                                                    <div class="btn-group btn-group-sm" role="group">
+                                                        <button class="btn btn-outline-primary" @onclick="() => SelectAliasById(route.AliasId)">Alias</button>
+                                                        <button class="btn btn-outline-secondary" @onclick="() => SelectClientById(route.ClientId)">Client</button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+
                 <div class="card shadow-sm feature-card mb-4">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <span>API keys for @_selectedClient.DisplayName</span>
@@ -514,6 +654,7 @@ else
                                         <th>Alias</th>
                                         <th>Route</th>
                                         <th>Policies</th>
+                                        <th>Readiness</th>
                                         <th>Status</th>
                                         <th></th>
                                     </tr>
@@ -521,6 +662,7 @@ else
                                 <tbody>
                                     @foreach (CryptoApiManagedKeyAlias alias in _accessSnapshot.KeyAliases)
                                     {
+                                        CryptoApiAliasReadinessViewItem? aliasReadiness = GetAliasReadiness(alias.AliasId);
                                         <tr class="@(ReferenceEquals(alias, _selectedAlias) ? "table-active" : null)">
                                             <td>
                                                 <div class="fw-semibold">@alias.AliasName</div>
@@ -550,6 +692,15 @@ else
                                             </td>
                                             <td class="small text-muted">@(FormatBoundPolicySummary(alias.BoundPolicyIds))</td>
                                             <td>
+                                                @if (aliasReadiness is not null)
+                                                {
+                                                    <div class="d-flex flex-column gap-1">
+                                                        <span class="badge @GetReadinessBadgeClass(aliasReadiness.Level)">@GetReadinessLabel(aliasReadiness.Level)</span>
+                                                        <div class="small text-muted">@aliasReadiness.Summary</div>
+                                                    </div>
+                                                }
+                                            </td>
+                                            <td>
                                                 <span class="badge @(alias.IsEnabled ? "text-bg-success" : "text-bg-secondary")">@(alias.IsEnabled ? "Enabled" : "Disabled")</span>
                                             </td>
                                             <td class="text-end">
@@ -563,6 +714,99 @@ else
                     }
                 </div>
             </div>
+
+            @if (_selectedAlias is not null)
+            {
+                CryptoApiAliasReadinessViewItem? selectedAliasReadiness = GetAliasReadiness(_selectedAlias.AliasId);
+                IReadOnlyList<CryptoApiClientAliasReadinessViewItem> selectedAliasRoutes = GetRoutesForAlias(_selectedAlias.AliasId);
+
+                <div class="card shadow-sm feature-card mb-4" data-testid="crypto-api-alias-readiness-panel">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span>Client readiness for alias @_selectedAlias.AliasName</span>
+                        @if (selectedAliasReadiness is not null)
+                        {
+                            <span class="badge @GetReadinessBadgeClass(selectedAliasReadiness.Level)">@GetReadinessLabel(selectedAliasReadiness.Level)</span>
+                        }
+                    </div>
+                    <div class="card-body">
+                        @if (selectedAliasReadiness is not null)
+                        {
+                            <div class="small text-muted mb-3">@selectedAliasReadiness.Summary</div>
+                            <div class="small text-muted mb-3">Ready clients: @selectedAliasReadiness.ReadyClientCount · Needs attention: @selectedAliasReadiness.NeedsAttentionClientCount · Blocked: @selectedAliasReadiness.BlockedClientCount</div>
+                            @if (selectedAliasReadiness.Issues.Count > 0)
+                            {
+                                <ul class="small mb-3 ps-3">
+                                    @foreach (CryptoApiAccessReadinessIssue issue in selectedAliasReadiness.Issues)
+                                    {
+                                        <li class="mb-2">
+                                            <span class="@(issue.Severity == CryptoApiAccessIssueSeverity.Blocker ? "text-danger" : "text-warning-emphasis")">@issue.Message</span>
+                                            @if (issue.TargetId is not null && !string.IsNullOrWhiteSpace(issue.ActionLabel))
+                                            {
+                                                <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="() => SelectReadinessTarget(issue)">@issue.ActionLabel</button>
+                                            }
+                                        </li>
+                                    }
+                                </ul>
+                            }
+                        }
+
+                        @if (selectedAliasRoutes.Count == 0)
+                        {
+                            <div class="empty-state">No client routes exist for this alias yet.</div>
+                        }
+                        else
+                        {
+                            <div class="table-responsive table-shell" data-testid="crypto-api-alias-client-matrix">
+                                <table class="table table-hover align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Client</th>
+                                            <th>Shared policies</th>
+                                            <th>Allowed operations</th>
+                                            <th>Readiness</th>
+                                            <th>Fix</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (CryptoApiClientAliasReadinessViewItem route in selectedAliasRoutes)
+                                        {
+                                            <tr>
+                                                <td>
+                                                    <div class="fw-semibold">@route.ClientDisplayName</div>
+                                                    <div class="small text-muted">@route.ClientName</div>
+                                                </td>
+                                                <td class="small text-muted">@(route.SharedPolicyNames.Count == 0 ? "None" : string.Join(", ", route.SharedPolicyNames))</td>
+                                                <td class="small text-muted">@(route.AllowedOperations.Count == 0 ? "None" : string.Join(", ", route.AllowedOperations))</td>
+                                                <td>
+                                                    <div class="d-flex flex-column gap-1">
+                                                        <span class="badge @GetReadinessBadgeClass(route.Level)">@GetReadinessLabel(route.Level)</span>
+                                                        <div class="small text-muted">@route.Summary</div>
+                                                        @if (route.Issues.Count > 0)
+                                                        {
+                                                            <ul class="small mb-0 ps-3 text-muted">
+                                                                @foreach (CryptoApiAccessReadinessIssue issue in route.Issues.Take(3))
+                                                                {
+                                                                    <li>@issue.Message</li>
+                                                                }
+                                                            </ul>
+                                                        }
+                                                    </div>
+                                                </td>
+                                                <td class="text-end">
+                                                    <div class="btn-group btn-group-sm" role="group">
+                                                        <button class="btn btn-outline-primary" @onclick="() => SelectClientById(route.ClientId)">Client</button>
+                                                        <button class="btn btn-outline-secondary" @onclick="() => SelectAliasById(route.AliasId)">Alias</button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
 
             <div class="card shadow-sm feature-card">
                 <div class="card-header">Policies</div>
@@ -581,6 +825,7 @@ else
                                         <th>Operations</th>
                                         <th>Bound clients</th>
                                         <th>Bound aliases</th>
+                                        <th>Readiness</th>
                                         <th>Status</th>
                                         <th></th>
                                     </tr>
@@ -588,6 +833,7 @@ else
                                 <tbody>
                                     @foreach (CryptoApiManagedPolicy policy in _accessSnapshot.Policies)
                                     {
+                                        CryptoApiPolicyReadinessViewItem? policyReadiness = GetPolicyReadiness(policy.PolicyId);
                                         <tr class="@(ReferenceEquals(policy, _selectedPolicy) ? "table-active" : null)">
                                             <td>
                                                 <div class="fw-semibold">@policy.PolicyName</div>
@@ -600,6 +846,15 @@ else
                                             <td class="small text-muted">@string.Join(", ", policy.AllowedOperations)</td>
                                             <td class="small text-muted">@(FormatBoundClientSummary(policy.BoundClientIds))</td>
                                             <td class="small text-muted">@(FormatBoundAliasSummary(policy.BoundAliasIds))</td>
+                                            <td>
+                                                @if (policyReadiness is not null)
+                                                {
+                                                    <div class="d-flex flex-column gap-1">
+                                                        <span class="badge @GetReadinessBadgeClass(policyReadiness.Level)">@GetReadinessLabel(policyReadiness.Level)</span>
+                                                        <div class="small text-muted">@policyReadiness.Summary</div>
+                                                    </div>
+                                                }
+                                            </td>
                                             <td>
                                                 <span class="badge @(policy.IsEnabled ? "text-bg-success" : "text-bg-secondary")">@(policy.IsEnabled ? "Enabled" : "Disabled")</span>
                                             </td>
@@ -625,6 +880,7 @@ else
     private CryptoApiManagedKeyAlias? _selectedAlias;
     private CryptoApiManagedPolicy? _selectedPolicy;
     private CryptoApiCreatedClientKey? _revealedKey;
+    private CryptoApiAccessReadinessState? _readiness;
     private string? _statusMessage;
     private bool _statusIsError;
 
@@ -676,6 +932,7 @@ else
 
         _clientSnapshot = await clientTask;
         _accessSnapshot = await accessTask;
+        _readiness = CryptoApiAccessReadinessView.Build(_clientSnapshot, _accessSnapshot, RuntimeOptions.Value, DateTimeOffset.UtcNow);
 
         if (_clientSnapshot.Clients.Count == 0)
         {
@@ -738,6 +995,100 @@ else
         }
 
         return items[0];
+    }
+
+    private CryptoApiClientReadinessViewItem? GetClientReadiness(Guid clientId)
+        => CryptoApiAccessReadinessView.GetClient(_readiness, clientId);
+
+    private CryptoApiAliasReadinessViewItem? GetAliasReadiness(Guid aliasId)
+        => CryptoApiAccessReadinessView.GetAlias(_readiness, aliasId);
+
+    private CryptoApiPolicyReadinessViewItem? GetPolicyReadiness(Guid policyId)
+        => CryptoApiAccessReadinessView.GetPolicy(_readiness, policyId);
+
+    private IReadOnlyList<CryptoApiClientAliasReadinessViewItem> GetRoutesForClient(Guid clientId)
+        => CryptoApiAccessReadinessView.GetRoutesForClient(_readiness, clientId);
+
+    private IReadOnlyList<CryptoApiClientAliasReadinessViewItem> GetRoutesForAlias(Guid aliasId)
+        => CryptoApiAccessReadinessView.GetRoutesForAlias(_readiness, aliasId);
+
+    private static string GetReadinessBadgeClass(CryptoApiAccessReadinessLevel level)
+        => level switch
+        {
+            CryptoApiAccessReadinessLevel.Ready => "text-bg-success",
+            CryptoApiAccessReadinessLevel.NeedsAttention => "text-bg-warning",
+            _ => "text-bg-danger"
+        };
+
+    private static string GetReadinessLabel(CryptoApiAccessReadinessLevel level)
+        => level switch
+        {
+            CryptoApiAccessReadinessLevel.Ready => "Ready",
+            CryptoApiAccessReadinessLevel.NeedsAttention => "Needs attention",
+            _ => "Blocked"
+        };
+
+    private void SelectReadinessTarget(CryptoApiAccessReadinessIssue issue)
+    {
+        if (issue.TargetId is not Guid targetId)
+        {
+            return;
+        }
+
+        switch (issue.TargetKind)
+        {
+            case CryptoApiAccessReadinessTargetKind.Client:
+                SelectClientById(targetId);
+                break;
+            case CryptoApiAccessReadinessTargetKind.Alias:
+                SelectAliasById(targetId);
+                break;
+            case CryptoApiAccessReadinessTargetKind.Policy:
+                SelectPolicyById(targetId);
+                break;
+        }
+    }
+
+    private void SelectClientById(Guid clientId)
+    {
+        if (_clientSnapshot is null)
+        {
+            return;
+        }
+
+        CryptoApiManagedClient? client = _clientSnapshot.Clients.FirstOrDefault(candidate => candidate.ClientId == clientId);
+        if (client is not null)
+        {
+            SelectClient(client);
+        }
+    }
+
+    private void SelectAliasById(Guid aliasId)
+    {
+        if (_accessSnapshot is null)
+        {
+            return;
+        }
+
+        CryptoApiManagedKeyAlias? alias = _accessSnapshot.KeyAliases.FirstOrDefault(candidate => candidate.AliasId == aliasId);
+        if (alias is not null)
+        {
+            SelectAlias(alias);
+        }
+    }
+
+    private void SelectPolicyById(Guid policyId)
+    {
+        if (_accessSnapshot is null)
+        {
+            return;
+        }
+
+        CryptoApiManagedPolicy? policy = _accessSnapshot.Policies.FirstOrDefault(candidate => candidate.PolicyId == policyId);
+        if (policy is not null)
+        {
+            SelectPolicy(policy);
+        }
     }
 
     private void SelectClient(CryptoApiManagedClient client)

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccessReadinessView.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccessReadinessView.cs
@@ -1,0 +1,714 @@
+using Pkcs11Wrapper.Admin.Web.Configuration;
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Clients;
+
+namespace Pkcs11Wrapper.Admin.Web.Components.Pages;
+
+public static class CryptoApiAccessReadinessView
+{
+    public static CryptoApiAccessReadinessState Build(
+        CryptoApiClientManagementSnapshot clientSnapshot,
+        CryptoApiKeyAccessSnapshot accessSnapshot,
+        AdminCryptoApiRouteRuntimeOptions? runtimeOptions,
+        DateTimeOffset nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(clientSnapshot);
+        ArgumentNullException.ThrowIfNull(accessSnapshot);
+
+        CryptoApiRuntimeInspection runtimeInspection = CryptoApiRuntimeInspection.Create(runtimeOptions);
+        IReadOnlyDictionary<Guid, CryptoApiManagedClient> clientsById = clientSnapshot.Clients.ToDictionary(client => client.ClientId);
+        IReadOnlyDictionary<Guid, CryptoApiManagedKeyAlias> aliasesById = accessSnapshot.KeyAliases.ToDictionary(alias => alias.AliasId);
+        IReadOnlyDictionary<Guid, CryptoApiManagedPolicy> policiesById = accessSnapshot.Policies.ToDictionary(policy => policy.PolicyId);
+        HashSet<Guid> enabledPolicyIds = accessSnapshot.Policies
+            .Where(static policy => policy.IsEnabled)
+            .Select(policy => policy.PolicyId)
+            .ToHashSet();
+        IReadOnlyDictionary<Guid, int> activeKeysByClientId = clientSnapshot.Clients.ToDictionary(
+            client => client.ClientId,
+            client => client.Keys.Count(key => IsActiveKey(key, nowUtc)));
+
+        List<CryptoApiClientAliasReadinessViewItem> routes = [];
+        foreach (CryptoApiManagedClient client in clientSnapshot.Clients)
+        {
+            foreach (CryptoApiManagedKeyAlias alias in accessSnapshot.KeyAliases)
+            {
+                routes.Add(BuildRoute(client, alias, policiesById, enabledPolicyIds, activeKeysByClientId, runtimeInspection));
+            }
+        }
+
+        IReadOnlyList<CryptoApiClientReadinessViewItem> clients = clientSnapshot.Clients
+            .Select(client => BuildClient(client, accessSnapshot.KeyAliases, routes, enabledPolicyIds, activeKeysByClientId))
+            .ToArray();
+        IReadOnlyList<CryptoApiAliasReadinessViewItem> aliases = accessSnapshot.KeyAliases
+            .Select(alias => BuildAlias(alias, clientSnapshot.Clients, routes, enabledPolicyIds, activeKeysByClientId))
+            .ToArray();
+        IReadOnlyList<CryptoApiPolicyReadinessViewItem> policies = accessSnapshot.Policies
+            .Select(policy => BuildPolicy(policy, clientsById, aliasesById, routes, activeKeysByClientId))
+            .ToArray();
+
+        return new CryptoApiAccessReadinessState(
+            RuntimeInspectionConfigured: runtimeInspection.HasRuntimeContext,
+            RuntimeInspectionSummary: runtimeInspection.Summary,
+            Clients: clients,
+            Aliases: aliases,
+            Policies: policies,
+            Routes: routes);
+    }
+
+    public static CryptoApiClientReadinessViewItem? GetClient(CryptoApiAccessReadinessState? state, Guid clientId)
+        => state?.Clients.FirstOrDefault(item => item.ClientId == clientId);
+
+    public static CryptoApiAliasReadinessViewItem? GetAlias(CryptoApiAccessReadinessState? state, Guid aliasId)
+        => state?.Aliases.FirstOrDefault(item => item.AliasId == aliasId);
+
+    public static CryptoApiPolicyReadinessViewItem? GetPolicy(CryptoApiAccessReadinessState? state, Guid policyId)
+        => state?.Policies.FirstOrDefault(item => item.PolicyId == policyId);
+
+    public static IReadOnlyList<CryptoApiClientAliasReadinessViewItem> GetRoutesForClient(CryptoApiAccessReadinessState? state, Guid clientId)
+        => state?.Routes
+            .Where(item => item.ClientId == clientId)
+            .OrderBy(item => item.Level)
+            .ThenBy(item => item.AliasName, StringComparer.OrdinalIgnoreCase)
+            .ToArray()
+            ?? [];
+
+    public static IReadOnlyList<CryptoApiClientAliasReadinessViewItem> GetRoutesForAlias(CryptoApiAccessReadinessState? state, Guid aliasId)
+        => state?.Routes
+            .Where(item => item.AliasId == aliasId)
+            .OrderBy(item => item.Level)
+            .ThenBy(item => item.ClientDisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToArray()
+            ?? [];
+
+    private static CryptoApiClientAliasReadinessViewItem BuildRoute(
+        CryptoApiManagedClient client,
+        CryptoApiManagedKeyAlias alias,
+        IReadOnlyDictionary<Guid, CryptoApiManagedPolicy> policiesById,
+        HashSet<Guid> enabledPolicyIds,
+        IReadOnlyDictionary<Guid, int> activeKeysByClientId,
+        CryptoApiRuntimeInspection runtimeInspection)
+    {
+        List<CryptoApiAccessReadinessIssue> issues = [];
+
+        if (!client.IsEnabled)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' is disabled.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+
+        if (activeKeysByClientId.TryGetValue(client.ClientId, out int activeKeyCount) && activeKeyCount == 0)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' has no active API key.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+
+        if (!alias.IsEnabled)
+        {
+            issues.Add(Blocker($"Alias '{alias.AliasName}' is disabled.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+
+        IReadOnlyList<CryptoApiManagedPolicy> enabledClientPolicies = client.BoundPolicyIds
+            .Where(enabledPolicyIds.Contains)
+            .Select(policyId => policiesById[policyId])
+            .OrderBy(policy => policy.PolicyName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        IReadOnlyList<CryptoApiManagedPolicy> enabledAliasPolicies = alias.BoundPolicyIds
+            .Where(enabledPolicyIds.Contains)
+            .Select(policyId => policiesById[policyId])
+            .OrderBy(policy => policy.PolicyName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Guid[] sharedDisabledPolicyIds = client.BoundPolicyIds
+            .Intersect(alias.BoundPolicyIds)
+            .Where(policyId => policiesById.TryGetValue(policyId, out CryptoApiManagedPolicy? policy) && !policy.IsEnabled)
+            .Distinct()
+            .ToArray();
+
+        AddPolicyBindingIssues(
+            issues,
+            ownerLabel: $"Client '{client.DisplayName}'",
+            boundPolicyIds: client.BoundPolicyIds,
+            enabledPolicies: enabledClientPolicies,
+            fallbackTargetKind: CryptoApiAccessReadinessTargetKind.Client,
+            fallbackTargetId: client.ClientId,
+            fallbackActionLabel: "Open client",
+            policiesById);
+        AddPolicyBindingIssues(
+            issues,
+            ownerLabel: $"Alias '{alias.AliasName}'",
+            boundPolicyIds: alias.BoundPolicyIds,
+            enabledPolicies: enabledAliasPolicies,
+            fallbackTargetKind: CryptoApiAccessReadinessTargetKind.Alias,
+            fallbackTargetId: alias.AliasId,
+            fallbackActionLabel: "Open alias",
+            policiesById);
+
+        IReadOnlyList<CryptoApiManagedPolicy> sharedEnabledPolicies = enabledClientPolicies
+            .Where(policy => alias.BoundPolicyIds.Contains(policy.PolicyId))
+            .OrderBy(policy => policy.PolicyName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (sharedEnabledPolicies.Count == 0)
+        {
+            if (sharedDisabledPolicyIds.Length > 0)
+            {
+                CryptoApiManagedPolicy disabledSharedPolicy = policiesById[sharedDisabledPolicyIds[0]];
+                issues.Add(Blocker(
+                    $"Client '{client.DisplayName}' and alias '{alias.AliasName}' only share disabled policies.",
+                    CryptoApiAccessReadinessTargetKind.Policy,
+                    disabledSharedPolicy.PolicyId,
+                    "Open policy"));
+            }
+            else if (client.BoundPolicyIds.Count > 0 && alias.BoundPolicyIds.Count > 0)
+            {
+                issues.Add(Blocker(
+                    $"Client '{client.DisplayName}' and alias '{alias.AliasName}' do not share any enabled policies.",
+                    CryptoApiAccessReadinessTargetKind.Client,
+                    client.ClientId,
+                    "Open client"));
+            }
+        }
+
+        foreach (CryptoApiAccessReadinessIssue routeIssue in EvaluateRoute(alias, runtimeInspection))
+        {
+            issues.Add(routeIssue);
+        }
+
+        CryptoApiAccessReadinessLevel level = DetermineLevel(issues);
+        string summary = level switch
+        {
+            CryptoApiAccessReadinessLevel.Ready => $"Ready via {sharedEnabledPolicies.Count} shared enabled {(sharedEnabledPolicies.Count == 1 ? "policy" : "policies")}",
+            CryptoApiAccessReadinessLevel.NeedsAttention => issues.First(issue => issue.Severity == CryptoApiAccessIssueSeverity.Warning).Message,
+            _ => issues.First(issue => issue.Severity == CryptoApiAccessIssueSeverity.Blocker).Message
+        };
+
+        string routeSummary = BuildRouteSummary(alias, runtimeInspection);
+        IReadOnlyList<string> allowedOperations = sharedEnabledPolicies
+            .SelectMany(policy => policy.AllowedOperations)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(operation => operation, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new CryptoApiClientAliasReadinessViewItem(
+            ClientId: client.ClientId,
+            ClientDisplayName: client.DisplayName,
+            ClientName: client.ClientName,
+            AliasId: alias.AliasId,
+            AliasName: alias.AliasName,
+            Level: level,
+            Summary: summary,
+            RouteSummary: routeSummary,
+            SharedPolicyNames: sharedEnabledPolicies.Select(policy => policy.PolicyName).ToArray(),
+            AllowedOperations: allowedOperations,
+            Issues: issues);
+    }
+
+    private static CryptoApiClientReadinessViewItem BuildClient(
+        CryptoApiManagedClient client,
+        IReadOnlyList<CryptoApiManagedKeyAlias> aliases,
+        IReadOnlyList<CryptoApiClientAliasReadinessViewItem> routes,
+        HashSet<Guid> enabledPolicyIds,
+        IReadOnlyDictionary<Guid, int> activeKeysByClientId)
+    {
+        IReadOnlyList<CryptoApiClientAliasReadinessViewItem> clientRoutes = routes
+            .Where(route => route.ClientId == client.ClientId)
+            .ToArray();
+        int readyRouteCount = clientRoutes.Count(route => route.Level == CryptoApiAccessReadinessLevel.Ready);
+        int attentionRouteCount = clientRoutes.Count(route => route.Level == CryptoApiAccessReadinessLevel.NeedsAttention);
+        int blockedRouteCount = clientRoutes.Count - readyRouteCount - attentionRouteCount;
+        int activeKeyCount = activeKeysByClientId.TryGetValue(client.ClientId, out int count) ? count : 0;
+        List<CryptoApiAccessReadinessIssue> issues = [];
+
+        if (!client.IsEnabled)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' is disabled.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+
+        if (activeKeyCount == 0)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' has no active API key.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+
+        IReadOnlyList<Guid> enabledClientPolicyIds = client.BoundPolicyIds.Where(enabledPolicyIds.Contains).ToArray();
+        if (client.BoundPolicyIds.Count == 0)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' is not bound to any policies.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+        else if (enabledClientPolicyIds.Count == 0)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' only has disabled policy bindings.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+
+        if (aliases.Count == 0)
+        {
+            issues.Add(Blocker("No key aliases exist yet.", CryptoApiAccessReadinessTargetKind.Alias, null, null));
+        }
+        else if (readyRouteCount == 0 && attentionRouteCount == 0)
+        {
+            issues.Add(Blocker($"Client '{client.DisplayName}' cannot currently authorize any alias.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+        else if (readyRouteCount == 0 && attentionRouteCount > 0)
+        {
+            issues.Add(Warning($"Client '{client.DisplayName}' has alias routes that still need route-host verification.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+        else if (blockedRouteCount > 0)
+        {
+            issues.Add(Warning($"{blockedRouteCount} alias {(blockedRouteCount == 1 ? "route is" : "routes are")} still blocked for this client.", CryptoApiAccessReadinessTargetKind.Client, client.ClientId, "Open client"));
+        }
+
+        CryptoApiAccessReadinessLevel level = DetermineAggregateLevel(readyRouteCount, attentionRouteCount);
+        string summary = level switch
+        {
+            CryptoApiAccessReadinessLevel.Ready => $"Operable against {readyRouteCount} alias {(readyRouteCount == 1 ? "route" : "routes")}",
+            CryptoApiAccessReadinessLevel.NeedsAttention => attentionRouteCount == 1
+                ? "No alias is fully verified yet, but 1 route is close to ready."
+                : $"No alias is fully verified yet, but {attentionRouteCount} routes are close to ready.",
+            _ => issues.FirstOrDefault(issue => issue.Severity == CryptoApiAccessIssueSeverity.Blocker)?.Message
+                ?? $"No usable alias routes are available for client '{client.DisplayName}'."
+        };
+
+        return new CryptoApiClientReadinessViewItem(
+            ClientId: client.ClientId,
+            Level: level,
+            Summary: summary,
+            ActiveKeyCount: activeKeyCount,
+            ReadyRouteCount: readyRouteCount,
+            NeedsAttentionRouteCount: attentionRouteCount,
+            BlockedRouteCount: blockedRouteCount,
+            Issues: issues);
+    }
+
+    private static CryptoApiAliasReadinessViewItem BuildAlias(
+        CryptoApiManagedKeyAlias alias,
+        IReadOnlyList<CryptoApiManagedClient> clients,
+        IReadOnlyList<CryptoApiClientAliasReadinessViewItem> routes,
+        HashSet<Guid> enabledPolicyIds,
+        IReadOnlyDictionary<Guid, int> activeKeysByClientId)
+    {
+        IReadOnlyList<CryptoApiClientAliasReadinessViewItem> aliasRoutes = routes
+            .Where(route => route.AliasId == alias.AliasId)
+            .ToArray();
+        int readyClientCount = aliasRoutes.Count(route => route.Level == CryptoApiAccessReadinessLevel.Ready);
+        int attentionClientCount = aliasRoutes.Count(route => route.Level == CryptoApiAccessReadinessLevel.NeedsAttention);
+        int blockedClientCount = aliasRoutes.Count - readyClientCount - attentionClientCount;
+        List<CryptoApiAccessReadinessIssue> issues = [];
+
+        if (!alias.IsEnabled)
+        {
+            issues.Add(Blocker($"Alias '{alias.AliasName}' is disabled.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+
+        IReadOnlyList<Guid> enabledAliasPolicyIds = alias.BoundPolicyIds.Where(enabledPolicyIds.Contains).ToArray();
+        if (alias.BoundPolicyIds.Count == 0)
+        {
+            issues.Add(Blocker($"Alias '{alias.AliasName}' is not bound to any policies.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+        else if (enabledAliasPolicyIds.Count == 0)
+        {
+            issues.Add(Blocker($"Alias '{alias.AliasName}' only has disabled policy bindings.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+
+        foreach (CryptoApiAccessReadinessIssue routeIssue in EvaluateRoute(alias, CryptoApiRuntimeInspection.None))
+        {
+            if (routeIssue.Severity == CryptoApiAccessIssueSeverity.Blocker)
+            {
+                issues.Add(routeIssue);
+            }
+        }
+
+        if (clients.Count == 0)
+        {
+            issues.Add(Blocker("No API clients exist yet.", CryptoApiAccessReadinessTargetKind.Client, null, null));
+        }
+        else if (!clients.Any(client => client.IsEnabled && activeKeysByClientId.TryGetValue(client.ClientId, out int activeKeyCount) && activeKeyCount > 0))
+        {
+            issues.Add(Blocker("No enabled client currently has an active API key.", CryptoApiAccessReadinessTargetKind.Client, null, null));
+        }
+        else if (readyClientCount == 0 && attentionClientCount == 0)
+        {
+            issues.Add(Blocker($"Alias '{alias.AliasName}' is not currently operable for any client.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+        else if (readyClientCount == 0 && attentionClientCount > 0)
+        {
+            issues.Add(Warning($"Alias '{alias.AliasName}' still needs route-host verification before any client is fully ready.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+        else if (blockedClientCount > 0)
+        {
+            issues.Add(Warning($"{blockedClientCount} client {(blockedClientCount == 1 ? "binding is" : "bindings are")} still blocked for this alias.", CryptoApiAccessReadinessTargetKind.Alias, alias.AliasId, "Open alias"));
+        }
+
+        CryptoApiAccessReadinessLevel level = DetermineAggregateLevel(readyClientCount, attentionClientCount);
+        string summary = level switch
+        {
+            CryptoApiAccessReadinessLevel.Ready => $"Callable by {readyClientCount} client {(readyClientCount == 1 ? "route" : "routes")}",
+            CryptoApiAccessReadinessLevel.NeedsAttention => attentionClientCount == 1
+                ? "No client is fully verified yet, but 1 route is close to ready."
+                : $"No client is fully verified yet, but {attentionClientCount} routes are close to ready.",
+            _ => issues.FirstOrDefault(issue => issue.Severity == CryptoApiAccessIssueSeverity.Blocker)?.Message
+                ?? $"Alias '{alias.AliasName}' is not currently operable."
+        };
+
+        return new CryptoApiAliasReadinessViewItem(
+            AliasId: alias.AliasId,
+            Level: level,
+            Summary: summary,
+            ReadyClientCount: readyClientCount,
+            NeedsAttentionClientCount: attentionClientCount,
+            BlockedClientCount: blockedClientCount,
+            Issues: issues);
+    }
+
+    private static CryptoApiPolicyReadinessViewItem BuildPolicy(
+        CryptoApiManagedPolicy policy,
+        IReadOnlyDictionary<Guid, CryptoApiManagedClient> clientsById,
+        IReadOnlyDictionary<Guid, CryptoApiManagedKeyAlias> aliasesById,
+        IReadOnlyList<CryptoApiClientAliasReadinessViewItem> routes,
+        IReadOnlyDictionary<Guid, int> activeKeysByClientId)
+    {
+        IReadOnlyList<CryptoApiClientAliasReadinessViewItem> policyRoutes = routes
+            .Where(route => route.SharedPolicyNames.Contains(policy.PolicyName, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
+        int readyRouteCount = policyRoutes.Count(route => route.Level == CryptoApiAccessReadinessLevel.Ready);
+        int attentionRouteCount = policyRoutes.Count(route => route.Level == CryptoApiAccessReadinessLevel.NeedsAttention);
+        int blockedRouteCount = policyRoutes.Count - readyRouteCount - attentionRouteCount;
+        int enabledClientBindingCount = policy.BoundClientIds.Count(clientId => clientsById.TryGetValue(clientId, out CryptoApiManagedClient? client) && client.IsEnabled);
+        int enabledAliasBindingCount = policy.BoundAliasIds.Count(aliasId => aliasesById.TryGetValue(aliasId, out CryptoApiManagedKeyAlias? alias) && alias.IsEnabled);
+        int activeClientBindingCount = policy.BoundClientIds.Count(clientId => clientsById.TryGetValue(clientId, out CryptoApiManagedClient? client)
+            && client.IsEnabled
+            && activeKeysByClientId.TryGetValue(clientId, out int activeKeyCount)
+            && activeKeyCount > 0);
+
+        List<CryptoApiAccessReadinessIssue> issues = [];
+        if (!policy.IsEnabled)
+        {
+            issues.Add(Blocker($"Policy '{policy.PolicyName}' is disabled.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+
+        if (policy.BoundClientIds.Count == 0)
+        {
+            issues.Add(Blocker($"Policy '{policy.PolicyName}' is not bound to any clients.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+        else if (enabledClientBindingCount == 0)
+        {
+            issues.Add(Blocker($"Policy '{policy.PolicyName}' is only bound to disabled clients.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+        else if (activeClientBindingCount == 0)
+        {
+            issues.Add(Blocker($"No enabled client bound to policy '{policy.PolicyName}' has an active API key.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+
+        if (policy.BoundAliasIds.Count == 0)
+        {
+            issues.Add(Blocker($"Policy '{policy.PolicyName}' is not bound to any aliases.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+        else if (enabledAliasBindingCount == 0)
+        {
+            issues.Add(Blocker($"Policy '{policy.PolicyName}' is only bound to disabled aliases.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+
+        if (readyRouteCount == 0 && attentionRouteCount > 0)
+        {
+            issues.Add(Warning($"Policy '{policy.PolicyName}' is bound on both sides, but route-host verification is still pending.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+        else if (readyRouteCount == 0 && blockedRouteCount > 0)
+        {
+            issues.Add(Blocker($"Policy '{policy.PolicyName}' does not currently authorize any operable client/alias route.", CryptoApiAccessReadinessTargetKind.Policy, policy.PolicyId, "Open policy"));
+        }
+
+        CryptoApiAccessReadinessLevel level = DetermineAggregateLevel(readyRouteCount, attentionRouteCount);
+        string summary = level switch
+        {
+            CryptoApiAccessReadinessLevel.Ready => $"Authorizes {readyRouteCount} ready {(readyRouteCount == 1 ? "route" : "routes")}",
+            CryptoApiAccessReadinessLevel.NeedsAttention => attentionRouteCount == 1
+                ? "Bound on both sides, but 1 route still needs verification."
+                : $"Bound on both sides, but {attentionRouteCount} routes still need verification.",
+            _ => issues.FirstOrDefault(issue => issue.Severity == CryptoApiAccessIssueSeverity.Blocker)?.Message
+                ?? $"Policy '{policy.PolicyName}' is not currently usable."
+        };
+
+        return new CryptoApiPolicyReadinessViewItem(
+            PolicyId: policy.PolicyId,
+            Level: level,
+            Summary: summary,
+            ReadyRouteCount: readyRouteCount,
+            NeedsAttentionRouteCount: attentionRouteCount,
+            BlockedRouteCount: blockedRouteCount,
+            Issues: issues);
+    }
+
+    private static IReadOnlyList<CryptoApiAccessReadinessIssue> EvaluateRoute(CryptoApiManagedKeyAlias alias, CryptoApiRuntimeInspection runtimeInspection)
+    {
+        List<CryptoApiAccessReadinessIssue> issues = [];
+
+        if (!string.IsNullOrWhiteSpace(alias.RouteGroupName))
+        {
+            string routeGroupName = alias.RouteGroupName.Trim();
+            if (!runtimeInspection.HasRuntimeContext)
+            {
+                issues.Add(Warning(
+                    $"Route group '{routeGroupName}' is defined in shared state, but the admin host does not expose CryptoApiRuntime config to verify it locally.",
+                    CryptoApiAccessReadinessTargetKind.Alias,
+                    alias.AliasId,
+                    "Open alias"));
+                return issues;
+            }
+
+            if (!runtimeInspection.RouteGroups.TryGetValue(routeGroupName, out CryptoApiRuntimeRouteGroupInspection? routeGroup))
+            {
+                issues.Add(Blocker(
+                    $"Route group '{routeGroupName}' is not defined in the admin runtime context.",
+                    CryptoApiAccessReadinessTargetKind.Alias,
+                    alias.AliasId,
+                    "Open alias"));
+                return issues;
+            }
+
+            if (routeGroup.Candidates.Count == 0)
+            {
+                issues.Add(Blocker(
+                    $"Route group '{routeGroupName}' has no enabled backend candidates.",
+                    CryptoApiAccessReadinessTargetKind.Alias,
+                    alias.AliasId,
+                    "Open alias"));
+            }
+
+            return issues;
+        }
+
+        if (alias.SlotId is null)
+        {
+            issues.Add(Blocker(
+                $"Alias '{alias.AliasName}' does not define a slot id or route group.",
+                CryptoApiAccessReadinessTargetKind.Alias,
+                alias.AliasId,
+                "Open alias"));
+            return issues;
+        }
+
+        if (!string.IsNullOrWhiteSpace(alias.DeviceRoute)
+            && runtimeInspection.EnabledBackendNames.Count > 0
+            && !runtimeInspection.EnabledBackendNames.Contains(alias.DeviceRoute.Trim()))
+        {
+            issues.Add(Blocker(
+                $"Legacy device route '{alias.DeviceRoute}' is not enabled in the admin runtime context.",
+                CryptoApiAccessReadinessTargetKind.Alias,
+                alias.AliasId,
+                "Open alias"));
+        }
+
+        return issues;
+    }
+
+    private static string BuildRouteSummary(CryptoApiManagedKeyAlias alias, CryptoApiRuntimeInspection runtimeInspection)
+    {
+        if (!string.IsNullOrWhiteSpace(alias.RouteGroupName))
+        {
+            string routeGroupName = alias.RouteGroupName.Trim();
+            if (runtimeInspection.RouteGroups.TryGetValue(routeGroupName, out CryptoApiRuntimeRouteGroupInspection? routeGroup)
+                && routeGroup.Candidates.Count > 0)
+            {
+                return $"group={routeGroupName} ({routeGroup.Candidates.Count} candidate{(routeGroup.Candidates.Count == 1 ? string.Empty : "s")})";
+            }
+
+            return $"group={routeGroupName}";
+        }
+
+        string slot = alias.SlotId?.ToString() ?? "missing";
+        string device = string.IsNullOrWhiteSpace(alias.DeviceRoute) ? "default" : alias.DeviceRoute.Trim();
+        return $"slot={slot}, device={device}";
+    }
+
+    private static void AddPolicyBindingIssues(
+        ICollection<CryptoApiAccessReadinessIssue> issues,
+        string ownerLabel,
+        IReadOnlyCollection<Guid> boundPolicyIds,
+        IReadOnlyList<CryptoApiManagedPolicy> enabledPolicies,
+        CryptoApiAccessReadinessTargetKind fallbackTargetKind,
+        Guid fallbackTargetId,
+        string fallbackActionLabel,
+        IReadOnlyDictionary<Guid, CryptoApiManagedPolicy> policiesById)
+    {
+        if (boundPolicyIds.Count == 0)
+        {
+            issues.Add(Blocker($"{ownerLabel} is not bound to any policies.", fallbackTargetKind, fallbackTargetId, fallbackActionLabel));
+            return;
+        }
+
+        if (enabledPolicies.Count > 0)
+        {
+            return;
+        }
+
+        Guid disabledPolicyId = boundPolicyIds.First();
+        if (policiesById.TryGetValue(disabledPolicyId, out CryptoApiManagedPolicy? disabledPolicy) && !disabledPolicy.IsEnabled)
+        {
+            issues.Add(Blocker($"{ownerLabel} only has disabled policy bindings.", CryptoApiAccessReadinessTargetKind.Policy, disabledPolicy.PolicyId, "Open policy"));
+            return;
+        }
+
+        issues.Add(Blocker($"{ownerLabel} only has unusable policy bindings.", fallbackTargetKind, fallbackTargetId, fallbackActionLabel));
+    }
+
+    private static CryptoApiAccessReadinessLevel DetermineLevel(IReadOnlyCollection<CryptoApiAccessReadinessIssue> issues)
+        => issues.Any(issue => issue.Severity == CryptoApiAccessIssueSeverity.Blocker)
+            ? CryptoApiAccessReadinessLevel.Blocked
+            : issues.Any(issue => issue.Severity == CryptoApiAccessIssueSeverity.Warning)
+                ? CryptoApiAccessReadinessLevel.NeedsAttention
+                : CryptoApiAccessReadinessLevel.Ready;
+
+    private static CryptoApiAccessReadinessLevel DetermineAggregateLevel(int readyCount, int attentionCount)
+        => readyCount > 0
+            ? CryptoApiAccessReadinessLevel.Ready
+            : attentionCount > 0
+                ? CryptoApiAccessReadinessLevel.NeedsAttention
+                : CryptoApiAccessReadinessLevel.Blocked;
+
+    private static CryptoApiAccessReadinessIssue Blocker(string message, CryptoApiAccessReadinessTargetKind targetKind, Guid? targetId, string? actionLabel)
+        => new(CryptoApiAccessIssueSeverity.Blocker, message, targetKind, targetId, actionLabel);
+
+    private static CryptoApiAccessReadinessIssue Warning(string message, CryptoApiAccessReadinessTargetKind targetKind, Guid? targetId, string? actionLabel)
+        => new(CryptoApiAccessIssueSeverity.Warning, message, targetKind, targetId, actionLabel);
+
+    private static bool IsActiveKey(CryptoApiManagedClientKey key, DateTimeOffset nowUtc)
+        => key.IsEnabled
+            && key.RevokedAtUtc is null
+            && (key.ExpiresAtUtc is null || key.ExpiresAtUtc > nowUtc);
+
+    private sealed record CryptoApiRuntimeInspection(
+        bool HasRuntimeContext,
+        string Summary,
+        IReadOnlyDictionary<string, CryptoApiRuntimeRouteGroupInspection> RouteGroups,
+        HashSet<string> EnabledBackendNames)
+    {
+        public static CryptoApiRuntimeInspection None { get; } = new(
+            HasRuntimeContext: false,
+            Summary: "The admin host does not expose CryptoApiRuntime configuration, so route-group aliases are reported as needing local route-host verification.",
+            RouteGroups: new Dictionary<string, CryptoApiRuntimeRouteGroupInspection>(StringComparer.OrdinalIgnoreCase),
+            EnabledBackendNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        public static CryptoApiRuntimeInspection Create(AdminCryptoApiRouteRuntimeOptions? options)
+        {
+            if (options is null)
+            {
+                return None;
+            }
+
+            bool hasRuntimeContext = !string.IsNullOrWhiteSpace(options.ModulePath)
+                || options.Backends.Count > 0
+                || options.RouteGroups.Count > 0;
+            if (!hasRuntimeContext)
+            {
+                return None;
+            }
+
+            HashSet<string> enabledBackends = options.Backends
+                .Where(static backend => backend.Enabled && !string.IsNullOrWhiteSpace(backend.Name))
+                .Select(backend => backend.Name!.Trim())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            Dictionary<string, CryptoApiRuntimeRouteGroupInspection> routeGroups = new(StringComparer.OrdinalIgnoreCase);
+            foreach (AdminCryptoApiRuntimeRouteGroupOptions group in options.RouteGroups)
+            {
+                if (string.IsNullOrWhiteSpace(group.Name))
+                {
+                    continue;
+                }
+
+                string name = group.Name.Trim();
+                IReadOnlyList<CryptoApiRouteCandidate> candidates = group.Backends
+                    .Where(static candidate => candidate.Enabled && !string.IsNullOrWhiteSpace(candidate.BackendName))
+                    .Select(candidate => new CryptoApiRouteCandidate(candidate.BackendName!.Trim(), candidate.SlotId, candidate.Priority))
+                    .Where(candidate => enabledBackends.Count == 0 || enabledBackends.Contains(candidate.DeviceRoute ?? string.Empty))
+                    .OrderBy(candidate => candidate.Priority)
+                    .ThenBy(candidate => candidate.DeviceRoute, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                routeGroups[name] = new CryptoApiRuntimeRouteGroupInspection(name, candidates);
+            }
+
+            return new CryptoApiRuntimeInspection(
+                HasRuntimeContext: true,
+                Summary: "Route diagnostics are evaluated against the admin host CryptoApiRuntime configuration. Group availability here should match at least one deployed Crypto API runtime to count as fully ready.",
+                RouteGroups: routeGroups,
+                EnabledBackendNames: enabledBackends);
+        }
+    }
+}
+
+public sealed record CryptoApiAccessReadinessState(
+    bool RuntimeInspectionConfigured,
+    string RuntimeInspectionSummary,
+    IReadOnlyList<CryptoApiClientReadinessViewItem> Clients,
+    IReadOnlyList<CryptoApiAliasReadinessViewItem> Aliases,
+    IReadOnlyList<CryptoApiPolicyReadinessViewItem> Policies,
+    IReadOnlyList<CryptoApiClientAliasReadinessViewItem> Routes);
+
+public sealed record CryptoApiClientReadinessViewItem(
+    Guid ClientId,
+    CryptoApiAccessReadinessLevel Level,
+    string Summary,
+    int ActiveKeyCount,
+    int ReadyRouteCount,
+    int NeedsAttentionRouteCount,
+    int BlockedRouteCount,
+    IReadOnlyList<CryptoApiAccessReadinessIssue> Issues);
+
+public sealed record CryptoApiAliasReadinessViewItem(
+    Guid AliasId,
+    CryptoApiAccessReadinessLevel Level,
+    string Summary,
+    int ReadyClientCount,
+    int NeedsAttentionClientCount,
+    int BlockedClientCount,
+    IReadOnlyList<CryptoApiAccessReadinessIssue> Issues);
+
+public sealed record CryptoApiPolicyReadinessViewItem(
+    Guid PolicyId,
+    CryptoApiAccessReadinessLevel Level,
+    string Summary,
+    int ReadyRouteCount,
+    int NeedsAttentionRouteCount,
+    int BlockedRouteCount,
+    IReadOnlyList<CryptoApiAccessReadinessIssue> Issues);
+
+public sealed record CryptoApiClientAliasReadinessViewItem(
+    Guid ClientId,
+    string ClientDisplayName,
+    string ClientName,
+    Guid AliasId,
+    string AliasName,
+    CryptoApiAccessReadinessLevel Level,
+    string Summary,
+    string RouteSummary,
+    IReadOnlyList<string> SharedPolicyNames,
+    IReadOnlyList<string> AllowedOperations,
+    IReadOnlyList<CryptoApiAccessReadinessIssue> Issues);
+
+public sealed record CryptoApiAccessReadinessIssue(
+    CryptoApiAccessIssueSeverity Severity,
+    string Message,
+    CryptoApiAccessReadinessTargetKind TargetKind,
+    Guid? TargetId,
+    string? ActionLabel);
+
+public sealed record CryptoApiRuntimeRouteGroupInspection(
+    string Name,
+    IReadOnlyList<CryptoApiRouteCandidate> Candidates);
+
+public enum CryptoApiAccessReadinessLevel
+{
+    Ready = 0,
+    NeedsAttention = 1,
+    Blocked = 2
+}
+
+public enum CryptoApiAccessIssueSeverity
+{
+    Warning = 0,
+    Blocker = 1
+}
+
+public enum CryptoApiAccessReadinessTargetKind
+{
+    None = 0,
+    Client,
+    Alias,
+    Policy
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Configuration/AdminCryptoApiRouteRuntimeOptions.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Configuration/AdminCryptoApiRouteRuntimeOptions.cs
@@ -1,0 +1,37 @@
+namespace Pkcs11Wrapper.Admin.Web.Configuration;
+
+public sealed class AdminCryptoApiRouteRuntimeOptions
+{
+    public const string SectionName = "CryptoApiRuntime";
+
+    public string? ModulePath { get; set; }
+
+    public List<AdminCryptoApiRuntimeBackendOptions> Backends { get; set; } = [];
+
+    public List<AdminCryptoApiRuntimeRouteGroupOptions> RouteGroups { get; set; } = [];
+}
+
+public sealed class AdminCryptoApiRuntimeBackendOptions
+{
+    public string? Name { get; set; }
+
+    public bool Enabled { get; set; } = true;
+}
+
+public sealed class AdminCryptoApiRuntimeRouteGroupOptions
+{
+    public string? Name { get; set; }
+
+    public List<AdminCryptoApiRuntimeRouteBackendOptions> Backends { get; set; } = [];
+}
+
+public sealed class AdminCryptoApiRuntimeRouteBackendOptions
+{
+    public string? BackendName { get; set; }
+
+    public ulong SlotId { get; set; }
+
+    public int Priority { get; set; }
+
+    public bool Enabled { get; set; } = true;
+}

--- a/src/Pkcs11Wrapper.Admin.Web/Program.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Program.cs
@@ -66,6 +66,8 @@ builder.Services.AddOptions<CryptoApiSharedPersistenceOptions>()
         static options => CryptoApiSharedPersistenceDefaults.IsSupportedProvider(options.Provider),
         $"Crypto API shared persistence supports '{CryptoApiSharedPersistenceDefaults.PostgresProvider}' only.")
     .ValidateOnStart();
+builder.Services.AddOptions<AdminCryptoApiRouteRuntimeOptions>()
+    .Bind(builder.Configuration.GetSection(AdminCryptoApiRouteRuntimeOptions.SectionName));
 
 AdminStorageOptions adminStorage = builder.Configuration.GetSection("AdminStorage").Get<AdminStorageOptions>() ?? new();
 adminStorage.DataRoot = AdminHostDefaults.ResolveStorageRoot(adminStorage.DataRoot, builder.Environment.ContentRootPath);

--- a/tests/Pkcs11Wrapper.Admin.Tests/CryptoApiAccessReadinessViewTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/CryptoApiAccessReadinessViewTests.cs
@@ -1,0 +1,264 @@
+using Pkcs11Wrapper.Admin.Web.Components.Pages;
+using Pkcs11Wrapper.Admin.Web.Configuration;
+using Pkcs11Wrapper.CryptoApi.Access;
+using Pkcs11Wrapper.CryptoApi.Clients;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed class CryptoApiAccessReadinessViewTests
+{
+    private static readonly DateTimeOffset NowUtc = new(2026, 04, 05, 17, 30, 00, TimeSpan.Zero);
+
+    [Fact]
+    public void BuildMarksLegacyClientAliasPolicyPathReady()
+    {
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid policyId = Guid.NewGuid();
+
+        CryptoApiAccessReadinessState state = CryptoApiAccessReadinessView.Build(
+            CreateClientSnapshot(CreateClient(clientId, policyId, CreateActiveKey(clientId))),
+            CreateAccessSnapshot(CreateAlias(aliasId, policyId, slotId: 7), CreatePolicy(policyId, clientId, aliasId)),
+            runtimeOptions: null,
+            nowUtc: NowUtc);
+
+        CryptoApiClientReadinessViewItem client = Assert.Single(state.Clients);
+        CryptoApiAliasReadinessViewItem alias = Assert.Single(state.Aliases);
+        CryptoApiPolicyReadinessViewItem policy = Assert.Single(state.Policies);
+        CryptoApiClientAliasReadinessViewItem route = Assert.Single(state.Routes);
+
+        Assert.Equal(CryptoApiAccessReadinessLevel.Ready, client.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.Ready, alias.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.Ready, policy.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.Ready, route.Level);
+        Assert.Contains("sign", route.AllowedOperations);
+        Assert.Contains("verify", route.AllowedOperations);
+    }
+
+    [Fact]
+    public void BuildBlocksClientAndRouteWhenNoActiveKeyExists()
+    {
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid policyId = Guid.NewGuid();
+
+        CryptoApiAccessReadinessState state = CryptoApiAccessReadinessView.Build(
+            CreateClientSnapshot(CreateClient(clientId, policyId, CreateDisabledKey(clientId))),
+            CreateAccessSnapshot(CreateAlias(aliasId, policyId, slotId: 9), CreatePolicy(policyId, clientId, aliasId)),
+            runtimeOptions: null,
+            nowUtc: NowUtc);
+
+        CryptoApiClientReadinessViewItem client = Assert.Single(state.Clients);
+        CryptoApiClientAliasReadinessViewItem route = Assert.Single(state.Routes);
+
+        Assert.Equal(CryptoApiAccessReadinessLevel.Blocked, client.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.Blocked, route.Level);
+        Assert.Contains(client.Issues, issue => issue.Message.Contains("no active API key", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(route.Issues, issue => issue.Message.Contains("no active API key", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildBlocksWhenClientAndAliasOnlyShareDisabledPolicies()
+    {
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid policyId = Guid.NewGuid();
+
+        CryptoApiAccessReadinessState state = CryptoApiAccessReadinessView.Build(
+            CreateClientSnapshot(CreateClient(clientId, policyId, CreateActiveKey(clientId))),
+            CreateAccessSnapshot(CreateAlias(aliasId, policyId, slotId: 4), CreatePolicy(policyId, clientId, aliasId, enabled: false)),
+            runtimeOptions: null,
+            nowUtc: NowUtc);
+
+        CryptoApiClientAliasReadinessViewItem route = Assert.Single(state.Routes);
+        CryptoApiPolicyReadinessViewItem policy = Assert.Single(state.Policies);
+
+        Assert.Equal(CryptoApiAccessReadinessLevel.Blocked, route.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.Blocked, policy.Level);
+        Assert.Contains(route.Issues, issue => issue.Message.Contains("disabled policies", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(policy.Issues, issue => issue.Message.Contains("disabled", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildBlocksWhenClientAndAliasDoNotShareAnyEnabledPolicy()
+    {
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid clientPolicyId = Guid.NewGuid();
+        Guid aliasPolicyId = Guid.NewGuid();
+
+        CryptoApiAccessReadinessState state = CryptoApiAccessReadinessView.Build(
+            CreateClientSnapshot(CreateClient(clientId, clientPolicyId, CreateActiveKey(clientId))),
+            new CryptoApiKeyAccessSnapshot(
+                SharedPersistenceConfigured: true,
+                SharedPersistenceProvider: "postgres",
+                ConnectionTarget: "postgres://tests",
+                SchemaVersion: 1,
+                KeyAliases: [CreateAlias(aliasId, aliasPolicyId, slotId: 11)],
+                Policies:
+                [
+                    CreatePolicy(clientPolicyId, clientId, aliasId: Guid.NewGuid()),
+                    CreatePolicy(aliasPolicyId, clientId: Guid.NewGuid(), aliasId)
+                ]),
+            runtimeOptions: null,
+            nowUtc: NowUtc);
+
+        CryptoApiClientAliasReadinessViewItem route = Assert.Single(state.Routes);
+
+        Assert.Equal(CryptoApiAccessReadinessLevel.Blocked, route.Level);
+        Assert.Contains(route.Issues, issue => issue.Message.Contains("do not share any enabled policies", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildMarksRouteGroupAliasesNeedsAttentionWhenAdminHostCannotValidateThem()
+    {
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid policyId = Guid.NewGuid();
+
+        CryptoApiAccessReadinessState state = CryptoApiAccessReadinessView.Build(
+            CreateClientSnapshot(CreateClient(clientId, policyId, CreateActiveKey(clientId))),
+            CreateAccessSnapshot(CreateAlias(aliasId, policyId, slotId: null, routeGroupName: "payments"), CreatePolicy(policyId, clientId, aliasId)),
+            runtimeOptions: null,
+            nowUtc: NowUtc);
+
+        CryptoApiClientReadinessViewItem client = Assert.Single(state.Clients);
+        CryptoApiAliasReadinessViewItem alias = Assert.Single(state.Aliases);
+        CryptoApiClientAliasReadinessViewItem route = Assert.Single(state.Routes);
+
+        Assert.Equal(CryptoApiAccessReadinessLevel.NeedsAttention, client.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.NeedsAttention, alias.Level);
+        Assert.Equal(CryptoApiAccessReadinessLevel.NeedsAttention, route.Level);
+        Assert.Contains("does not expose CryptoApiRuntime config", route.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.False(state.RuntimeInspectionConfigured);
+    }
+
+    [Fact]
+    public void BuildBlocksWhenRouteGroupIsMissingFromAdminRuntimeContext()
+    {
+        Guid clientId = Guid.NewGuid();
+        Guid aliasId = Guid.NewGuid();
+        Guid policyId = Guid.NewGuid();
+
+        AdminCryptoApiRouteRuntimeOptions runtimeOptions = new()
+        {
+            ModulePath = "/tmp/pkcs11.so",
+            Backends =
+            [
+                new AdminCryptoApiRuntimeBackendOptions
+                {
+                    Name = "backend-a",
+                    Enabled = true
+                }
+            ],
+            RouteGroups =
+            [
+                new AdminCryptoApiRuntimeRouteGroupOptions
+                {
+                    Name = "other-group",
+                    Backends =
+                    [
+                        new AdminCryptoApiRuntimeRouteBackendOptions
+                        {
+                            BackendName = "backend-a",
+                            SlotId = 2,
+                            Priority = 0,
+                            Enabled = true
+                        }
+                    ]
+                }
+            ]
+        };
+
+        CryptoApiAccessReadinessState state = CryptoApiAccessReadinessView.Build(
+            CreateClientSnapshot(CreateClient(clientId, policyId, CreateActiveKey(clientId))),
+            CreateAccessSnapshot(CreateAlias(aliasId, policyId, slotId: null, routeGroupName: "payments"), CreatePolicy(policyId, clientId, aliasId)),
+            runtimeOptions,
+            nowUtc: NowUtc);
+
+        CryptoApiClientAliasReadinessViewItem route = Assert.Single(state.Routes);
+
+        Assert.Equal(CryptoApiAccessReadinessLevel.Blocked, route.Level);
+        Assert.Contains(route.Issues, issue => issue.Message.Contains("not defined in the admin runtime context", StringComparison.OrdinalIgnoreCase));
+        Assert.True(state.RuntimeInspectionConfigured);
+    }
+
+    private static CryptoApiClientManagementSnapshot CreateClientSnapshot(params CryptoApiManagedClient[] clients)
+        => new(
+            SharedPersistenceConfigured: true,
+            SharedPersistenceProvider: "postgres",
+            ConnectionTarget: "postgres://tests",
+            SchemaVersion: 1,
+            Clients: clients);
+
+    private static CryptoApiKeyAccessSnapshot CreateAccessSnapshot(CryptoApiManagedKeyAlias alias, CryptoApiManagedPolicy policy)
+        => new(
+            SharedPersistenceConfigured: true,
+            SharedPersistenceProvider: "postgres",
+            ConnectionTarget: "postgres://tests",
+            SchemaVersion: 1,
+            KeyAliases: [alias],
+            Policies: [policy]);
+
+    private static CryptoApiManagedClient CreateClient(Guid clientId, Guid policyId, params CryptoApiManagedClientKey[] keys)
+        => new(
+            ClientId: clientId,
+            ClientName: "payments-gateway",
+            DisplayName: "Payments Gateway",
+            ApplicationType: "service",
+            AuthenticationMode: "api-key",
+            IsEnabled: true,
+            Notes: null,
+            CreatedAtUtc: NowUtc.AddHours(-2),
+            UpdatedAtUtc: NowUtc.AddHours(-1),
+            BoundPolicyIds: [policyId],
+            Keys: keys);
+
+    private static CryptoApiManagedClientKey CreateActiveKey(Guid clientId)
+        => new(
+            ClientKeyId: Guid.NewGuid(),
+            ClientId: clientId,
+            KeyName: "primary",
+            KeyIdentifier: "kid-1",
+            CredentialType: "shared-secret",
+            SecretHashAlgorithm: "sha256",
+            SecretHint: null,
+            IsEnabled: true,
+            CreatedAtUtc: NowUtc.AddHours(-1),
+            UpdatedAtUtc: NowUtc.AddMinutes(-30),
+            ExpiresAtUtc: NowUtc.AddDays(14),
+            RevokedAtUtc: null,
+            RevokedReason: null,
+            LastUsedAtUtc: null);
+
+    private static CryptoApiManagedClientKey CreateDisabledKey(Guid clientId)
+        => CreateActiveKey(clientId) with { IsEnabled = false };
+
+    private static CryptoApiManagedKeyAlias CreateAlias(Guid aliasId, Guid policyId, ulong? slotId, string? routeGroupName = null)
+        => new(
+            AliasId: aliasId,
+            AliasName: "payments-signer",
+            RouteGroupName: routeGroupName,
+            DeviceRoute: null,
+            SlotId: slotId,
+            ObjectLabel: "Payments Key",
+            ObjectIdHex: null,
+            Notes: null,
+            IsEnabled: true,
+            CreatedAtUtc: NowUtc.AddHours(-2),
+            UpdatedAtUtc: NowUtc.AddHours(-1),
+            BoundPolicyIds: [policyId]);
+
+    private static CryptoApiManagedPolicy CreatePolicy(Guid policyId, Guid clientId, Guid aliasId, bool enabled = true)
+        => new(
+            PolicyId: policyId,
+            PolicyName: "payments-signing",
+            Description: null,
+            Revision: 1,
+            AllowedOperations: ["sign", "verify"],
+            IsEnabled: enabled,
+            CreatedAtUtc: NowUtc.AddHours(-2),
+            UpdatedAtUtc: NowUtc.AddHours(-1),
+            BoundClientIds: [clientId],
+            BoundAliasIds: [aliasId]);
+}


### PR DESCRIPTION
Add operator-facing route readiness diagnostics to the Crypto API Access control-plane surface. This introduces a dedicated readiness analysis/view-model layer, readiness badges and blocker reasons for clients/aliases/policies, client↔alias route matrices, and fix affordances back into the relevant editors. Closes #175.