### PR TITLE
Add responsive mobile nav shell for admin

### DIFF
--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor
@@ -1,16 +1,31 @@
 @inherits LayoutComponentBase
+@implements IDisposable
+@using Microsoft.AspNetCore.Components.Routing
 @inject NavigationManager Navigation
 
 <a class="skip-link" href="#admin-main-content">Skip to main content</a>
 
-<div class="admin-shell">
-    <aside class="admin-sidebar" aria-label="Admin console branding and primary navigation">
-        <div class="admin-brand">
-            <div class="admin-brand-mark">P11</div>
-            <div>
-                <div class="admin-brand-eyebrow">Pkcs11Wrapper</div>
-                <div class="admin-brand-title">Admin Console</div>
+<div class="admin-shell @NavigationShellClass">
+    <button class="admin-sidebar-backdrop" type="button" @onclick="CloseNavigation" tabindex="-1" aria-hidden="true"></button>
+
+    <aside id="admin-sidebar" class="admin-sidebar" aria-label="Admin console branding and primary navigation">
+        <div class="admin-sidebar-header">
+            <div class="admin-brand">
+                <div class="admin-brand-mark">P11</div>
+                <div>
+                    <div class="admin-brand-eyebrow">Pkcs11Wrapper</div>
+                    <div class="admin-brand-title">Admin Console</div>
+                </div>
             </div>
+
+            <button class="admin-sidebar-close"
+                    type="button"
+                    @onclick="CloseNavigation"
+                    aria-controls="admin-sidebar"
+                    aria-expanded="@NavigationExpanded"
+                    aria-label="Close navigation menu">
+                <span aria-hidden="true">×</span>
+            </button>
         </div>
 
         <div class="admin-brand-copy">
@@ -27,9 +42,25 @@
 
     <div class="admin-main">
         <header class="admin-topbar">
-            <div>
-                <div class="admin-topbar-eyebrow">Operations workspace</div>
-                <div class="admin-topbar-title" id="admin-section-title">@CurrentSectionTitle</div>
+            <div class="admin-topbar-primary">
+                <button class="admin-nav-toggle"
+                        type="button"
+                        @onclick="ToggleNavigation"
+                        aria-controls="admin-sidebar"
+                        aria-expanded="@NavigationExpanded"
+                        aria-label="@NavigationToggleLabel">
+                    <span class="admin-nav-toggle-box" aria-hidden="true">
+                        <span class="admin-nav-toggle-line"></span>
+                        <span class="admin-nav-toggle-line"></span>
+                        <span class="admin-nav-toggle-line"></span>
+                    </span>
+                    <span class="admin-nav-toggle-copy">Menu</span>
+                </button>
+
+                <div>
+                    <div class="admin-topbar-eyebrow">Operations workspace</div>
+                    <div class="admin-topbar-title" id="admin-section-title">@CurrentSectionTitle</div>
+                </div>
             </div>
 
             <div class="admin-topbar-meta">
@@ -52,6 +83,14 @@
 </div>
 
 @code {
+    private bool _isNavigationOpen;
+
+    private string NavigationShellClass => _isNavigationOpen ? "admin-shell-nav-open" : string.Empty;
+
+    private string NavigationExpanded => _isNavigationOpen ? "true" : "false";
+
+    private string NavigationToggleLabel => _isNavigationOpen ? "Close navigation menu" : "Open navigation menu";
+
     private string CurrentSectionTitle
     {
         get
@@ -67,9 +106,42 @@
                 "audit" => "Audit Logs",
                 "configuration" => "Configuration Transfer",
                 "lab" => "PKCS#11 Lab",
+                "telemetry" => "PKCS#11 Telemetry",
+                "crypto-api-access" => "Crypto API Access",
                 "users" => "Local Users",
                 _ => "Admin Console"
             };
         }
+    }
+
+    protected override void OnInitialized()
+    {
+        Navigation.LocationChanged += HandleLocationChanged;
+    }
+
+    public void Dispose()
+    {
+        Navigation.LocationChanged -= HandleLocationChanged;
+    }
+
+    private void ToggleNavigation()
+    {
+        _isNavigationOpen = !_isNavigationOpen;
+    }
+
+    private void CloseNavigation()
+    {
+        _isNavigationOpen = false;
+    }
+
+    private void HandleLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        if (!_isNavigationOpen)
+        {
+            return;
+        }
+
+        _isNavigationOpen = false;
+        _ = InvokeAsync(StateHasChanged);
     }
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor.css
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/MainLayout.razor.css
@@ -20,6 +20,7 @@
 }
 
 .admin-shell {
+    position: relative;
     min-height: 100vh;
     display: grid;
     grid-template-columns: 320px minmax(0, 1fr);
@@ -28,10 +29,17 @@
         linear-gradient(180deg, #f8fbff 0%, #f3f6fb 100%);
 }
 
+.admin-sidebar-backdrop {
+    display: none;
+}
+
 .admin-sidebar {
     position: sticky;
     top: 0;
     min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
     padding: 1.5rem 1.25rem 1.25rem;
     background:
         radial-gradient(circle at top left, rgba(96, 165, 250, 0.22), transparent 16rem),
@@ -41,11 +49,47 @@
     box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.02);
 }
 
