### PR TITLE
Add admin accessibility baseline improvements

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor
@@ -1,8 +1,10 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Navigation
 
+<a class="skip-link" href="#admin-main-content">Skip to main content</a>
+
 <div class="admin-shell">
-    <aside class="admin-sidebar">
+    <aside class="admin-sidebar" aria-label="Admin console branding and primary navigation">
         <div class="admin-brand">
             <div class="admin-brand-mark">P11</div>
             <div>
@@ -27,7 +29,7 @@
         <header class="admin-topbar">
             <div>
                 <div class="admin-topbar-eyebrow">Operations workspace</div>
-                <div class="admin-topbar-title">@CurrentSectionTitle</div>
+                <div class="admin-topbar-title" id="admin-section-title">@CurrentSectionTitle</div>
             </div>
 
             <div class="admin-topbar-meta">
@@ -37,13 +39,13 @@
             </div>
         </header>
 
-        <main class="admin-page-host">
+        <main class="admin-page-host" id="admin-main-content" tabindex="-1" aria-labelledby="admin-section-title">
             @Body
         </main>
     </div>
 </div>
 
-<div id="blazor-error-ui" data-nosnippet>
+<div id="blazor-error-ui" data-nosnippet role="alert" aria-live="assertive" aria-atomic="true">
     An unhandled error has occurred.
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor.css
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor.css
@@ -1,3 +1,24 @@
+.skip-link {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    z-index: 2000;
+    padding: 0.75rem 1rem;
+    border-radius: 0.9rem;
+    background: #0f172a;
+    color: #f8fafc;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    box-shadow: 0 18px 28px rgba(15, 23, 42, 0.2);
+    transform: translateY(-160%);
+    transition: transform 0.16s ease;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+    transform: translateY(0);
+    color: #f8fafc;
+}
+
 .admin-shell {
     min-height: 100vh;
     display: grid;

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor
@@ -1,6 +1,6 @@
 @using Pkcs11Wrapper.Admin.Application.Models
 
-<nav class="app-nav">
+<nav class="app-nav" aria-label="Primary admin navigation">
     <AuthorizeView>
         <Authorized Context="userContext">
             <div class="app-user-panel">

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor.css
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor.css
@@ -76,6 +76,16 @@
     box-shadow: 0 14px 24px rgba(2, 6, 23, 0.18);
 }
 
