### PR TITLE
Add configuration import preflight preview

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Application/Models/AdminConfigurationModels.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Models/AdminConfigurationModels.cs
@@ -25,6 +25,51 @@ public sealed class AdminConfigurationExportBundle
     public List<HsmDeviceProfile> DeviceProfiles { get; init; } = [];
 }
 
+public sealed record AdminConfigurationImportIssue(
+    string Scope,
+    string Severity,
+    string? DeviceName,
+    string? DeviceId,
+    string Message);
+
+public sealed record AdminConfigurationImportImpact(
+    AdminConfigurationImportMode Mode,
+    bool CanImport,
+    int FinalDeviceProfileCount,
+    int AddedDeviceProfileCount,
+    int UpdatedDeviceProfileCount,
+    int RemovedDeviceProfileCount,
+    int DuplicateDeviceProfileCount,
+    int InvalidDeviceProfileCount,
+    IReadOnlyList<string> AddedDeviceProfileNames,
+    IReadOnlyList<string> UpdatedDeviceProfileNames,
+    IReadOnlyList<string> RemovedDeviceProfileNames,
+    IReadOnlyList<string> Blockers,
+    string Summary);
+
+public sealed record AdminConfigurationImportAnalysis(
+    int ExistingDeviceProfileCount,
+    int ImportedDeviceProfileCount,
+    int ReadyDeviceProfileCount,
+    int DuplicateDeviceProfileCount,
+    int InvalidDeviceProfileCount,
+    AdminConfigurationImportImpact MergeImpact,
+    AdminConfigurationImportImpact ReplaceAllImpact,
+    IReadOnlyList<AdminConfigurationImportIssue> Issues);
+
+public sealed record AdminConfigurationImportPreview(
+    string SourceName,
+    string? Format,
+    int? SchemaVersion,
+    string? ProductName,
+    string? ProductVersion,
+    DateTimeOffset? ExportedUtc,
+    IReadOnlyList<string> IncludedSections,
+    IReadOnlyList<string> ExcludedSections,
+    IReadOnlyList<string> Problems,
+    IReadOnlyList<string> Warnings,
+    AdminConfigurationImportAnalysis Analysis);
+
 public sealed record AdminConfigurationImportResult(
     AdminConfigurationImportMode Mode,
     int ImportedDeviceProfileCount,

--- a/src/Pkcs11Wrapper.Admin.Application/Services/DeviceProfileService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/DeviceProfileService.cs
@@ -6,6 +6,16 @@ namespace Pkcs11Wrapper.Admin.Application.Services;
 
 public sealed class DeviceProfileService(IDeviceProfileStore store)
 {
+    private sealed record ImportCandidate(int Index, HsmDeviceProfile SourceProfile, HsmDeviceProfile? NormalizedProfile, string? ValidationError)
+    {
+        public bool IsValid => NormalizedProfile is not null && ValidationError is null;
+    }
+
+    private sealed record ImportEvaluation(
+        IReadOnlyList<HsmDeviceProfile> ExistingProfiles,
+        IReadOnlyList<HsmDeviceProfile> ReadyProfiles,
+        AdminConfigurationImportAnalysis Analysis);
+
     public async Task<IReadOnlyList<HsmDeviceProfile>> GetAllAsync(CancellationToken cancellationToken = default)
         => (await store.GetAllAsync(cancellationToken)).OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).ToArray();
 
@@ -67,62 +77,69 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
         return created;
     }
 