+.admin-sidebar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.admin-sidebar-close {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.95rem;
+    background: rgba(15, 23, 42, 0.24);
+    color: #f8fbff;
+    font-size: 1.35rem;
+    line-height: 1;
+    transition: background-color 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+}
+
+.admin-sidebar-close:hover {
+    transform: translateY(-1px);
+    background: rgba(30, 41, 59, 0.52);
+    border-color: rgba(96, 165, 250, 0.22);
+    box-shadow: 0 14px 24px rgba(2, 6, 23, 0.18);
+}
+
+.admin-sidebar-close:focus-visible {
+    outline: 3px solid rgba(191, 219, 254, 0.92);
+    outline-offset: 3px;
+    border-color: rgba(191, 219, 254, 0.42);
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.18);
+}
+
 .admin-brand {
     display: flex;
     align-items: center;
     gap: 0.95rem;
-    margin-bottom: 1rem;
 }
 
 .admin-brand-mark {
@@ -77,7 +121,6 @@
 }
 
 .admin-brand-copy {
-    margin-bottom: 1.4rem;
     font-size: 0.92rem;
     line-height: 1.6;
     color: rgba(226, 232, 240, 0.74);
@@ -124,6 +167,71 @@
     background: rgba(248, 251, 255, 0.9);
     border-bottom: 1px solid rgba(148, 163, 184, 0.18);
     backdrop-filter: blur(14px);
+}
+
+.admin-topbar-primary {
+    min-width: 0;
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.admin-nav-toggle {
+    display: none;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.86);
+    color: #0f172a;
+    box-shadow: 0 10px 22px rgba(148, 163, 184, 0.14);
+    transition: transform 0.16s ease, background-color 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.admin-nav-toggle:hover {
+    transform: translateY(-1px);
+    background: #ffffff;
+    border-color: rgba(59, 130, 246, 0.28);
+    box-shadow: 0 14px 24px rgba(148, 163, 184, 0.18);
+}
+
+.admin-nav-toggle:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.28);
+    outline-offset: 3px;
+}
+
+.admin-nav-toggle-box {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.22rem;
+}
+
+.admin-nav-toggle-line {
+    display: block;
+    width: 1rem;
+    height: 0.125rem;
+    border-radius: 999px;
+    background: currentColor;
+    transition: transform 0.16s ease, opacity 0.16s ease;
+}
+
+.admin-nav-toggle-copy {
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.admin-shell-nav-open .admin-nav-toggle-line:nth-child(1) {
+    transform: translateY(0.345rem) rotate(45deg);
+}
+
+.admin-shell-nav-open .admin-nav-toggle-line:nth-child(2) {
+    opacity: 0;
+}
+
+.admin-shell-nav-open .admin-nav-toggle-line:nth-child(3) {
+    transform: translateY(-0.345rem) rotate(-45deg);
 }
 
 .admin-topbar-eyebrow {
@@ -188,17 +296,59 @@
 
 @media (max-width: 860px) {
     .admin-shell {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .admin-shell-nav-open {
+        height: 100vh;
+        overflow: hidden;
+    }
+
+    .admin-sidebar-backdrop {
+        display: block;
+        position: fixed;
+        inset: 0;
+        z-index: 90;
+        border: 0;
+        padding: 0;
+        margin: 0;
+        background: rgba(15, 23, 42, 0.56);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease;
+    }
+
+    .admin-shell-nav-open .admin-sidebar-backdrop {
+        opacity: 1;
+        pointer-events: auto;
     }
 
     .admin-sidebar {
-        position: static;
-        min-height: auto;
-        padding-bottom: 1rem;
+        position: fixed;
+        inset: 0 auto 0 0;
+        z-index: 100;
+        width: min(22rem, calc(100vw - 2.5rem));
+        max-width: 100%;
+        min-height: 100vh;
+        min-height: 100dvh;
+        padding: 1.25rem 1rem 1.1rem;
+        transform: translateX(-100%);
+        transition: transform 0.22s ease, box-shadow 0.22s ease;
+        overflow-y: auto;
+        box-shadow: none;
+    }
+
+    .admin-shell-nav-open .admin-sidebar {
+        transform: translateX(0);
+        box-shadow: 0 32px 64px rgba(15, 23, 42, 0.34);
+    }
+
+    .admin-sidebar-close,
+    .admin-nav-toggle {
+        display: inline-flex;
     }
 
     .admin-topbar {
-        position: static;
         padding-top: 1.1rem;
         padding-bottom: 1rem;
     }
@@ -210,11 +360,27 @@
         flex-direction: column;
     }
 
+    .admin-topbar-primary,
+    .admin-topbar-meta {
+        width: 100%;
+    }
+
     .admin-topbar-meta {
         justify-content: flex-start;
     }
 
     .admin-page-host {
         padding: 1.1rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .skip-link,
+    .admin-sidebar-backdrop,
+    .admin-sidebar,
+    .admin-sidebar-close,
+    .admin-nav-toggle,
+    .admin-nav-toggle-line {
+        transition: none;
     }
 }

--- a/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor.css
+++ b/src/Pkcs11Wrapper.Admin.Web/Components/Layout/NavMenu.razor.css
@@ -1,4 +1,6 @@
 .app-nav {
+    flex: 1 1 auto;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     gap: 1.2rem;
@@ -130,4 +132,10 @@
     font-size: 0.78rem;
     line-height: 1.45;
     color: rgba(191, 219, 254, 0.72);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .app-nav-item ::deep a.app-nav-link {
+        transition: none;
+    }
 }

--- a/tests/Pkcs11Wrapper.Admin.Tests/AdminAccessibilityIntegrationTests.cs
+++ b/tests/Pkcs11Wrapper.Admin.Tests/AdminAccessibilityIntegrationTests.cs
@@ -48,6 +48,10 @@ public sealed partial class AdminAccessibilityIntegrationTests
             Assert.Contains("id=\"admin-main-content\"", html, StringComparison.Ordinal);
             Assert.Contains("aria-labelledby=\"admin-section-title\"", html, StringComparison.Ordinal);
             Assert.Contains("aria-label=\"Primary admin navigation\"", html, StringComparison.Ordinal);
+            Assert.Contains("id=\"admin-sidebar\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-controls=\"admin-sidebar\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Open navigation menu\"", html, StringComparison.Ordinal);
+            Assert.Contains("aria-label=\"Close navigation menu\"", html, StringComparison.Ordinal);
             Assert.Contains("aria-label=\"Username\"", html, StringComparison.Ordinal);
             Assert.Contains("aria-label=\"Password\"", html, StringComparison.Ordinal);
             Assert.Contains("aria-live=\"polite\"", html, StringComparison.Ordinal);
@@ -75,6 +79,8 @@ public sealed partial class AdminAccessibilityIntegrationTests
             string devices = await GetHtmlAsync(client, "/devices");
             Assert.Contains("aria-label=\"Device name\"", devices, StringComparison.Ordinal);
             Assert.Contains("aria-label=\"Device status filter\"", devices, StringComparison.Ordinal);
+            Assert.Contains("aria-controls=\"admin-sidebar\"", devices, StringComparison.Ordinal);
+            AssertSectionTitle(devices, "Device Profiles");
 
             string users = await GetHtmlAsync(client, "/users");
             Assert.Contains("aria-label=\"Username\"", users, StringComparison.Ordinal);
@@ -96,6 +102,10 @@ public sealed partial class AdminAccessibilityIntegrationTests
             string telemetry = await GetHtmlAsync(client, "/telemetry");
             Assert.Contains("aria-label=\"Search telemetry entries\"", telemetry, StringComparison.Ordinal);
             Assert.Contains("aria-label=\"Telemetry page size\"", telemetry, StringComparison.Ordinal);
+            AssertSectionTitle(telemetry, "PKCS#11 Telemetry");
+
+            string cryptoApiAccess = await GetHtmlAsync(client, "/crypto-api-access");
+            AssertSectionTitle(cryptoApiAccess, "Crypto API Access");
 
             string audit = await GetHtmlAsync(client, "/audit");
             Assert.Contains("aria-label=\"Search audit logs\"", audit, StringComparison.Ordinal);
@@ -197,6 +207,11 @@ public sealed partial class AdminAccessibilityIntegrationTests
         {
             Directory.Delete(path, recursive: true);
         }
+    }
+
+    private static void AssertSectionTitle(string html, string title)
+    {
+        Assert.Matches($"id=\\\"admin-section-title\\\"[^>]*>\\s*{Regex.Escape(title)}\\s*<", html);
     }
 
     [GeneratedRegex("role=\"(?:status|alert)\"[^>]*aria-live=\"(?:polite|assertive)\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]


### PR DESCRIPTION
Make the Blazor admin shell usable on mobile/narrow screens by turning the existing sidebar into a responsive off-canvas drawer on small layouts while preserving the desktop shell. This adds a topbar menu toggle, backdrop, mobile close affordance, auto-close on navigation, and keeps accessibility hooks intact. Closes #171.