+.app-nav-item ::deep a.app-nav-link:focus-visible,
+.app-login-button:focus-visible,
+.app-logout-button:focus-visible {
+    outline: 3px solid rgba(191, 219, 254, 0.92);
+    outline-offset: 3px;
+    background: rgba(30, 41, 59, 0.6);
+    border-color: rgba(191, 219, 254, 0.42);
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.18);
+}
+
 .app-nav-item ::deep a.app-nav-link.active {
     background: linear-gradient(135deg, rgba(37, 99, 235, 0.22) 0%, rgba(79, 70, 229, 0.24) 100%);
     border-color: rgba(96, 165, 250, 0.28);

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Audit.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Audit.razor
@@ -32,7 +32,7 @@
 
 @if (_integrity is not null)
 {
-    <div class="alert @(_integrity.IsValid ? "alert-success" : "alert-danger")">
+    <div class="alert @(_integrity.IsValid ? "alert-success" : "alert-danger")" role="@(_integrity.IsValid ? "status" : "alert")" aria-live="@(_integrity.IsValid ? "polite" : "assertive")" aria-atomic="true">
         <div class="fw-semibold">Audit integrity</div>
         <div>@_integrity.Summary</div>
         @if (!string.IsNullOrWhiteSpace(_integrity.FailureReason))
@@ -84,11 +84,11 @@
         </div>
         <div class="col-xl-4 col-lg-5 col-md-6">
             <label class="form-label">Search</label>
-            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="actor, action, target, details..." />
+            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" aria-label="Search audit logs" placeholder="actor, action, target, details..." />
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Category</label>
-            <select class="form-select" @bind="_categoryFilter" @bind:after="OnFiltersChanged">
+            <select class="form-select" @bind="_categoryFilter" @bind:after="OnFiltersChanged" aria-label="Audit category filter">
                 <option value="">All categories</option>
                 @foreach (string category in AvailableCategories)
                 {
@@ -98,7 +98,7 @@
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Outcome</label>
-            <select class="form-select" @bind="_outcomeFilter" @bind:after="OnFiltersChanged">
+            <select class="form-select" @bind="_outcomeFilter" @bind:after="OnFiltersChanged" aria-label="Audit outcome filter">
                 <option value="all">All outcomes</option>
                 <option value="success">Success only</option>
                 <option value="failure">Non-success only</option>
@@ -106,7 +106,7 @@
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Page size</label>
-            <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChanged">
+            <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChanged" aria-label="Audit page size">
                 <option value="25">25</option>
                 <option value="50">50</option>
                 <option value="100">100</option>
@@ -135,16 +135,17 @@ else
 
     <div class="table-responsive table-shell">
         <table class="table table-striped align-middle">
+            <caption class="visually-hidden">Filtered audit log entries including timestamp, actor, roles, category, action, target, outcome, and details.</caption>
             <thead>
                 <tr>
-                    <th>When</th>
-                    <th>Actor</th>
-                    <th>Roles</th>
-                    <th>Category</th>
-                    <th>Action</th>
-                    <th>Target</th>
-                    <th>Outcome</th>
-                    <th>Details</th>
+                    <th scope="col">When</th>
+                    <th scope="col">Actor</th>
+                    <th scope="col">Roles</th>
+                    <th scope="col">Category</th>
+                    <th scope="col">Action</th>
+                    <th scope="col">Target</th>
+                    <th scope="col">Outcome</th>
+                    <th scope="col">Details</th>
                 </tr>
             </thead>
             <tbody>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Configuration.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Configuration.razor
@@ -30,10 +30,7 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="configuration-status" />
 
 <div class="row g-3 mb-4">
     <div class="col-xl-3 col-md-6">
@@ -119,7 +116,7 @@
                 <div>
                     <div class="mb-3">
                         <label class="form-label">Configuration file</label>
-                        <InputFile @key="_filePickerKey" class="form-control" OnChange="OnFileChangedAsync" accept=".json,application/json" />
+                        <InputFile @key="_filePickerKey" class="form-control" OnChange="OnFileChangedAsync" aria-label="Configuration import file" accept=".json,application/json" />
                         @if (_selectedFile is not null)
                         {
                             <div class="form-text">Selected: @_selectedFile.Name (@FormatSize(_selectedFile.Size))</div>
@@ -128,7 +125,7 @@
 
                     <div class="mb-3">
                         <label class="form-label">Import mode</label>
-                        <InputSelect class="form-select" @bind-Value="_importMode">
+                        <InputSelect class="form-select" @bind-Value="_importMode" aria-label="Configuration import mode">
                             <option value="@AdminConfigurationImportMode.Merge">Merge existing configuration</option>
                             <option value="@AdminConfigurationImportMode.ReplaceAll">Replace all existing configuration</option>
                         </InputSelect>
@@ -144,8 +141,10 @@
                         </div>
 
                         <div class="form-check mb-3">
-                            <InputCheckbox class="form-check-input" @bind-Value="_acknowledgeReplaceAll" />
-                            <label class="form-check-label">I understand that Replace All overwrites the current device configuration.</label>
+                            <label class="form-check-label d-inline-flex align-items-center gap-2">
+                                <InputCheckbox class="form-check-input m-0" @bind-Value="_acknowledgeReplaceAll" aria-label="Acknowledge that Replace All overwrites the current device configuration" />
+                                <span>I understand that Replace All overwrites the current device configuration.</span>
+                            </label>
                         </div>
                     }
 

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccess.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/CryptoApiAccess.razor
@@ -38,15 +38,12 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="crypto-api-access-status">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="crypto-api-access-status" />
 
 @if (_revealedKey is not null)
 {
-    <div class="alert alert-warning" data-testid="crypto-api-access-secret">
-        <div class="fw-semibold">New API key secret — copy it now</div>
+        <div class="alert alert-warning" role="alert" aria-live="assertive" aria-atomic="true" data-testid="crypto-api-access-secret">
+            <div class="fw-semibold">New API key secret — copy it now</div>
         <div class="small mt-2">Key identifier</div>
         <code>@_revealedKey.KeyIdentifier</code>
         <div class="small mt-3">Secret</div>
@@ -124,7 +121,7 @@ else
                 <div class="card-body row g-3">
                     <div class="col-12">
                         <label class="form-label">Client name</label>
-                        <input class="form-control" @bind="_createClientName" @bind:event="oninput" placeholder="payments-gateway" data-testid="crypto-api-client-name" />
+                        <input class="form-control" @bind="_createClientName" @bind:event="oninput" aria-label="Client name" placeholder="payments-gateway" data-testid="crypto-api-client-name" />
                         <div class="form-text">Stable machine-facing identifier.</div>
                     </div>
                     <div class="col-12">
@@ -167,8 +164,8 @@ else
                         </div>
                         <div class="col-12"><hr class="my-1" /></div>
                         <div class="col-12">
-                            <label class="form-label">New API key name</label>
-                            <input class="form-control" @bind="_newKeyName" @bind:event="oninput" placeholder="primary" data-testid="crypto-api-key-name" />
+                        <label class="form-label">New API key name</label>
+                            <input class="form-control" @bind="_newKeyName" @bind:event="oninput" aria-label="New API key name" placeholder="primary" data-testid="crypto-api-key-name" />
                         </div>
                         <div class="col-12">
                             <label class="form-label">Expire after days (optional)</label>
@@ -220,12 +217,12 @@ else
                 <div class="card-body row g-3">
                     <div class="col-12">
                         <label class="form-label">Alias name</label>
-                        <input class="form-control" @bind="_createAliasName" @bind:event="oninput" placeholder="payments-signer" data-testid="crypto-api-alias-name" />
+                        <input class="form-control" @bind="_createAliasName" @bind:event="oninput" aria-label="Alias name" placeholder="payments-signer" data-testid="crypto-api-alias-name" />
                         <div class="form-text">Customer-facing alias used by the Crypto API request payload.</div>
                     </div>
                     <div class="col-12">
                         <label class="form-label">Route group (preferred)</label>
-                        <input class="form-control" @bind="_createAliasRouteGroupName" @bind:event="oninput" placeholder="payments-signers" data-testid="crypto-api-alias-route-group" />
+                        <input class="form-control" @bind="_createAliasRouteGroupName" @bind:event="oninput" aria-label="Alias route group" placeholder="payments-signers" data-testid="crypto-api-alias-route-group" />
                         <div class="form-text">Preferred routing mode: map the alias to a configured backend pool / route group on the Crypto API host.</div>
                     </div>
                     <div class="col-md-6">
@@ -234,7 +231,7 @@ else
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">Legacy slot id (optional)</label>
-                        <input class="form-control" @bind="_createAliasSlotId" @bind:event="oninput" placeholder="0" data-testid="crypto-api-alias-slot-id" />
+                        <input class="form-control" @bind="_createAliasSlotId" @bind:event="oninput" aria-label="Legacy slot id" placeholder="0" data-testid="crypto-api-alias-slot-id" />
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">Object id hex (optional)</label>
@@ -242,7 +239,7 @@ else
                     </div>
                     <div class="col-12">
                         <label class="form-label">Object label</label>
-                        <input class="form-control" @bind="_createAliasObjectLabel" @bind:event="oninput" placeholder="Payments signing key" data-testid="crypto-api-alias-object-label" />
+                        <input class="form-control" @bind="_createAliasObjectLabel" @bind:event="oninput" aria-label="Alias object label" placeholder="Payments signing key" data-testid="crypto-api-alias-object-label" />
                         <div class="form-text">Provide object label and/or object id hex. When route group is set, the host selects a backend from that pool; otherwise the legacy device-route/slot mapping is used.</div>
                     </div>
                     <div class="col-12">
@@ -336,7 +333,7 @@ else
                 <div class="card-body row g-3">
                     <div class="col-12">
                         <label class="form-label">Policy name</label>
-                        <input class="form-control" @bind="_createPolicyName" @bind:event="oninput" placeholder="payments-signing" data-testid="crypto-api-policy-name" />
+                        <input class="form-control" @bind="_createPolicyName" @bind:event="oninput" aria-label="Policy name" placeholder="payments-signing" data-testid="crypto-api-policy-name" />
                         <div class="form-text">Stable machine-facing identifier for shared authorization rules.</div>
                     </div>
                     <div class="col-12">
@@ -345,7 +342,7 @@ else
                     </div>
                     <div class="col-12">
                         <label class="form-label">Allowed operations</label>
-                        <textarea class="form-control" rows="3" @bind="_createPolicyOperations" placeholder="sign, verify, random" data-testid="crypto-api-policy-operations"></textarea>
+                        <textarea class="form-control" rows="3" @bind="_createPolicyOperations" aria-label="Allowed operations" placeholder="sign, verify, random" data-testid="crypto-api-policy-operations"></textarea>
                         <div class="form-text">Use comma, semicolon, or newline separators. <code>*</code> is allowed.</div>
                     </div>
                     <div class="col-12">

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Devices.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Devices.razor
@@ -35,10 +35,7 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="devices-status">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="devices-status" />
 
 @if (_devices.Count != 0)
 {
@@ -91,19 +88,19 @@
 
                     <div class="mb-3">
                         <label class="form-label">Name</label>
-                        <InputText class="form-control" @bind-Value="_input.Name" data-testid="device-name" />
+                        <InputText class="form-control" @bind-Value="_input.Name" aria-label="Device name" data-testid="device-name" />
                     </div>
                     <div class="mb-3">
                         <label class="form-label">PKCS#11 Module Path</label>
-                        <InputText class="form-control" @bind-Value="_input.ModulePath" data-testid="device-module-path" />
+                        <InputText class="form-control" @bind-Value="_input.ModulePath" aria-label="PKCS#11 module path" data-testid="device-module-path" />
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Default Token Label</label>
-                        <InputText class="form-control" @bind-Value="_input.DefaultTokenLabel" data-testid="device-token-label" />
+                        <InputText class="form-control" @bind-Value="_input.DefaultTokenLabel" aria-label="Default token label" data-testid="device-token-label" />
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Vendor profile</label>
-                        <select class="form-select" @bind="_vendorSelection" @bind:after="OnVendorSelectionChanged" data-testid="device-vendor-profile">
+                        <select class="form-select" @bind="_vendorSelection" @bind:after="OnVendorSelectionChanged" aria-label="Vendor profile" data-testid="device-vendor-profile">
                             <option value="@DeviceVendorProfileCatalog.VendorNeutralSelectionId">Vendor-neutral / generic</option>
                             @foreach (DeviceVendorProfileDefinition profile in DeviceVendorProfileCatalog.Profiles)
                             {
@@ -126,11 +123,11 @@
                         <div class="row g-3 mb-3">
                             <div class="col-12">
                                 <label class="form-label">Vendor name</label>
-                                <InputText class="form-control" @bind-Value="_input.VendorName" data-testid="device-vendor-name" />
+                                <InputText class="form-control" @bind-Value="_input.VendorName" aria-label="Vendor name" data-testid="device-vendor-name" />
                             </div>
                             <div class="col-12">
                                 <label class="form-label">Vendor profile label</label>
-                                <InputText class="form-control" @bind-Value="_input.VendorProfileName" data-testid="device-vendor-profile-name" />
+                                <InputText class="form-control" @bind-Value="_input.VendorProfileName" aria-label="Vendor profile label" data-testid="device-vendor-profile-name" />
                                 <div class="form-text">Optional label such as client family, module wrapper, or standard PKCS#11 track for this vendor.</div>
                             </div>
                         </div>
@@ -138,11 +135,13 @@
 
                     <div class="mb-3">
                         <label class="form-label">Notes</label>
-                        <InputTextArea class="form-control" @bind-Value="_input.Notes" data-testid="device-notes" />
+                        <InputTextArea class="form-control" @bind-Value="_input.Notes" aria-label="Device notes" data-testid="device-notes" />
                     </div>
                     <div class="form-check mb-3">
-                        <InputCheckbox class="form-check-input" @bind-Value="_input.IsEnabled" />
-                        <label class="form-check-label">Enabled</label>
+                        <label class="form-check-label d-inline-flex align-items-center gap-2">
+                            <InputCheckbox class="form-check-input m-0" @bind-Value="_input.IsEnabled" aria-label="Enabled" />
+                            <span>Enabled</span>
+                        </label>
                     </div>
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary" disabled="@(!_isAdmin)" data-testid="device-save">Save</button>
@@ -168,11 +167,11 @@
             <div class="card-body border-bottom row g-3 align-items-end">
                 <div class="col-lg-5">
                     <label class="form-label">Search</label>
-                    <input class="form-control" @bind="_searchText" @bind:event="oninput" placeholder="name, path, token, vendor, notes..." />
+                    <input class="form-control" @bind="_searchText" @bind:event="oninput" aria-label="Search devices" placeholder="name, path, token, vendor, notes..." />
                 </div>
                 <div class="col-lg-3 col-md-6">
                     <label class="form-label">Status</label>
-                    <select class="form-select" @bind="_statusFilter">
+                    <select class="form-select" @bind="_statusFilter" aria-label="Device status filter">
                         <option value="all">All devices</option>
                         <option value="enabled">Enabled</option>
                         <option value="disabled">Disabled</option>
@@ -180,7 +179,7 @@
                 </div>
                 <div class="col-lg-4 col-md-6">
                     <label class="form-label">Sort</label>
-                    <select class="form-select" @bind="_sortMode">
+                    <select class="form-select" @bind="_sortMode" aria-label="Device sort order">
                         <option value="name">Name (A-Z)</option>
                         <option value="updated">Recently updated</option>
                         <option value="created">Recently created</option>
@@ -202,15 +201,16 @@
                 {
                     <div class="table-responsive table-shell">
                         <table class="table table-striped align-middle" data-testid="devices-table">
+                            <caption class="visually-hidden">Configured HSM devices with module path, default token label, vendor details, profile status, last update time, and available actions.</caption>
                             <thead>
                                 <tr>
-                                    <th>Name</th>
-                                    <th>Module Path</th>
-                                    <th>Token</th>
-                                    <th>Vendor</th>
-                                    <th>Status</th>
-                                    <th>Updated</th>
-                                    <th class="text-end">Actions</th>
+                                    <th scope="col">Name</th>
+                                    <th scope="col">Module Path</th>
+                                    <th scope="col">Token</th>
+                                    <th scope="col">Vendor</th>
+                                    <th scope="col">Status</th>
+                                    <th scope="col">Updated</th>
+                                    <th scope="col" class="text-end">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor
@@ -33,16 +33,13 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="keys-status">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="keys-status" />
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
         <div class="col-lg-3">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" data-testid="keys-device">
+            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" aria-label="Keys device" data-testid="keys-device">
                 <option value="">Select device...</option>
                 @foreach (HsmDeviceProfile device in _devices)
                 {
@@ -52,7 +49,7 @@
         </div>
         <div class="col-lg-2">
             <label class="form-label">Slot</label>
-            <select class="form-select" @bind="_selectedSlotId" @bind:after="OnSelectedSlotChangedAsync" data-testid="keys-slot">
+            <select class="form-select" @bind="_selectedSlotId" @bind:after="OnSelectedSlotChangedAsync" aria-label="Keys slot" data-testid="keys-slot">
                 <option value="">Select slot...</option>
                 @foreach (HsmSlotSummary slot in _slots)
                 {
@@ -62,15 +59,17 @@
         </div>
         <div class="col-lg-2">
             <label class="form-label">Load-time Label Filter</label>
-            <input class="form-control" @bind="_labelFilter" data-testid="keys-label-filter" />
+            <input class="form-control" @bind="_labelFilter" aria-label="Load-time label filter" data-testid="keys-label-filter" />
             <div class="form-text">Sent to the server-side PKCS#11 search before the object list is loaded.</div>
         </div>
         <div class="col-lg-2">
             <label class="form-label">User PIN</label>
-            <input class="form-control" type="password" @bind="_userPin" data-testid="keys-user-pin" />
+            <input class="form-control" type="password" @bind="_userPin" aria-label="User PIN" data-testid="keys-user-pin" />
             <div class="form-check mt-2">
-                <input class="form-check-input" type="checkbox" @bind="_rememberPin" />
-                <label class="form-check-label">Remember in protected local storage</label>
+                <label class="form-check-label d-inline-flex align-items-center gap-2">
+                    <input class="form-check-input m-0" type="checkbox" @bind="_rememberPin" aria-label="Remember PIN in protected local storage" />
+                    <span>Remember in protected local storage</span>
+                </label>
             </div>
         </div>
         <div class="col-lg-3 d-flex gap-2">
@@ -133,15 +132,15 @@
                 @RenderOperationWarnings(GetAesWarnings())
                 <div class="col-md-6">
                     <label class="form-label">Label</label>
-                    <input class="form-control" @bind="_aesRequest.Label" />
+                    <input class="form-control" @bind="_aesRequest.Label" aria-label="AES key label" />
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">ID (hex)</label>
-                    <input class="form-control" @bind="_aesRequest.IdHex" />
+                    <input class="form-control" @bind="_aesRequest.IdHex" aria-label="AES key identifier in hex" />
                 </div>
                 <div class="col-md-4">
                     <label class="form-label">Size</label>
-                    <select class="form-select" @bind="_aesRequest.SizeBytes">
+                    <select class="form-select" @bind="_aesRequest.SizeBytes" aria-label="AES key size">
                         <option value="16">128-bit</option>
                         <option value="24">192-bit</option>
                         <option value="32">256-bit</option>
@@ -175,15 +174,15 @@
                 @RenderOperationWarnings(GetImportWarnings())
                 <div class="col-md-6">
                     <label class="form-label">Label</label>
-                    <input class="form-control" @bind="_importAesRequest.Label" />
+                    <input class="form-control" @bind="_importAesRequest.Label" aria-label="Imported AES key label" />
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">ID (hex)</label>
-                    <input class="form-control" @bind="_importAesRequest.IdHex" />
+                    <input class="form-control" @bind="_importAesRequest.IdHex" aria-label="Imported AES key identifier in hex" />
                 </div>
                 <div class="col-12">
                     <label class="form-label">Key Value (hex)</label>
-                    <textarea class="form-control font-monospace" rows="4" @bind="_importAesRequest.ValueHex"></textarea>
+                    <textarea class="form-control font-monospace" rows="4" @bind="_importAesRequest.ValueHex" aria-label="AES key value in hex"></textarea>
                     <div class="form-text">Raw key import uses <code>C_CreateObject</code> with AES secret-key attributes. Keep this field local and short-lived.</div>
                 </div>
                 <div class="col-12 d-flex flex-wrap gap-3 align-items-center">
@@ -212,15 +211,15 @@
                 @RenderOperationWarnings(GetRsaWarnings())
                 <div class="col-md-6">
                     <label class="form-label">Label</label>
-                    <input class="form-control" @bind="_rsaRequest.Label" />
+                    <input class="form-control" @bind="_rsaRequest.Label" aria-label="RSA key pair label" />
                 </div>
                 <div class="col-md-6">
                     <label class="form-label">ID (hex)</label>
-                    <input class="form-control" @bind="_rsaRequest.IdHex" />
+                    <input class="form-control" @bind="_rsaRequest.IdHex" aria-label="RSA key pair identifier in hex" />
                 </div>
                 <div class="col-md-4">
                     <label class="form-label">Modulus bits</label>
-                    <select class="form-select" @bind="_rsaRequest.ModulusBits">
+                    <select class="form-select" @bind="_rsaRequest.ModulusBits" aria-label="RSA modulus bits">
                         <option value="1024">1024</option>
                         <option value="2048">2048</option>
                         <option value="3072">3072</option>
@@ -229,7 +228,7 @@
                 </div>
                 <div class="col-md-4">
                     <label class="form-label">Public exponent</label>
-                    <input class="form-control" @bind="_rsaRequest.PublicExponentHex" />
+                    <input class="form-control" @bind="_rsaRequest.PublicExponentHex" aria-label="RSA public exponent in hex" />
                 </div>
                 <div class="col-md-4 d-flex align-items-end">
                     @CapabilityCheckbox(() => _rsaRequest.Token, value => _rsaRequest.Token = value, "Token objects")
@@ -291,11 +290,11 @@
         <div class="card-body row g-3 align-items-end">
             <div class="col-xl-4 col-lg-5 col-md-6">
                 <label class="form-label">Search</label>
-                <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnKeyViewChangedAsync" placeholder="handle, label, id, class, key type..." />
+                <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnKeyViewChangedAsync" aria-label="Search loaded keys and objects" placeholder="handle, label, id, class, key type..." />
             </div>
             <div class="col-xl-2 col-lg-3 col-md-6">
                 <label class="form-label">Class</label>
-                <select class="form-select" @bind="_classFilter" @bind:after="OnKeyViewChangedAsync">
+                <select class="form-select" @bind="_classFilter" @bind:after="OnKeyViewChangedAsync" aria-label="Object class filter">
                     <option value="all">All classes</option>
                     <option value="secretkey">Secret Key</option>
                     <option value="privatekey">Private Key</option>
@@ -305,7 +304,7 @@
             </div>
             <div class="col-xl-2 col-lg-4 col-md-6">
                 <label class="form-label">Capability</label>
-                <select class="form-select" @bind="_capabilityFilter" @bind:after="OnKeyViewChangedAsync">
+                <select class="form-select" @bind="_capabilityFilter" @bind:after="OnKeyViewChangedAsync" aria-label="Capability filter">
                     <option value="all">All capabilities</option>
                     <option value="encrypt">Encrypt</option>
                     <option value="decrypt">Decrypt</option>
@@ -317,7 +316,7 @@
             </div>
             <div class="col-xl-2 col-lg-4 col-md-6">
                 <label class="form-label">Sort</label>
-                <select class="form-select" @bind="_sortMode" @bind:after="OnKeyViewChangedAsync">
+                <select class="form-select" @bind="_sortMode" @bind:after="OnKeyViewChangedAsync" aria-label="Keys sort order">
                     <option value="handle">Handle</option>
                     <option value="label">Label</option>
                     <option value="class">Class</option>
@@ -326,7 +325,7 @@
             </div>
             <div class="col-xl-2 col-lg-4 col-md-6">
                 <label class="form-label">Page size</label>
-                <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChangedAsync">
+                <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChangedAsync" aria-label="Keys page size">
                     <option value="10">10</option>
                     <option value="25">25</option>
                     <option value="50">50</option>
@@ -351,15 +350,16 @@
             {
                 <div class="table-responsive table-shell">
                     <table class="table table-striped table-hover align-middle" data-testid="keys-table">
+                        <caption class="visually-hidden">Loaded PKCS#11 objects for the selected device and slot, including handles, labels, identifiers, object classes, key types, capability summaries, and actions.</caption>
                         <thead>
                             <tr>
-                                <th>Handle</th>
-                                <th>Label</th>
-                                <th>ID</th>
-                                <th>Class</th>
-                                <th>Key Type</th>
-                                <th>Capabilities</th>
-                                <th class="text-end">Actions</th>
+                                <th scope="col">Handle</th>
+                                <th scope="col">Label</th>
+                                <th scope="col">ID</th>
+                                <th scope="col">Class</th>
+                                <th scope="col">Key Type</th>
+                                <th scope="col">Capabilities</th>
+                                <th scope="col" class="text-end">Actions</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -525,11 +525,11 @@
                         </div>
                         <div class="col-md-6">
                             <label class="form-label">New Label</label>
-                            <input class="form-control" @bind="_editRequest.Label" />
+                            <input class="form-control" @bind="_editRequest.Label" aria-label="Updated object label" />
                         </div>
                         <div class="col-md-6">
                             <label class="form-label">ID (hex)</label>
-                            <input class="form-control" @bind="_editRequest.IdHex" />
+                            <input class="form-control" @bind="_editRequest.IdHex" aria-label="Updated object identifier in hex" />
                         </div>
                         <div class="col-12">
                             <div class="alert alert-warning small mb-0">Only attributes supported by both PKCS#11 and the token are updated. Disabled toggles below are obviously unsupported for the selected object type or because the object is not modifiable.</div>
@@ -575,11 +575,11 @@
                         </div>
                         <div class="col-md-6">
                             <label class="form-label">New Label</label>
-                            <input class="form-control" @bind="_copyRequest.Label" />
+                            <input class="form-control" @bind="_copyRequest.Label" aria-label="Copied object label" />
                         </div>
                         <div class="col-md-6">
                             <label class="form-label">ID (hex)</label>
-                            <input class="form-control" @bind="_copyRequest.IdHex" />
+                            <input class="form-control" @bind="_copyRequest.IdHex" aria-label="Copied object identifier in hex" />
                         </div>
                         <div class="col-12">
                             <div class="alert alert-info small mb-0">This uses PKCS#11 <code>C_CopyObject</code>. The token still decides which attributes may be overridden during the copy.</div>
@@ -620,12 +620,14 @@
                         </ul>
                         <div class="mb-3">
                             <label class="form-label">Type exact confirmation text</label>
-                            <input class="form-control" @bind="_destroyRequest.ConfirmationText" />
+                            <input class="form-control" @bind="_destroyRequest.ConfirmationText" aria-label="Destroy confirmation text" />
                             <div class="form-text"><code>@DestroyConfirmationText</code></div>
                         </div>
                         <div class="form-check mb-3">
-                            <input class="form-check-input" type="checkbox" @bind="_destroyRequest.AcknowledgePermanentDeletion" />
-                            <label class="form-check-label">I understand this deletion is permanent.</label>
+                            <label class="form-check-label d-inline-flex align-items-center gap-2">
+                                <input class="form-check-input m-0" type="checkbox" @bind="_destroyRequest.AcknowledgePermanentDeletion" aria-label="Acknowledge that deletion is permanent" />
+                                <span>I understand this deletion is permanent.</span>
+                            </label>
                         </div>
                         <div class="d-flex gap-2">
                             <button class="btn btn-danger" @onclick="DestroyAsync" disabled="@(!_isOperator)">Destroy Now</button>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor.cs
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Keys.razor.cs
@@ -883,15 +883,18 @@ public partial class Keys
     {
         builder.OpenElement(0, "div");
         builder.AddAttribute(1, "class", "form-check");
-        builder.OpenElement(2, "input");
-        builder.AddAttribute(3, "class", "form-check-input");
-        builder.AddAttribute(4, "type", "checkbox");
-        builder.AddAttribute(5, "checked", getValue());
-        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<bool>(this, setValue, getValue()));
+        builder.OpenElement(2, "label");
+        builder.AddAttribute(3, "class", "form-check-label d-inline-flex align-items-center gap-2 mb-0");
+        builder.OpenElement(4, "input");
+        builder.AddAttribute(5, "class", "form-check-input m-0");
+        builder.AddAttribute(6, "type", "checkbox");
+        builder.AddAttribute(7, "checked", getValue());
+        builder.AddAttribute(8, "aria-label", label);
+        builder.AddAttribute(9, "onchange", EventCallback.Factory.CreateBinder<bool>(this, setValue, getValue()));
         builder.CloseElement();
-        builder.OpenElement(7, "label");
-        builder.AddAttribute(8, "class", "form-check-label");
-        builder.AddContent(9, label);
+        builder.OpenElement(10, "span");
+        builder.AddContent(11, label);
+        builder.CloseElement();
         builder.CloseElement();
         builder.CloseElement();
     };
@@ -899,18 +902,22 @@ public partial class Keys
     private RenderFragment NullableCheckbox(Func<bool?> getValue, Action<bool?> setValue, string label, bool enabled) => builder =>
     {
         bool current = getValue() == true;
+        string accessibleLabel = !enabled ? $"{label} unsupported here" : getValue() is null ? $"{label} keep existing" : label;
         builder.OpenElement(0, "div");
         builder.AddAttribute(1, "class", "form-check form-switch");
-        builder.OpenElement(2, "input");
-        builder.AddAttribute(3, "class", "form-check-input");
-        builder.AddAttribute(4, "type", "checkbox");
-        builder.AddAttribute(5, "checked", current);
-        builder.AddAttribute(6, "disabled", !enabled);
-        builder.AddAttribute(7, "onchange", EventCallback.Factory.CreateBinder<bool>(this, value => setValue(value), current));
+        builder.OpenElement(2, "label");
+        builder.AddAttribute(3, "class", "form-check-label d-inline-flex align-items-center gap-2 mb-0");
+        builder.OpenElement(4, "input");
+        builder.AddAttribute(5, "class", "form-check-input m-0");
+        builder.AddAttribute(6, "type", "checkbox");
+        builder.AddAttribute(7, "checked", current);
+        builder.AddAttribute(8, "disabled", !enabled);
+        builder.AddAttribute(9, "aria-label", accessibleLabel);
+        builder.AddAttribute(10, "onchange", EventCallback.Factory.CreateBinder<bool>(this, value => setValue(value), current));
         builder.CloseElement();
-        builder.OpenElement(8, "label");
-        builder.AddAttribute(9, "class", "form-check-label");
-        builder.AddContent(10, !enabled ? $"{label} (unsupported here)" : getValue() is null ? $"{label} (keep existing)" : label);
+        builder.OpenElement(11, "span");
+        builder.AddContent(12, !enabled ? $"{label} (unsupported here)" : getValue() is null ? $"{label} (keep existing)" : label);
+        builder.CloseElement();
         builder.CloseElement();
         builder.CloseElement();
     };

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Login.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Login.razor
@@ -33,7 +33,7 @@
 
         @if (_showError)
         {
-            <div class="alert alert-danger">@_errorMessage</div>
+            <div class="alert alert-danger" role="alert" aria-live="assertive" aria-atomic="true">@_errorMessage</div>
         }
 
         @if (!_interactiveReady)
@@ -46,11 +46,11 @@
         <fieldset disabled="@(!_interactiveReady)">
             <div class="mb-3">
                 <label class="form-label">Username</label>
-                <input class="form-control" name="username" autocomplete="username" data-testid="login-username" />
+                <input class="form-control" name="username" autocomplete="username" aria-label="Username" data-testid="login-username" />
             </div>
             <div class="mb-3">
                 <label class="form-label">Password</label>
-                <input class="form-control" type="password" name="password" autocomplete="current-password" data-testid="login-password" />
+                <input class="form-control" type="password" name="password" autocomplete="current-password" aria-label="Password" data-testid="login-password" />
             </div>
 
             <button class="btn btn-primary w-100" type="submit" data-testid="login-submit">Sign in</button>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Pkcs11Lab.razor
@@ -33,10 +33,7 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="lab-status">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="lab-status" />
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
@@ -747,4 +744,3 @@
         </div>
     </div>
 </div>
-

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Sessions.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Sessions.razor
@@ -32,10 +32,7 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="sessions-status" />
 
 @if (_sessions.Count != 0)
 {
@@ -100,11 +97,11 @@
         </div>
         <div class="col-xl-3 col-lg-4 col-md-6">
             <label class="form-label">Search</label>
-            <input class="form-control" @bind="_searchText" @bind:event="oninput" placeholder="session id, device, slot, operation..." />
+            <input class="form-control" @bind="_searchText" @bind:event="oninput" aria-label="Search tracked sessions" placeholder="session id, device, slot, operation..." />
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Health</label>
-            <select class="form-select" @bind="_healthFilter">
+            <select class="form-select" @bind="_healthFilter" aria-label="Session health filter">
                 <option value="all">All health states</option>
                 <option value="healthy">Healthy only</option>
                 <option value="invalidated">Invalidated only</option>
@@ -112,7 +109,7 @@
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_deviceFilter">
+            <select class="form-select" @bind="_deviceFilter" aria-label="Session device filter">
                 <option value="">All devices</option>
                 @foreach (string deviceName in AvailableDevices)
                 {
@@ -122,7 +119,7 @@
         </div>
         <div class="col-xl-3 col-lg-5 col-md-12">
             <label class="form-label">Sort</label>
-            <select class="form-select" @bind="_sortMode">
+            <select class="form-select" @bind="_sortMode" aria-label="Session sort order">
                 <option value="lastTouched">Last touched (newest)</option>
                 <option value="opened">Opened (newest)</option>
                 <option value="slot">Device / slot</option>
@@ -241,14 +238,15 @@
                                 </div>
                                 <div class="table-responsive table-shell">
                                     <table class="table table-sm align-middle mb-0">
+                                        <caption class="visually-hidden">Bulk cleanup review sessions for @deviceGroup.DeviceName grouped by health, including slot, mode, status, review note, and keep-open action.</caption>
                                         <thead>
                                             <tr>
-                                                <th>Session Id</th>
-                                                <th>Slot</th>
-                                                <th>Mode</th>
-                                                <th>Status</th>
-                                                <th>Review note</th>
-                                                <th></th>
+                                                <th scope="col">Session Id</th>
+                                                <th scope="col">Slot</th>
+                                                <th scope="col">Mode</th>
+                                                <th scope="col">Status</th>
+                                                <th scope="col">Review note</th>
+                                                <th scope="col"></th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -288,13 +286,14 @@
                     </div>
                     <div class="table-responsive table-shell">
                         <table class="table table-sm align-middle mb-0">
+                            <caption class="visually-hidden">Tracked sessions excluded from the pending cleanup review, including device, health status, reason kept open, and restore action.</caption>
                             <thead>
                                 <tr>
-                                    <th>Device</th>
-                                    <th>Session Id</th>
-                                    <th>Status</th>
-                                    <th>Reason kept open</th>
-                                    <th></th>
+                                    <th scope="col">Device</th>
+                                    <th scope="col">Session Id</th>
+                                    <th scope="col">Status</th>
+                                    <th scope="col">Reason kept open</th>
+                                    <th scope="col"></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -324,7 +323,7 @@
                 {
                     <div class="mb-3">
                         <label class="form-label">Large batch confirmation</label>
-                        <input class="form-control" @bind="_cleanupConfirmationText" @bind:event="oninput" placeholder="Type exact confirmation text" />
+                        <input class="form-control" @bind="_cleanupConfirmationText" @bind:event="oninput" aria-label="Large batch cleanup confirmation text" placeholder="Type exact confirmation text" />
                         <div class="form-text">Type <code>@plan.ConfirmationText</code> to execute this larger cleanup batch.</div>
                     </div>
                 }
@@ -377,15 +376,16 @@ else
                     </div>
                     <div class="table-responsive table-shell">
                         <table class="table table-striped align-middle mb-0">
+                            <caption class="visually-hidden">Tracked sessions grouped by device, including slot, mode, state, last operation, health status, and actions.</caption>
                             <thead>
                                 <tr>
-                                    <th>Session Id</th>
-                                    <th>Slot</th>
-                                    <th>Mode</th>
-                                    <th>State</th>
-                                    <th>Last Operation</th>
-                                    <th>Status</th>
-                                    <th></th>
+                                    <th scope="col">Session Id</th>
+                                    <th scope="col">Slot</th>
+                                    <th scope="col">Mode</th>
+                                    <th scope="col">State</th>
+                                    <th scope="col">Last Operation</th>
+                                    <th scope="col">Status</th>
+                                    <th scope="col"></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -462,10 +462,12 @@ else
                         <div class="row g-3">
                             <div class="col-12">
                                 <label class="form-label">User PIN</label>
-                                <input class="form-control" type="password" @bind="_userPin" />
+                                <input class="form-control" type="password" @bind="_userPin" aria-label="Tracked session user PIN" />
                                 <div class="form-check mt-2">
-                                    <input class="form-check-input" type="checkbox" @bind="_rememberPin" />
-                                    <label class="form-check-label">Remember PIN in protected local storage</label>
+                                    <label class="form-check-label d-inline-flex align-items-center gap-2">
+                                        <input class="form-check-input m-0" type="checkbox" @bind="_rememberPin" aria-label="Remember PIN in protected local storage" />
+                                        <span>Remember PIN in protected local storage</span>
+                                    </label>
                                 </div>
                                 <div class="form-text">Login/logout operates on the tracked session itself so you can watch state transitions immediately. Once invalidated, only close/refresh remain meaningful.</div>
                             </div>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Slots.razor
@@ -35,16 +35,13 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="slots-status">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="slots-status" />
 
 <div class="card shadow-sm mb-4 panel-toolbar-card feature-card">
     <div class="card-body row g-3 align-items-end">
         <div class="col-lg-4">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" data-testid="slots-device">
+            <select class="form-select" @bind="_selectedDeviceId" @bind:after="OnSelectedDeviceChangedAsync" aria-label="Slot device" data-testid="slots-device">
                 <option value="">Select device...</option>
                 @foreach (HsmDeviceProfile device in _devices)
                 {
@@ -54,10 +51,12 @@
         </div>
         <div class="col-lg-4">
             <label class="form-label">Optional User PIN</label>
-            <input class="form-control" type="password" @bind="_userPin" data-testid="slots-user-pin" />
+            <input class="form-control" type="password" @bind="_userPin" aria-label="Optional user PIN" data-testid="slots-user-pin" />
             <div class="form-check mt-2">
-                <input class="form-check-input" type="checkbox" @bind="_rememberPin" />
-                <label class="form-check-label">Remember this PIN in protected local storage</label>
+                <label class="form-check-label d-inline-flex align-items-center gap-2">
+                    <input class="form-check-input m-0" type="checkbox" @bind="_rememberPin" aria-label="Remember this PIN in protected local storage" />
+                    <span>Remember this PIN in protected local storage</span>
+                </label>
             </div>
         </div>
         <div class="col-lg-4 d-flex gap-2">
@@ -112,11 +111,11 @@
         <div class="card-body row g-3 align-items-end">
             <div class="col-lg-5">
                 <label class="form-label">Search</label>
-                <input class="form-control" @bind="_searchText" @bind:event="oninput" placeholder="slot description, token label, serial..." />
+                <input class="form-control" @bind="_searchText" @bind:event="oninput" aria-label="Search loaded slots" placeholder="slot description, token label, serial..." />
             </div>
             <div class="col-lg-3 col-md-6">
                 <label class="form-label">Token filter</label>
-                <select class="form-select" @bind="_tokenFilter">
+                <select class="form-select" @bind="_tokenFilter" aria-label="Token presence filter">
                     <option value="all">All slots</option>
                     <option value="present">Token present</option>
                     <option value="missing">No token</option>
@@ -124,7 +123,7 @@
             </div>
             <div class="col-lg-4 col-md-6">
                 <label class="form-label">Sort</label>
-                <select class="form-select" @bind="_sortMode">
+                <select class="form-select" @bind="_sortMode" aria-label="Slot sort order">
                     <option value="slot">Slot id</option>
                     <option value="token">Token label</option>
                     <option value="mechanisms">Mechanism count</option>
@@ -142,14 +141,15 @@
     {
         <div class="table-responsive table-shell">
             <table class="table table-striped align-middle" data-testid="slots-table">
+                <caption class="visually-hidden">Loaded slots for the selected device, including token presence, slot flags, supported mechanism counts, and direct slot actions.</caption>
                 <thead>
                     <tr>
-                        <th>Slot</th>
-                        <th>Description</th>
-                        <th>Token</th>
-                        <th>Flags</th>
-                        <th>Mechanisms</th>
-                        <th class="text-end">Actions</th>
+                        <th scope="col">Slot</th>
+                        <th scope="col">Description</th>
+                        <th scope="col">Token</th>
+                        <th scope="col">Flags</th>
+                        <th scope="col">Mechanisms</th>
+                        <th scope="col" class="text-end">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -214,15 +214,16 @@
         </div>
         <div class="table-responsive table-shell">
         <table class="table table-sm table-bordered align-middle">
+            <caption class="visually-hidden">Tracked sessions that belong to the currently selected device, including mode, state, health, last operation, and close actions.</caption>
             <thead>
                 <tr>
-                    <th>Session</th>
-                    <th>Slot</th>
-                    <th>Mode</th>
-                    <th>State</th>
-                    <th>Health</th>
-                    <th>Last Operation</th>
-                    <th></th>
+                    <th scope="col">Session</th>
+                    <th scope="col">Slot</th>
+                    <th scope="col">Mode</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Health</th>
+                    <th scope="col">Last Operation</th>
+                    <th scope="col"></th>
                 </tr>
             </thead>
             <tbody>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Telemetry.razor
@@ -140,11 +140,11 @@
         </div>
         <div class="col-xl-4 col-lg-5 col-md-6">
             <label class="form-label">Search</label>
-            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="device, native op, return value, actor, trace, field..." data-testid="telemetry-search" />
+            <input class="form-control" @bind="_searchText" @bind:event="oninput" @bind:after="OnFiltersChanged" aria-label="Search telemetry entries" placeholder="device, native op, return value, actor, trace, field..." data-testid="telemetry-search" />
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Device</label>
-            <select class="form-select" @bind="_deviceFilter" @bind:after="OnFiltersChanged" data-testid="telemetry-device-filter">
+            <select class="form-select" @bind="_deviceFilter" @bind:after="OnFiltersChanged" aria-label="Telemetry device filter" data-testid="telemetry-device-filter">
                 <option value="">All devices</option>
                 @foreach (string device in AvailableDevices)
                 {
@@ -154,7 +154,7 @@
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Operation</label>
-            <select class="form-select" @bind="_operationFilter" @bind:after="OnFiltersChanged">
+            <select class="form-select" @bind="_operationFilter" @bind:after="OnFiltersChanged" aria-label="Telemetry operation filter">
                 <option value="">All operations</option>
                 @foreach (string operation in AvailableOperations)
                 {
@@ -164,19 +164,19 @@
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Slot</label>
-            <input class="form-control" @bind="_slotFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="decimal or hex" />
+            <input class="form-control" @bind="_slotFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" aria-label="Telemetry slot filter" placeholder="decimal or hex" />
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Mechanism</label>
-            <input class="form-control" @bind="_mechanismFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" placeholder="0x1082 or 4226" />
+            <input class="form-control" @bind="_mechanismFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" aria-label="Telemetry mechanism filter" placeholder="0x1082 or 4226" />
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Min duration (ms)</label>
-            <input class="form-control" @bind="_minDurationFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" inputmode="decimal" placeholder="250" data-testid="telemetry-min-duration" />
+            <input class="form-control" @bind="_minDurationFilter" @bind:event="oninput" @bind:after="OnFiltersChanged" aria-label="Minimum telemetry duration in milliseconds" inputmode="decimal" placeholder="250" data-testid="telemetry-min-duration" />
         </div>
         <div class="col-xl-2 col-lg-4 col-md-6">
             <label class="form-label">Status</label>
-            <select class="form-select" @bind="_statusFilter" @bind:after="OnFiltersChanged">
+            <select class="form-select" @bind="_statusFilter" @bind:after="OnFiltersChanged" aria-label="Telemetry status filter">
                 <option value="all">All statuses</option>
                 <option value="success">Success only</option>
                 <option value="non-success">Non-success</option>
@@ -186,7 +186,7 @@
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Time range</label>
-            <select class="form-select" @bind="_timeRangeFilter" @bind:after="OnFiltersChanged">
+            <select class="form-select" @bind="_timeRangeFilter" @bind:after="OnFiltersChanged" aria-label="Telemetry time range filter">
                 <option value="all">All loaded</option>
                 <option value="1h">Last hour</option>
                 <option value="6h">Last 6 hours</option>
@@ -196,7 +196,7 @@
         </div>
         <div class="col-xl-2 col-lg-3 col-md-6">
             <label class="form-label">Page size</label>
-            <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChanged">
+            <select class="form-select" @bind="_pageSize" @bind:after="OnPageSizeChanged" aria-label="Telemetry page size">
                 <option value="25">25</option>
                 <option value="50">50</option>
                 <option value="100">100</option>
@@ -266,13 +266,14 @@ else
                     {
                         <div class="table-responsive table-shell">
                             <table class="table table-striped align-middle mb-0" data-testid="telemetry-top-operations">
+                                <caption class="visually-hidden">Top telemetry operations in the current view with call counts, non-success counts, duration summaries, and focus actions.</caption>
                                 <thead>
                                     <tr>
-                                        <th>Operation</th>
-                                        <th>Calls</th>
-                                        <th>Non-success</th>
-                                        <th>Avg / max</th>
-                                        <th>Focus</th>
+                                        <th scope="col">Operation</th>
+                                        <th scope="col">Calls</th>
+                                        <th scope="col">Non-success</th>
+                                        <th scope="col">Avg / max</th>
+                                        <th scope="col">Focus</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -321,12 +322,13 @@ else
                     {
                         <div class="table-responsive table-shell">
                             <table class="table table-striped align-middle mb-0" data-testid="telemetry-failure-hotspots">
+                                <caption class="visually-hidden">Telemetry failure hotspots grouped by operation, device, and failure signature, with count, latest occurrence, and investigation actions.</caption>
                                 <thead>
                                     <tr>
-                                        <th>Failure slice</th>
-                                        <th>Count</th>
-                                        <th>Latest</th>
-                                        <th>Focus</th>
+                                        <th scope="col">Failure slice</th>
+                                        <th scope="col">Count</th>
+                                        <th scope="col">Latest</th>
+                                        <th scope="col">Focus</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -367,16 +369,17 @@ else
 
     <div class="table-responsive table-shell">
         <table class="table table-striped align-middle" data-testid="telemetry-table">
+            <caption class="visually-hidden">Filtered PKCS#11 telemetry entries with timestamp, device, operation, slot, mechanism, status, duration, and redacted details.</caption>
             <thead>
                 <tr>
-                    <th>When</th>
-                    <th>Device</th>
-                    <th>Operation</th>
-                    <th>Slot</th>
-                    <th>Mechanism</th>
-                    <th>Status</th>
-                    <th>Duration</th>
-                    <th>Details</th>
+                    <th scope="col">When</th>
+                    <th scope="col">Device</th>
+                    <th scope="col">Operation</th>
+                    <th scope="col">Slot</th>
+                    <th scope="col">Mechanism</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Duration</th>
+                    <th scope="col">Details</th>
                 </tr>
             </thead>
             <tbody>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Users.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Pages/Users.razor
@@ -31,10 +31,7 @@
     </div>
 </section>
 
-@if (!string.IsNullOrWhiteSpace(_statusMessage))
-{
-    <div class="alert @(_statusIsError ? "alert-danger" : "alert-success")" data-testid="users-status">@_statusMessage</div>
-}
+<StatusAnnouncement Message="@_statusMessage" IsError="@_statusIsError" TestId="users-status" />
 
 @if (_snapshot is null)
 {
@@ -103,11 +100,11 @@ else
                 <div class="card-body row g-3">
                     <div class="col-12">
                         <label class="form-label">Username</label>
-                        <input class="form-control" @bind="_createUserName" @bind:event="oninput" placeholder="operator1" data-testid="users-create-username" />
+                        <input class="form-control" @bind="_createUserName" @bind:event="oninput" aria-label="Username" placeholder="operator1" data-testid="users-create-username" />
                     </div>
                     <div class="col-12">
                         <label class="form-label">Initial password</label>
-                        <input class="form-control" type="password" @bind="_createPassword" @bind:event="oninput" data-testid="users-create-password" />
+                        <input class="form-control" type="password" @bind="_createPassword" @bind:event="oninput" aria-label="Initial password" data-testid="users-create-password" />
                         <div class="form-text">At least 12 characters.</div>
                     </div>
                     <div class="col-12">
@@ -157,7 +154,7 @@ else
 
                         <div class="col-12">
                             <label class="form-label">Rotate password</label>
-                            <input class="form-control" type="password" @bind="_rotatePassword" @bind:event="oninput" data-testid="users-rotate-password" />
+                            <input class="form-control" type="password" @bind="_rotatePassword" @bind:event="oninput" aria-label="Rotate password" data-testid="users-rotate-password" />
                             <div class="form-text">Set a new password for this local user.</div>
                         </div>
                         <div class="col-12 d-flex gap-2 flex-wrap">
@@ -168,7 +165,7 @@ else
 
                         <div class="col-12">
                             <label class="form-label">Delete confirmation</label>
-                            <input class="form-control" @bind="_deleteConfirmation" @bind:event="oninput" placeholder="Type username to confirm" disabled="@_selectedUser.IsCurrentUser" />
+                            <input class="form-control" @bind="_deleteConfirmation" @bind:event="oninput" aria-label="Delete confirmation" placeholder="Type username to confirm" disabled="@_selectedUser.IsCurrentUser" />
                             <div class="form-text">Type <code>@_selectedUser.Username</code> to delete this user.</div>
                         </div>
                         <div class="col-12 d-flex gap-2 flex-wrap">
@@ -192,11 +189,11 @@ else
                 <div class="card-body border-bottom row g-3 align-items-end">
                     <div class="col-lg-5">
                         <label class="form-label">Search</label>
-                        <input class="form-control" @bind="_userSearchText" @bind:event="oninput" placeholder="username or role..." />
+                        <input class="form-control" @bind="_userSearchText" @bind:event="oninput" aria-label="Search local users" placeholder="username or role..." />
                     </div>
                     <div class="col-lg-3 col-md-6">
                         <label class="form-label">Role filter</label>
-                        <select class="form-select" @bind="_roleFilter">
+                        <select class="form-select" @bind="_roleFilter" aria-label="Local user role filter">
                             <option value="all">All users</option>
                             <option value="admin">Admin</option>
                             <option value="operator">Operator</option>
@@ -206,7 +203,7 @@ else
                     </div>
                     <div class="col-lg-4 col-md-6">
                         <label class="form-label">Sort</label>
-                        <select class="form-select" @bind="_sortMode">
+                        <select class="form-select" @bind="_sortMode" aria-label="Local user sort order">
                             <option value="username">Username (A-Z)</option>
                             <option value="newest">Newest first</option>
                             <option value="oldest">Oldest first</option>
@@ -223,12 +220,13 @@ else
                     {
                         <div class="table-responsive table-shell">
                             <table class="table table-hover align-middle mb-0">
+                                <caption class="visually-hidden">Local admin users with assigned roles, creation time, current-session markers, bootstrap status markers, and management actions.</caption>
                                 <thead>
                                     <tr>
-                                        <th>User</th>
-                                        <th>Roles</th>
-                                        <th>Created</th>
-                                        <th></th>
+                                        <th scope="col">User</th>
+                                        <th scope="col">Roles</th>
+                                        <th scope="col">Created</th>
+                                        <th scope="col"></th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Shared/StatusAnnouncement.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Shared/StatusAnnouncement.razor
@@ -1,0 +1,23 @@
+@if (!string.IsNullOrWhiteSpace(Message))
+{
+    <div class="alert @(IsError ? "alert-danger" : "alert-success")" role="@(IsError ? "alert" : "status")" aria-live="@(IsError ? "assertive" : "polite")" aria-atomic="true" @attributes="AdditionalAttributes">@Message</div>
+}
+
+@code {
+    [Parameter]
+    public string? Message { get; set; }
+
+    [Parameter]
+    public bool IsError { get; set; }
+
+    [Parameter]
+    public string? TestId { get; set; }
+
+    private IReadOnlyDictionary<string, object>? AdditionalAttributes
+        => string.IsNullOrWhiteSpace(TestId)
+            ? null
+            : new Dictionary<string, object>(StringComparer.Ordinal)
+            {
+                ["data-testid"] = TestId
+            };
+}

--- a/src/Pkcs11Wrapper.Admin.Web/wwwroot/app.css
+++ b/src/Pkcs11Wrapper.Admin.Web/wwwroot/app.css
@@ -54,8 +54,14 @@ h6 {
     letter-spacing: -0.03em;
 }
 
-h1:focus {
-    outline: none;
+h1:focus,
+h1:focus-visible,
+a:focus-visible,
+[tabindex="-1"]:focus,
+[tabindex="-1"]:focus-visible {
+    outline: 3px solid rgba(37, 99, 235, 0.42);
+    outline-offset: 0.3rem;
+    border-radius: 0.6rem;
 }
 
 p,

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminAccessibilityIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminAccessibilityIntegrationTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Pkcs11Wrapper.Admin.Application.Models;
+using Pkcs11Wrapper.Admin.Application.Services;
+using Pkcs11Wrapper.Admin.Web.Components;
+using Pkcs11Wrapper.Admin.Web.Configuration;
+using Pkcs11Wrapper.Admin.Web.Security;
+
+namespace Pkcs11Wrapper.Admin.Tests;
+
+public sealed partial class AdminAccessibilityIntegrationTests
+{
+    private const string BootstrapUserName = "admin";
+    private const string BootstrapPassword = "Accessibility!Bootstrap123";
+
+    [Fact]
+    public async Task LoginPageIncludesSkipLinkAndAccessibleLoginForm()
+    {
+        string rootPath = CreateTempDirectory();
+        await using WebApplicationFactory<App> factory = CreateFactory(rootPath);
+
+        try
+        {
+            await SeedAccessibilitySmokeDataAsync(factory);
+
+            using HttpClient client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = true
+            });
+
+            using HttpResponseMessage response = await client.GetAsync("/login");
+            string html = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("href=\"#admin-main-content\"", html, StringComparison.Ordinal);
+            Assert.Contains("id=\"admin-main-content\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-labelledby=\"admin-section-title\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Primary admin navigation\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Username\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Password\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-live=\"polite\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteDirectory(rootPath);
+        }
+    }
+
+    [Fact]
+    public async Task AuthenticatedAdminPagesRenderAccessibilityBaselineMarkup()
+    {
+        string rootPath = CreateTempDirectory();
+        await using WebApplicationFactory<App> factory = CreateAuthenticatedFactory(rootPath);
+
+        try
+        {
+            using HttpClient client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = true
+            });
+
+            string devices = await GetHtmlAsync(client, "/devices");
+            Assert.Contains("aria-label=\"Device name\"", devices, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Device status filter\"", devices, StringComparison.Ordinal);
+
+            string users = await GetHtmlAsync(client, "/users");
+            Assert.Contains("aria-label=\"Username\"", users, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Search local users\"", users, StringComparison.Ordinal);
+            Assert.Contains("Local admin users with assigned roles, creation time, current-session markers, bootstrap status markers, and management actions.", users, StringComparison.Ordinal);
+
+            string configuration = await GetHtmlAsync(client, "/configuration");
+            Assert.Contains("aria-label=\"Configuration import file\"", configuration, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Configuration import mode\"", configuration, StringComparison.Ordinal);
+
+            string keys = await GetHtmlAsync(client, "/keys");
+            Assert.Contains("aria-label=\"Keys device\"", keys, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Remember PIN in protected local storage\"", keys, StringComparison.Ordinal);
+
+            string sessions = await GetHtmlAsync(client, "/sessions");
+            Assert.Contains("aria-label=\"Search tracked sessions\"", sessions, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Session sort order\"", sessions, StringComparison.Ordinal);
+
+            string telemetry = await GetHtmlAsync(client, "/telemetry");
+            Assert.Contains("aria-label=\"Search telemetry entries\"", telemetry, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Telemetry page size\"", telemetry, StringComparison.Ordinal);
+
+            string audit = await GetHtmlAsync(client, "/audit");
+            Assert.Contains("aria-label=\"Search audit logs\"", audit, StringComparison.Ordinal);
+            Assert.Contains("Filtered audit log entries including timestamp, actor, roles, category, action, target, outcome, and details.", audit, StringComparison.Ordinal);
+            Assert.Matches(RoleWithLiveRegionRegex(), audit);
+        }
+        finally
+        {
+            DeleteDirectory(rootPath);
+        }
+    }
+
+    private static WebApplicationFactory<App> CreateFactory(string rootPath)
+        => new WebApplicationFactory<App>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment(Environments.Development);
+                builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+                {
+                    configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["AdminStorage:DataRoot"] = rootPath,
+                        ["AdminRuntime:DisableHttpsRedirection"] = "true",
+                        ["LocalAdminBootstrap:UserName"] = BootstrapUserName,
+                        ["LocalAdminBootstrap:Password"] = BootstrapPassword,
+                        ["AdminBootstrapDevice:ModulePath"] = "/opt/pkcs11/mock/libpkcs11.so",
+                        ["AdminBootstrapDevice:Name"] = "Bootstrap mock device",
+                        ["AdminBootstrapDevice:DefaultTokenLabel"] = "bootstrap-token"
+                    });
+                });
+            });
+
+    private static WebApplicationFactory<App> CreateAuthenticatedFactory(string rootPath)
+        => CreateFactory(rootPath)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = TestAdminAuthHandler.SchemeName;
+                        options.DefaultChallengeScheme = TestAdminAuthHandler.SchemeName;
+                        options.DefaultScheme = TestAdminAuthHandler.SchemeName;
+                    }).AddScheme<AuthenticationSchemeOptions, TestAdminAuthHandler>(TestAdminAuthHandler.SchemeName, _ => { });
+
+                    services.PostConfigure<AdminBootstrapDeviceOptions>(options =>
+                    {
+                        options.ModulePath = "/opt/pkcs11/mock/libpkcs11.so";
+                        options.Name = "Bootstrap mock device";
+                        options.DefaultTokenLabel = "bootstrap-token";
+                    });
+                });
+            });
+
+    private static async Task<string> GetHtmlAsync(HttpClient client, string path)
+    {
+        using HttpResponseMessage response = await client.GetAsync(path);
+        string html = await response.Content.ReadAsStringAsync();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        return html;
+    }
+
+    private static async Task SeedAccessibilitySmokeDataAsync(WebApplicationFactory<App> factory)
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+
+        LocalAdminUserStore userStore = scope.ServiceProvider.GetRequiredService<LocalAdminUserStore>();
+        await userStore.EnsureSeedDataAsync();
+
+        DeviceProfileService deviceProfiles = scope.ServiceProvider.GetRequiredService<DeviceProfileService>();
+        if ((await deviceProfiles.GetAllAsync()).Count == 0)
+        {
+            await deviceProfiles.UpsertAsync(
+                id: null,
+                new HsmDeviceProfileInput
+                {
+                    Name = "Accessibility smoke device",
+                    ModulePath = "/opt/pkcs11/mock/libpkcs11.so",
+                    DefaultTokenLabel = "smoke-token",
+                    Notes = "Seeded for accessibility smoke coverage.",
+                    IsEnabled = true
+                });
+        }
+
+        AuditLogService auditLog = scope.ServiceProvider.GetRequiredService<AuditLogService>();
+        await auditLog.WriteAsync("AccessibilitySmoke", "Seed", "admin-accessibility", "Success", "Seeded representative admin accessibility smoke data.");
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "pkcs11wrapper-admin-accessibility-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    [GeneratedRegex("role=\"(?:status|alert)\"[^>]*aria-live=\"(?:polite|assertive)\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex RoleWithLiveRegionRegex();
+
+    private sealed class TestAdminAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string SchemeName = "TestAdmin";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            Claim[] claims =
+            [
+                new(ClaimTypes.Name, "accessibility-admin"),
+                new(ClaimTypes.Role, AdminRoles.Admin),
+                new(ClaimTypes.Role, AdminRoles.Operator),
+                new(ClaimTypes.Role, AdminRoles.Viewer)
+            ];
+
+            ClaimsIdentity identity = new(claims, SchemeName);
+            ClaimsPrincipal principal = new(identity);
+            AuthenticationTicket ticket = new(principal, SchemeName);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}


### PR DESCRIPTION
Establish a practical accessibility baseline across the Blazor admin console. This adds shared skip/focus scaffolding, consistent live-region status announcements, programmatic labeling and table semantics on core pages, and a minimal admin accessibility smoke test layer. Closes #172.