+    public async Task<AdminConfigurationImportAnalysis> AnalyzeImportAsync(IReadOnlyList<HsmDeviceProfile> importedProfiles, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(importedProfiles);
+
+        List<HsmDeviceProfile> existing = [.. await store.GetAllAsync(cancellationToken)];
+        return EvaluateImport(existing, importedProfiles).Analysis;
+    }
+
     public async Task<AdminConfigurationImportResult> ImportAsync(IReadOnlyList<HsmDeviceProfile> importedProfiles, AdminConfigurationImportMode mode, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(importedProfiles);
 
-        DateTimeOffset now = DateTimeOffset.UtcNow;
-        List<HsmDeviceProfile> imported = importedProfiles.Select(profile => NormalizeImported(profile, now)).ToList();
-        ValidateImportedProfiles(imported);
-
         List<HsmDeviceProfile> existing = [.. await store.GetAllAsync(cancellationToken)];
-        int added = 0;
-        int updated = 0;
-        int removed = 0;
+        ImportEvaluation evaluation = EvaluateImport(existing, importedProfiles);
+        AdminConfigurationImportImpact impact = mode switch
+        {
+            AdminConfigurationImportMode.Merge => evaluation.Analysis.MergeImpact,
+            AdminConfigurationImportMode.ReplaceAll => evaluation.Analysis.ReplaceAllImpact,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported configuration import mode.")
+        };
+
+        if (!impact.CanImport)
+        {
+            throw new InvalidOperationException(impact.Blockers.FirstOrDefault() ?? "Configuration import is blocked by preflight validation.");
+        }
 
         switch (mode)
         {
             case AdminConfigurationImportMode.Merge:
-                foreach (HsmDeviceProfile importedProfile in imported)
+            {
+                List<HsmDeviceProfile> merged = [.. existing];
+                foreach (HsmDeviceProfile importedProfile in evaluation.ReadyProfiles)
                 {
-                    int existingIndex = existing.FindIndex(x => x.Id == importedProfile.Id);
+                    int existingIndex = merged.FindIndex(x => x.Id == importedProfile.Id);
                     if (existingIndex >= 0)
                     {
-                        existing[existingIndex] = importedProfile;
-                        updated++;
+                        merged[existingIndex] = importedProfile;
                         continue;
                     }
 
-                    HsmDeviceProfile? conflictingName = existing.FirstOrDefault(x => string.Equals(x.Name, importedProfile.Name, StringComparison.OrdinalIgnoreCase));
-                    if (conflictingName is not null)
-                    {
-                        throw new InvalidOperationException($"Import would create a conflicting device name '{importedProfile.Name}'. Rename the device or use Replace All.");
-                    }
-
-                    existing.Add(importedProfile);
-                    added++;
+                    merged.Add(importedProfile);
                 }
 
-                await store.SaveAllAsync(existing, cancellationToken);
+                await store.SaveAllAsync(merged, cancellationToken);
                 return new(
                     mode,
-                    imported.Count,
-                    added,
-                    updated,
+                    importedProfiles.Count,
+                    impact.AddedDeviceProfileCount,
+                    impact.UpdatedDeviceProfileCount,
                     0,
-                    $"Merged {imported.Count} device profile(s): {added} added, {updated} updated.",
+                    $"Merged {importedProfiles.Count} device profile(s): {impact.AddedDeviceProfileCount} added, {impact.UpdatedDeviceProfileCount} updated.",
                     []);
+            }
 
             case AdminConfigurationImportMode.ReplaceAll:
-                removed = existing.Count;
-                await store.SaveAllAsync(imported, cancellationToken);
+                await store.SaveAllAsync(evaluation.ReadyProfiles, cancellationToken);
                 return new(
                     mode,
-                    imported.Count,
-                    imported.Count,
+                    importedProfiles.Count,
+                    impact.AddedDeviceProfileCount,
                     0,
-                    removed,
-                    $"Replaced device configuration with {imported.Count} imported profile(s); removed {removed} existing profile(s).",
+                    impact.RemovedDeviceProfileCount,
+                    $"Replaced device configuration with {importedProfiles.Count} imported profile(s); removed {impact.RemovedDeviceProfileCount} existing profile(s).",
                     []);
 
             default:
@@ -141,6 +158,167 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
 
         await store.SaveAllAsync(devices, cancellationToken);
     }
+
+    private static ImportEvaluation EvaluateImport(IReadOnlyList<HsmDeviceProfile> existingProfiles, IReadOnlyList<HsmDeviceProfile> importedProfiles)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        List<ImportCandidate> candidates = [];
+        List<AdminConfigurationImportIssue> issues = [];
+        List<string> commonBlockers = [];
+
+        for (int index = 0; index < importedProfiles.Count; index++)
+        {
+            HsmDeviceProfile sourceProfile = importedProfiles[index];
+            try
+            {
+                HsmDeviceProfile normalized = NormalizeImported(sourceProfile, now);
+                candidates.Add(new(index, sourceProfile, normalized, null));
+            }
+            catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+            {
+                string profileName = GetDisplayName(sourceProfile.Name);
+                string? profileId = TryFormatProfileId(sourceProfile.Id);
+                candidates.Add(new(index, sourceProfile, null, ex.Message));
+                commonBlockers.Add(ex.Message);
+                issues.Add(new("All modes", "Error", profileName, profileId, $"Profile #{index + 1}: {ex.Message}"));
+            }
+        }
+
+        List<ImportCandidate> validCandidates = candidates.Where(candidate => candidate.IsValid).ToList();
+        HashSet<int> duplicateIndexes = [];
+
+        foreach (IGrouping<Guid, ImportCandidate> group in validCandidates.GroupBy(candidate => candidate.NormalizedProfile!.Id).Where(group => group.Count() > 1))
+        {
+            string message = $"Imported configuration contains duplicate device id '{group.Key}'.";
+            commonBlockers.Add(message);
+            foreach (ImportCandidate candidate in group)
+            {
+                duplicateIndexes.Add(candidate.Index);
+            }
+
+            string profileNames = string.Join(", ", group.Select(candidate => candidate.NormalizedProfile!.Name).Distinct(StringComparer.OrdinalIgnoreCase));
+            issues.Add(new("All modes", "Error", profileNames, group.Key.ToString(), message));
+        }
+
+        foreach (IGrouping<string, ImportCandidate> group in validCandidates.GroupBy(candidate => candidate.NormalizedProfile!.Name, StringComparer.OrdinalIgnoreCase).Where(group => group.Count() > 1))
+        {
+            string message = $"Imported configuration contains duplicate device name '{group.Key}'.";
+            commonBlockers.Add(message);
+            foreach (ImportCandidate candidate in group)
+            {
+                duplicateIndexes.Add(candidate.Index);
+            }
+
+            string profileIds = string.Join(", ", group.Select(candidate => candidate.NormalizedProfile!.Id.ToString()).Distinct(StringComparer.OrdinalIgnoreCase));
+            issues.Add(new("All modes", "Error", group.Key, profileIds, message));
+        }
+
+        List<HsmDeviceProfile> readyProfiles = validCandidates
+            .Where(candidate => !duplicateIndexes.Contains(candidate.Index))
+            .Select(candidate => candidate.NormalizedProfile!)
+            .ToList();
+
+        Dictionary<Guid, HsmDeviceProfile> existingById = existingProfiles.ToDictionary(profile => profile.Id);
+        Dictionary<string, HsmDeviceProfile> existingByName = existingProfiles.ToDictionary(profile => profile.Name, StringComparer.OrdinalIgnoreCase);
+
+        List<HsmDeviceProfile> mergeAddedProfiles = [];
+        List<HsmDeviceProfile> mergeUpdatedProfiles = [];
+        List<string> mergeBlockers = [.. commonBlockers];
+        List<HsmDeviceProfile> mergeConflictProfiles = [];
+
+        foreach (HsmDeviceProfile profile in readyProfiles)
+        {
+            if (existingById.ContainsKey(profile.Id))
+            {
+                mergeUpdatedProfiles.Add(profile);
+                continue;
+            }
+
+            if (existingByName.TryGetValue(profile.Name, out HsmDeviceProfile? conflictingName) && conflictingName.Id != profile.Id)
+            {
+                string message = $"Import would create a conflicting device name '{profile.Name}'. Rename the device or use Replace All.";
+                mergeBlockers.Add(message);
+                mergeConflictProfiles.Add(profile);
+                issues.Add(new("Merge only", "Error", profile.Name, profile.Id.ToString(), message));
+                continue;
+            }
+
+            mergeAddedProfiles.Add(profile);
+        }
+
+        List<string> replaceBlockers = [.. commonBlockers];
+
+        AdminConfigurationImportImpact mergeImpact = new(
+            AdminConfigurationImportMode.Merge,
+            mergeBlockers.Count == 0,
+            existingProfiles.Count + mergeAddedProfiles.Count,
+            mergeAddedProfiles.Count,
+            mergeUpdatedProfiles.Count,
+            0,
+            duplicateIndexes.Count + mergeConflictProfiles.Count,
+            candidates.Count(candidate => !candidate.IsValid),
+            [.. mergeAddedProfiles.Select(profile => profile.Name).OrderBy(name => name, StringComparer.OrdinalIgnoreCase)],
+            [.. mergeUpdatedProfiles.Select(profile => profile.Name).OrderBy(name => name, StringComparer.OrdinalIgnoreCase)],
+            [],
+            mergeBlockers,
+            BuildSummary(AdminConfigurationImportMode.Merge, mergeAddedProfiles.Count, mergeUpdatedProfiles.Count, 0, duplicateIndexes.Count + mergeConflictProfiles.Count, candidates.Count(candidate => !candidate.IsValid), existingProfiles.Count + mergeAddedProfiles.Count, mergeBlockers.Count == 0));
+
+        AdminConfigurationImportImpact replaceAllImpact = new(
+            AdminConfigurationImportMode.ReplaceAll,
+            replaceBlockers.Count == 0,
+            readyProfiles.Count,
+            readyProfiles.Count,
+            0,
+            existingProfiles.Count,
+            duplicateIndexes.Count,
+            candidates.Count(candidate => !candidate.IsValid),
+            [.. readyProfiles.Select(profile => profile.Name).OrderBy(name => name, StringComparer.OrdinalIgnoreCase)],
+            [],
+            [.. existingProfiles.Select(profile => profile.Name).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(name => name, StringComparer.OrdinalIgnoreCase)],
+            replaceBlockers,
+            BuildSummary(AdminConfigurationImportMode.ReplaceAll, readyProfiles.Count, 0, existingProfiles.Count, duplicateIndexes.Count, candidates.Count(candidate => !candidate.IsValid), readyProfiles.Count, replaceBlockers.Count == 0));
+
+        AdminConfigurationImportAnalysis analysis = new(
+            existingProfiles.Count,
+            importedProfiles.Count,
+            readyProfiles.Count,
+            duplicateIndexes.Count,
+            candidates.Count(candidate => !candidate.IsValid),
+            mergeImpact,
+            replaceAllImpact,
+            issues);
+
+        return new(existingProfiles, readyProfiles, analysis);
+    }
+
+    private static string BuildSummary(
+        AdminConfigurationImportMode mode,
+        int added,
+        int updated,
+        int removed,
+        int duplicateCount,
+        int invalidCount,
+        int finalCount,
+        bool canImport)
+    {
+        string action = mode == AdminConfigurationImportMode.Merge
+            ? $"Would add {added} and update {updated} device profile(s)."
+            : $"Would apply {added} imported device profile(s) and remove {removed} current profile(s).";
+
+        string finalState = $" Final device count: {finalCount}.";
+        if (canImport)
+        {
+            return action + finalState;
+        }
+
+        return action + finalState + $" Blocked by {duplicateCount} duplicate/conflicting and {invalidCount} invalid profile(s).";
+    }
+
+    private static string GetDisplayName(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "<unnamed>" : value.Trim();
+
+    private static string? TryFormatProfileId(Guid id)
+        => id == Guid.Empty ? null : id.ToString();
 
     private static string ValidateName(string? value)
     {
@@ -210,25 +388,6 @@ public sealed class DeviceProfileService(IDeviceProfileStore store)
             UpdatedUtc = updatedUtc,
             Vendor = NormalizeVendorMetadata(profile.Vendor)
         };
-    }
-
-    private static void ValidateImportedProfiles(IReadOnlyList<HsmDeviceProfile> profiles)
-    {
-        HashSet<Guid> ids = [];
-        HashSet<string> names = new(StringComparer.OrdinalIgnoreCase);
-
-        foreach (HsmDeviceProfile profile in profiles)
-        {
-            if (!ids.Add(profile.Id))
-            {
-                throw new InvalidOperationException($"Imported configuration contains duplicate device id '{profile.Id}'.");
-            }
-
-            if (!names.Add(profile.Name))
-            {
-                throw new InvalidOperationException($"Imported configuration contains duplicate device name '{profile.Name}'.");
-            }
-        }
     }
 
     private static HsmDeviceVendorMetadata? NormalizeVendorMetadata(HsmDeviceVendorMetadata? vendor)

--- a/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
+++ b/src/Pkcs11Wrapper.Admin.Application/Services/HsmAdminService.cs
@@ -247,6 +247,55 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         }
     }
 
+    public async Task<AdminConfigurationImportPreview> PreviewConfigurationImportAsync(Stream stream, string? sourceName, CancellationToken cancellationToken = default)
+    {
+        authorization.DemandAdmin();
+        ArgumentNullException.ThrowIfNull(stream);
+
+        string importTarget = string.IsNullOrWhiteSpace(sourceName) ? "uploaded bundle" : sourceName;
+
+        try
+        {
+            AdminConfigurationExportBundle? bundle = await JsonSerializer.DeserializeAsync(stream, AdminApplicationJsonContext.Default.AdminConfigurationExportBundle, cancellationToken);
+            if (bundle is null)
+            {
+                return CreateUnreadableImportPreview(importTarget, "Configuration file was empty or unreadable.");
+            }
+
+            List<string> problems = GetConfigurationBundleProblems(bundle);
+            AdminConfigurationImportAnalysis analysis = bundle.DeviceProfiles is null
+                ? CreateEmptyImportAnalysis()
+                : await deviceProfiles.AnalyzeImportAsync(bundle.DeviceProfiles, cancellationToken);
+            List<string> warnings = GetConfigurationBundleWarnings(bundle);
+
+            if (problems.Count > 0)
+            {
+                analysis = analysis with
+                {
+                    MergeImpact = ApplyPreviewBlockers(analysis.MergeImpact, problems),
+                    ReplaceAllImpact = ApplyPreviewBlockers(analysis.ReplaceAllImpact, problems)
+                };
+            }
+
+            return new(
+                importTarget,
+                bundle.Format,
+                bundle.SchemaVersion,
+                bundle.ProductName,
+                string.IsNullOrWhiteSpace(bundle.ProductVersion) ? null : bundle.ProductVersion,
+                bundle.ExportedUtc == default ? null : bundle.ExportedUtc,
+                [.. bundle.IncludedSections],
+                [.. bundle.ExcludedSections],
+                problems,
+                warnings,
+                analysis);
+        }
+        catch (JsonException ex)
+        {
+            return CreateUnreadableImportPreview(importTarget, $"Configuration file could not be parsed: {ex.Message}");
+        }
+    }
+
     public async Task<AdminConfigurationImportResult> ImportConfigurationAsync(Stream stream, string? sourceName, AdminConfigurationImportMode mode, bool acknowledgeReplaceAll, CancellationToken cancellationToken = default)
     {
         authorization.DemandAdmin();
@@ -273,13 +322,7 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
             IReadOnlyList<HsmDeviceProfile> afterImport = await deviceProfiles.GetAllAsync(cancellationToken);
 
             DeviceDependencyCleanupSummary cleanup = await ReconcileDependentStateForImportAsync(beforeImport, afterImport, mode, cancellationToken);
-            List<string> warnings = [.. importResult.Warnings];
-            string currentVersion = GetCurrentProductVersion();
-            if (!string.IsNullOrWhiteSpace(bundle.ProductVersion) && !string.Equals(bundle.ProductVersion, currentVersion, StringComparison.OrdinalIgnoreCase))
-            {
-                warnings.Add($"Bundle was exported from admin version {bundle.ProductVersion}; current version is {currentVersion}.");
-            }
-
+            List<string> warnings = [.. importResult.Warnings, .. GetConfigurationBundleWarnings(bundle)];
             AdminConfigurationImportResult result = warnings.Count == importResult.Warnings.Count
                 ? importResult
                 : importResult with { Warnings = warnings };
@@ -2284,22 +2327,148 @@ public sealed class HsmAdminService(DeviceProfileService deviceProfiles, AuditLo
         return capabilities.Count == 0 ? "<none>" : string.Join(", ", capabilities);
     }
 
+    private static AdminConfigurationImportPreview CreateUnreadableImportPreview(string importTarget, string problem)
+        => new(
+            importTarget,
+            null,
+            null,
+            null,
+            null,
+            null,
+            [],
+            [],
+            [problem],
+            [],
+            CreateBlockedImportAnalysis(problem));
+
+    private static AdminConfigurationImportAnalysis CreateBlockedImportAnalysis(string blocker)
+        => new(
+            0,
+            0,
+            0,
+            0,
+            0,
+            new(
+                AdminConfigurationImportMode.Merge,
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                [],
+                [],
+                [],
+                [blocker],
+                "Import preview is blocked until the configuration file can be read."),
+            new(
+                AdminConfigurationImportMode.ReplaceAll,
+                false,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                [],
+                [],
+                [],
+                [blocker],
+                "Import preview is blocked until the configuration file can be read."),
+            []);
+
+    private static AdminConfigurationImportAnalysis CreateEmptyImportAnalysis()
+        => new(
+            0,
+            0,
+            0,
+            0,
+            0,
+            new(
+                AdminConfigurationImportMode.Merge,
+                true,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                [],
+                [],
+                [],
+                [],
+                "Would add 0 and update 0 device profile(s). Final device count: 0."),
+            new(
+                AdminConfigurationImportMode.ReplaceAll,
+                true,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                [],
+                [],
+                [],
+                [],
+                "Would apply 0 imported device profile(s) and remove 0 current profile(s). Final device count: 0."),
+            []);
+
+    private static AdminConfigurationImportImpact ApplyPreviewBlockers(AdminConfigurationImportImpact impact, IReadOnlyList<string> problems)
+    {
+        List<string> blockers = [.. problems, .. impact.Blockers];
+        return impact with
+        {
+            CanImport = false,
+            Blockers = blockers,
+            Summary = blockers.Count == 0
+                ? impact.Summary
+                : $"{impact.Summary} Bundle validation also reported {problems.Count} blocking issue(s)."
+        };
+    }
+
     private static void ValidateConfigurationBundle(AdminConfigurationExportBundle bundle)
     {
+        List<string> problems = GetConfigurationBundleProblems(bundle);
+        if (problems.Count > 0)
+        {
+            throw new InvalidOperationException(problems[0]);
+        }
+    }
+
+    private static List<string> GetConfigurationBundleProblems(AdminConfigurationExportBundle bundle)
+    {
+        List<string> problems = [];
+
         if (!string.Equals(bundle.Format, ConfigurationFormat, StringComparison.Ordinal))
         {
-            throw new InvalidOperationException($"Unsupported configuration format '{bundle.Format}'.");
+            problems.Add($"Unsupported configuration format '{bundle.Format}'.");
         }
 
         if (bundle.SchemaVersion != ConfigurationSchemaVersion)
         {
-            throw new InvalidOperationException($"Unsupported configuration schema version '{bundle.SchemaVersion}'.");
+            problems.Add($"Unsupported configuration schema version '{bundle.SchemaVersion}'.");
         }
 
         if (bundle.DeviceProfiles is null)
         {
-            throw new InvalidOperationException("Configuration bundle does not contain a device profile section.");
+            problems.Add("Configuration bundle does not contain a device profile section.");
         }
+
+        return problems;
+    }
+
+    private static List<string> GetConfigurationBundleWarnings(AdminConfigurationExportBundle bundle)
+    {
+        List<string> warnings = [];
+        string currentVersion = GetCurrentProductVersion();
+        if (!string.IsNullOrWhiteSpace(bundle.ProductVersion) && !string.Equals(bundle.ProductVersion, currentVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            warnings.Add($"Bundle was exported from admin version {bundle.ProductVersion}; current version is {currentVersion}.");
+        }
+
+        return warnings;
     }
 
     private static string GetCurrentProductVersion()

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Configuration.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Configuration.razor
@@ -115,49 +115,181 @@
     <div class="col-lg-7">
         <div class="card shadow-sm h-100 feature-card workflow-card">
             <div class="card-header">Import</div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label class="form-label">Configuration file</label>
-                    <InputFile @key="_filePickerKey" class="form-control" OnChange="OnFileChanged" accept=".json,application/json" />
-                    @if (_selectedFile is not null)
+            <div class="card-body d-flex flex-column gap-4">
+                <div>
+                    <div class="mb-3">
+                        <label class="form-label">Configuration file</label>
+                        <InputFile @key="_filePickerKey" class="form-control" OnChange="OnFileChangedAsync" accept=".json,application/json" />
+                        @if (_selectedFile is not null)
+                        {
+                            <div class="form-text">Selected: @_selectedFile.Name (@FormatSize(_selectedFile.Size))</div>
+                        }
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Import mode</label>
+                        <InputSelect class="form-select" @bind-Value="_importMode">
+                            <option value="@AdminConfigurationImportMode.Merge">Merge existing configuration</option>
+                            <option value="@AdminConfigurationImportMode.ReplaceAll">Replace all existing configuration</option>
+                        </InputSelect>
+                        <div class="form-text">
+                            Merge updates matching device IDs and adds new profiles. Replace All overwrites the current device-profile set with the imported bundle.
+                        </div>
+                    </div>
+
+                    @if (_importMode == AdminConfigurationImportMode.ReplaceAll)
                     {
-                        <div class="form-text">Selected: @_selectedFile.Name (@FormatSize(_selectedFile.Size))</div>
+                        <div class="alert alert-warning small mb-3">
+                            Replace All will remove every currently configured device profile before the imported bundle is applied.
+                        </div>
+
+                        <div class="form-check mb-3">
+                            <InputCheckbox class="form-check-input" @bind-Value="_acknowledgeReplaceAll" />
+                            <label class="form-check-label">I understand that Replace All overwrites the current device configuration.</label>
+                        </div>
                     }
-                </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Import mode</label>
-                    <InputSelect class="form-select" @bind-Value="_importMode">
-                        <option value="@AdminConfigurationImportMode.Merge">Merge existing configuration</option>
-                        <option value="@AdminConfigurationImportMode.ReplaceAll">Replace all existing configuration</option>
-                    </InputSelect>
-                    <div class="form-text">
-                        Merge updates matching device IDs and adds new profiles. Replace All overwrites the current device-profile set with the imported bundle.
+                    <div class="d-flex gap-2 align-items-center flex-wrap">
+                        <button class="btn btn-warning" @onclick="ImportAsync" disabled="@(!CanImportSelectedMode)">
+                            @(_isImporting ? "Importing..." : "Import configuration")
+                        </button>
+                        <button class="btn btn-outline-secondary" @onclick="RefreshPreviewAsync" disabled="@(_selectedFile is null || _isPreviewing || _isImporting)">
+                            @(_isPreviewing ? "Reviewing..." : "Refresh preview")
+                        </button>
+                        <button class="btn btn-outline-secondary" @onclick="ResetImportForm" disabled="@(_isImporting || _isPreviewing)">Reset</button>
                     </div>
                 </div>
 
-                @if (_importMode == AdminConfigurationImportMode.ReplaceAll)
-                {
-                    <div class="alert alert-warning small">
-                        Replace All will remove every currently configured device profile before the imported bundle is applied.
+                <div class="border rounded-3 p-3 bg-body-tertiary">
+                    <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                        <div>
+                            <div class="fw-semibold">Import preflight review</div>
+                            <div class="text-muted small">Selecting a bundle runs a read-only preview before any Merge or Replace All action is allowed.</div>
+                        </div>
+                        @if (_isPreviewing)
+                        {
+                            <span class="badge text-bg-info">Reviewing bundle…</span>
+                        }
+                        else if (_importPreview is not null)
+                        {
+                            <span class="badge @(SelectedImpact.CanImport ? "text-bg-success" : "text-bg-danger")">
+                                @(SelectedImpact.CanImport ? "Selected mode ready" : "Selected mode blocked")
+                            </span>
+                        }
                     </div>
 
-                    <div class="form-check mb-3">
-                        <InputCheckbox class="form-check-input" @bind-Value="_acknowledgeReplaceAll" />
-                        <label class="form-check-label">I understand that Replace All overwrites the current device configuration.</label>
-                    </div>
-                }
+                    @if (_selectedFile is null)
+                    {
+                        <div class="small text-muted mt-3">Choose a configuration export to see bundle metadata, validation issues, and Merge vs Replace All impact before import.</div>
+                    }
+                    else if (_isPreviewing && _importPreview is null)
+                    {
+                        <div class="small text-muted mt-3">Reading bundle metadata and comparing it with the current device profile set…</div>
+                    }
+                    else if (_importPreview is not null)
+                    {
+                        <div class="row g-3 mt-1">
+                            <div class="col-md-3 col-6">
+                                <div class="surface-item h-100">
+                                    <div class="fw-semibold small text-uppercase text-muted">Current profiles</div>
+                                    <div class="display-6 metric-meta">@_importPreview.Analysis.ExistingDeviceProfileCount</div>
+                                </div>
+                            </div>
+                            <div class="col-md-3 col-6">
+                                <div class="surface-item h-100">
+                                    <div class="fw-semibold small text-uppercase text-muted">Bundle profiles</div>
+                                    <div class="display-6 metric-meta">@_importPreview.Analysis.ImportedDeviceProfileCount</div>
+                                </div>
+                            </div>
+                            <div class="col-md-3 col-6">
+                                <div class="surface-item h-100">
+                                    <div class="fw-semibold small text-uppercase text-muted">Ready</div>
+                                    <div class="display-6 metric-meta text-success">@_importPreview.Analysis.ReadyDeviceProfileCount</div>
+                                </div>
+                            </div>
+                            <div class="col-md-3 col-6">
+                                <div class="surface-item h-100">
+                                    <div class="fw-semibold small text-uppercase text-muted">Bundle issues</div>
+                                    <div class="display-6 metric-meta @((_importPreview.Analysis.InvalidDeviceProfileCount + _importPreview.Analysis.DuplicateDeviceProfileCount) == 0 ? "text-success" : "text-danger")">
+                                        @(_importPreview.Analysis.InvalidDeviceProfileCount + _importPreview.Analysis.DuplicateDeviceProfileCount)
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
 
-                <div class="d-flex gap-2 align-items-center">
-                    <button class="btn btn-warning" @onclick="ImportAsync" disabled="@(_selectedFile is null || _isImporting)">
-                        @(_isImporting ? "Importing..." : "Import configuration")
-                    </button>
-                    <button class="btn btn-outline-secondary" @onclick="ResetImportForm" disabled="@_isImporting">Reset</button>
+                        @if (_importPreview.Problems.Count > 0)
+                        {
+                            <div class="alert alert-danger mt-3 mb-0">
+                                <div class="fw-semibold">Blocking bundle problems</div>
+                                <ul class="small mt-2 mb-0">
+                                    @foreach (string problem in _importPreview.Problems)
+                                    {
+                                        <li>@problem</li>
+                                    }
+                                </ul>
+                            </div>
+                        }
+
+                        @if (_importPreview.Warnings.Count > 0)
+                        {
+                            <div class="alert alert-warning mt-3 mb-0">
+                                <div class="fw-semibold">Bundle warnings</div>
+                                <ul class="small mt-2 mb-0">
+                                    @foreach (string warning in _importPreview.Warnings)
+                                    {
+                                        <li>@warning</li>
+                                    }
+                                </ul>
+                            </div>
+                        }
+
+                        <div class="surface-item mt-3">
+                            <div class="fw-semibold mb-2">Bundle metadata</div>
+                            <div class="small d-flex flex-column gap-1">
+                                <div><strong>Source:</strong> @_importPreview.SourceName</div>
+                                <div><strong>Format / schema:</strong> @(_importPreview.Format ?? "—") / @(_importPreview.SchemaVersion?.ToString() ?? "—")</div>
+                                <div><strong>Exported from:</strong> @((string.IsNullOrWhiteSpace(_importPreview.ProductName) ? "Unknown product" : _importPreview.ProductName) + (string.IsNullOrWhiteSpace(_importPreview.ProductVersion) ? string.Empty : $" {_importPreview.ProductVersion}"))</div>
+                                <div><strong>Exported at:</strong> @(_importPreview.ExportedUtc?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? "—")</div>
+                                <div><strong>Included:</strong> @FormatSections(_importPreview.IncludedSections)</div>
+                                <div><strong>Excluded:</strong> @FormatSections(_importPreview.ExcludedSections)</div>
+                            </div>
+                        </div>
+
+                        <div class="row g-3 mt-1">
+                            <div class="col-md-6">
+                                @RenderImpactCard(_importPreview.Analysis.MergeImpact, "Safest default for ongoing environments.")
+                            </div>
+                            <div class="col-md-6">
+                                @RenderImpactCard(_importPreview.Analysis.ReplaceAllImpact, "Use intentionally for rebuilds and migrations.")
+                            </div>
+                        </div>
+
+                        @if (_importPreview.Analysis.Issues.Count > 0)
+                        {
+                            <div class="surface-item mt-3">
+                                <div class="fw-semibold mb-2">Detected issues</div>
+                                <ul class="small mb-0 d-flex flex-column gap-2">
+                                    @foreach (AdminConfigurationImportIssue issue in _importPreview.Analysis.Issues)
+                                    {
+                                        <li>
+                                            <span class="badge text-bg-danger me-2">@issue.Scope</span>
+                                            <strong>@(string.IsNullOrWhiteSpace(issue.DeviceName) ? "Bundle" : issue.DeviceName)</strong>
+                                            @if (!string.IsNullOrWhiteSpace(issue.DeviceId))
+                                            {
+                                                <span class="text-muted">(@issue.DeviceId)</span>
+                                            }
+                                            <div class="text-muted">@issue.Message</div>
+                                        </li>
+                                    }
+                                </ul>
+                            </div>
+                        }
+                    }
                 </div>
 
                 @if (_lastImportResult is not null)
                 {
-                    <div class="alert alert-info mt-3 mb-0">
+                    <div class="alert alert-info mb-0">
                         <div class="fw-semibold">Latest import result</div>
                         <div>@_lastImportResult.Summary</div>
                         <div class="small mt-2">
@@ -178,10 +310,11 @@
                     </div>
                 }
 
-                <div class="border-top mt-4 pt-3">
+                <div class="border-top pt-3">
                     <div class="fw-semibold mb-2">Import safety checklist</div>
                     <ol class="small ps-3 mb-0 d-flex flex-column gap-1">
                         <li>Export the current bundle first.</li>
+                        <li>Review the preflight diff before committing Merge or Replace All.</li>
                         <li>Use <strong>Merge</strong> when you want the safest default for ongoing environments.</li>
                         <li>Use <strong>Replace All</strong> only when rebuilding or migrating the device-profile set intentionally.</li>
                         <li>Remember that local users, audit history, protected PIN cache, and Data Protection keys stay on the current host.</li>
@@ -194,29 +327,77 @@
 
 @code {
     private const long MaxImportBytes = 1024 * 1024;
+    private const int PreviewNameLimit = 6;
 
     private IBrowserFile? _selectedFile;
     private AdminConfigurationImportMode _importMode = AdminConfigurationImportMode.Merge;
     private AdminConfigurationImportResult? _lastImportResult;
+    private AdminConfigurationImportPreview? _importPreview;
     private string? _statusMessage;
     private bool _statusIsError;
     private bool _acknowledgeReplaceAll;
     private bool _isImporting;
+    private bool _isPreviewing;
     private Guid _filePickerKey = Guid.NewGuid();
     private int _deviceCount;
 
     protected override Task OnInitializedAsync() => LoadSummaryAsync();
+
+    private bool CanImportSelectedMode
+        => _selectedFile is not null
+           && _importPreview is not null
+           && !_isPreviewing
+           && !_isImporting
+           && SelectedImpact.CanImport
+           && (_importMode != AdminConfigurationImportMode.ReplaceAll || _acknowledgeReplaceAll);
+
+    private AdminConfigurationImportImpact SelectedImpact
+        => _importMode == AdminConfigurationImportMode.ReplaceAll
+            ? _importPreview?.Analysis.ReplaceAllImpact ?? EmptyImpact(AdminConfigurationImportMode.ReplaceAll)
+            : _importPreview?.Analysis.MergeImpact ?? EmptyImpact(AdminConfigurationImportMode.Merge);
 
     private async Task LoadSummaryAsync()
     {
         _deviceCount = (await Admin.GetDevicesAsync()).Count;
     }
 
-    private void OnFileChanged(InputFileChangeEventArgs args)
+    private async Task OnFileChangedAsync(InputFileChangeEventArgs args)
     {
         _selectedFile = args.FileCount == 0 ? null : args.File;
         _lastImportResult = null;
         _statusMessage = null;
+        _statusIsError = false;
+        _importPreview = null;
+        _acknowledgeReplaceAll = false;
+
+        if (_selectedFile is not null)
+        {
+            await RefreshPreviewAsync();
+        }
+    }
+
+    private async Task RefreshPreviewAsync()
+    {
+        if (_selectedFile is null)
+        {
+            return;
+        }
+
+        _isPreviewing = true;
+        try
+        {
+            await using Stream stream = _selectedFile.OpenReadStream(MaxImportBytes);
+            _importPreview = await Admin.PreviewConfigurationImportAsync(stream, _selectedFile.Name);
+        }
+        catch (Exception ex)
+        {
+            _statusMessage = ex.Message;
+            _statusIsError = true;
+        }
+        finally
+        {
+            _isPreviewing = false;
+        }
     }
 
     private async Task ImportAsync()
@@ -249,6 +430,69 @@
         }
     }
 
+    private RenderFragment RenderImpactCard(AdminConfigurationImportImpact impact, string note) => @<div class="card shadow-sm h-100 @GetImpactCardClass(impact)">
+        <div class="card-body d-flex flex-column gap-3">
+            <div>
+                <div class="d-flex justify-content-between align-items-start gap-2 flex-wrap">
+                    <div>
+                        <div class="fw-semibold">@GetImpactTitle(impact.Mode)</div>
+                        <div class="text-muted small">@note</div>
+                    </div>
+                    <span class="badge @(impact.CanImport ? "text-bg-success" : "text-bg-danger")">
+                        @(impact.CanImport ? "Ready" : "Blocked")
+                    </span>
+                </div>
+                <div class="small mt-2">@impact.Summary</div>
+            </div>
+
+            <div class="small d-flex flex-column gap-1">
+                <div><strong>Added:</strong> @impact.AddedDeviceProfileCount</div>
+                <div><strong>Updated:</strong> @impact.UpdatedDeviceProfileCount</div>
+                <div><strong>Removed:</strong> @impact.RemovedDeviceProfileCount</div>
+                <div><strong>Duplicate/conflicting:</strong> @impact.DuplicateDeviceProfileCount</div>
+                <div><strong>Invalid:</strong> @impact.InvalidDeviceProfileCount</div>
+                <div><strong>Final profiles:</strong> @impact.FinalDeviceProfileCount</div>
+            </div>
+
+            @if (impact.AddedDeviceProfileNames.Count > 0)
+            {
+                <div>
+                    <div class="fw-semibold small text-uppercase text-muted">Added</div>
+                    <div class="small">@FormatPreviewNames(impact.AddedDeviceProfileNames)</div>
+                </div>
+            }
+
+            @if (impact.UpdatedDeviceProfileNames.Count > 0)
+            {
+                <div>
+                    <div class="fw-semibold small text-uppercase text-muted">Updated</div>
+                    <div class="small">@FormatPreviewNames(impact.UpdatedDeviceProfileNames)</div>
+                </div>
+            }
+
+            @if (impact.RemovedDeviceProfileNames.Count > 0)
+            {
+                <div>
+                    <div class="fw-semibold small text-uppercase text-muted">Removed</div>
+                    <div class="small">@FormatPreviewNames(impact.RemovedDeviceProfileNames)</div>
+                </div>
+            }
+
+            @if (impact.Blockers.Count > 0)
+            {
+                <div class="mt-auto">
+                    <div class="fw-semibold small text-uppercase text-muted">Blockers</div>
+                    <ul class="small mb-0">
+                        @foreach (string blocker in impact.Blockers)
+                        {
+                            <li>@blocker</li>
+                        }
+                    </ul>
+                </div>
+            }
+        </div>
+    </div>;
+
     private void ResetImportForm()
         => ResetImportForm(clearStatus: true, keepResult: false);
 
@@ -257,6 +501,8 @@
         _selectedFile = null;
         _acknowledgeReplaceAll = false;
         _importMode = AdminConfigurationImportMode.Merge;
+        _importPreview = null;
+        _isPreviewing = false;
         _filePickerKey = Guid.NewGuid();
         if (clearStatus)
         {
@@ -268,6 +514,37 @@
         {
             _lastImportResult = null;
         }
+    }
+
+    private static AdminConfigurationImportImpact EmptyImpact(AdminConfigurationImportMode mode)
+        => new(mode, false, 0, 0, 0, 0, 0, 0, [], [], [], [], string.Empty);
+
+    private string GetImpactCardClass(AdminConfigurationImportImpact impact)
+    {
+        List<string> classes = ["border"];
+        if (_importMode == impact.Mode)
+        {
+            classes.Add(impact.CanImport ? "border-primary" : "border-danger");
+        }
+
+        return string.Join(' ', classes);
+    }
+
+    private static string GetImpactTitle(AdminConfigurationImportMode mode)
+        => mode == AdminConfigurationImportMode.ReplaceAll ? "Replace All impact" : "Merge impact";
+
+    private static string FormatSections(IReadOnlyList<string> sections)
+        => sections.Count == 0 ? "—" : string.Join(", ", sections);
+
+    private static string FormatPreviewNames(IReadOnlyList<string> names)
+    {
+        IReadOnlyList<string> preview = names.Take(PreviewNameLimit).ToArray();
+        if (names.Count <= PreviewNameLimit)
+        {
+            return string.Join(", ", preview);
+        }
+
+        return $"{string.Join(", ", preview)} +{names.Count - PreviewNameLimit} more";
     }
 
     private static string FormatSize(long bytes)

--- a/tests/Pkcs11Wrapper.Admin.Tests/ConfigurationTransferTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/ConfigurationTransferTests.cs
@@ -101,6 +101,97 @@ public sealed class ConfigurationTransferTests
         Assert.Contains("conflicting device name", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task PreviewConfigurationImportAsyncSummarizesMergeAndReplaceAllImpact()
+    {
+        Guid existingId = Guid.NewGuid();
+        HsmAdminService service = CreateService(
+        [
+            CreateProfile(existingId, "Primary HSM", "/usr/lib/original.so"),
+            CreateProfile(Guid.NewGuid(), "Legacy HSM", "/usr/lib/legacy.so")
+        ]);
+
+        AdminConfigurationExportBundle bundle = new()
+        {
+            ProductVersion = "0.9.0-preview",
+            DeviceProfiles =
+            [
+                CreateProfile(existingId, "Primary HSM", "/opt/updated.so"),
+                CreateProfile(Guid.NewGuid(), "Backup HSM", "/opt/backup.so")
+            ]
+        };
+
+        AdminConfigurationImportPreview preview = await service.PreviewConfigurationImportAsync(CreateBundleStream(bundle), "preview.json");
+
+        Assert.Equal("preview.json", preview.SourceName);
+        Assert.Contains("0.9.0-preview", preview.Warnings.Single());
+        Assert.Equal(2, preview.Analysis.ExistingDeviceProfileCount);
+        Assert.Equal(2, preview.Analysis.ImportedDeviceProfileCount);
+        Assert.True(preview.Analysis.MergeImpact.CanImport);
+        Assert.Equal(1, preview.Analysis.MergeImpact.AddedDeviceProfileCount);
+        Assert.Equal(1, preview.Analysis.MergeImpact.UpdatedDeviceProfileCount);
+        Assert.Equal(3, preview.Analysis.MergeImpact.FinalDeviceProfileCount);
+        Assert.True(preview.Analysis.ReplaceAllImpact.CanImport);
+        Assert.Equal(2, preview.Analysis.ReplaceAllImpact.AddedDeviceProfileCount);
+        Assert.Equal(2, preview.Analysis.ReplaceAllImpact.RemovedDeviceProfileCount);
+        Assert.Contains("Legacy HSM", preview.Analysis.ReplaceAllImpact.RemovedDeviceProfileNames);
+    }
+
+    [Fact]
+    public async Task PreviewConfigurationImportAsyncReportsInvalidDuplicateAndMergeOnlyProblems()
+    {
+        Guid existingId = Guid.NewGuid();
+        Guid duplicateId = Guid.NewGuid();
+        HsmAdminService service = CreateService(
+        [
+            CreateProfile(existingId, "Primary HSM", "/usr/lib/original.so")
+        ]);
+
+        AdminConfigurationExportBundle bundle = new()
+        {
+            DeviceProfiles =
+            [
+                CreateProfile(Guid.NewGuid(), "", "/opt/missing-name.so"),
+                CreateProfile(duplicateId, "Dup A", "/opt/dup-a.so"),
+                CreateProfile(duplicateId, "Dup B", "/opt/dup-b.so"),
+                CreateProfile(Guid.NewGuid(), "Primary HSM", "/opt/conflict.so")
+            ]
+        };
+
+        AdminConfigurationImportPreview preview = await service.PreviewConfigurationImportAsync(CreateBundleStream(bundle), "preview.json");
+
+        Assert.Equal(1, preview.Analysis.InvalidDeviceProfileCount);
+        Assert.Equal(2, preview.Analysis.DuplicateDeviceProfileCount);
+        Assert.False(preview.Analysis.MergeImpact.CanImport);
+        Assert.False(preview.Analysis.ReplaceAllImpact.CanImport);
+        Assert.Contains(preview.Analysis.MergeImpact.Blockers, blocker => blocker.Contains("conflicting device name", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(preview.Analysis.ReplaceAllImpact.Blockers, blocker => blocker.Contains("conflicting device name", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(preview.Analysis.Issues, issue => issue.Scope == "Merge only");
+        Assert.Contains(preview.Analysis.Issues, issue => issue.Message.Contains("Device name is required.", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PreviewConfigurationImportAsyncSurfacesBundleSchemaProblemsWithoutThrowing()
+    {
+        HsmAdminService service = CreateService([]);
+        AdminConfigurationExportBundle bundle = new()
+        {
+            Format = "Unexpected.Format",
+            SchemaVersion = 99,
+            DeviceProfiles =
+            [
+                CreateProfile(Guid.NewGuid(), "Imported HSM", "/opt/imported.so")
+            ]
+        };
+
+        AdminConfigurationImportPreview preview = await service.PreviewConfigurationImportAsync(CreateBundleStream(bundle), "preview.json");
+
+        Assert.False(preview.Analysis.MergeImpact.CanImport);
+        Assert.False(preview.Analysis.ReplaceAllImpact.CanImport);
+        Assert.Contains(preview.Problems, problem => problem.Contains("Unsupported configuration format", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(preview.Problems, problem => problem.Contains("Unsupported configuration schema version", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static MemoryStream CreateBundleStream(AdminConfigurationExportBundle bundle)
         => new(JsonSerializer.SerializeToUtf8Bytes(bundle, AdminApplicationJsonContext.Default.AdminConfigurationExportBundle));
 


### PR DESCRIPTION
Add a read-only configuration import preflight preview before execution. This surfaces bundle metadata, validation issues, and concrete Merge/Replace All impact summaries so operators can review added/updated/removed profiles before applying a config bundle. Closes #173.